### PR TITLE
Fix bug with NCCL resource reclamation when using multiple grid descriptors.

### DIFF
--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -55,6 +55,8 @@ struct cudecompHandle {
   int32_t local_rank;      // MPI rank
   int32_t local_nranks;    // MPI size
 
+  // Entries for NCCL management
+  int n_grid_descs_using_nccl = 0;      // Count of grid descriptors using NCCL
   ncclComm_t nccl_comm = nullptr;       // NCCL communicator (global)
   ncclComm_t nccl_local_comm = nullptr; // NCCL communicator (intranode)
 


### PR DESCRIPTION
Fixes a bug where NCCL resources would be reclaimed if a different grid descriptor was created that did not use NCCL backends. This PR adds a tally of grid descriptors using NCCL to the handle structure to avoid premature reclamation, similar to the NVSHMEM case.

Additionally, this PR adds reclamation code to `cudecompGridDescDestroy` to reclaim resources earlier when possible.