### PR TITLE
Add missing mpi.h include to cudecomp.h.

### DIFF
--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -40,6 +40,7 @@
 #include <string>
 
 #include <cuda_runtime.h>
+#include <mpi.h>
 
 #define CUDECOMP_MAJOR 0
 #define CUDECOMP_MINOR 2


### PR DESCRIPTION
This PR adds back the `mpi.h` include to `cudecomp.h`, which was erroneously removed in a previous commit.  

Fixes #9.
