### PR TITLE
Fix additional instance of erroneous empty pencil check. Some Fortran module clean up.

### DIFF
--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -153,8 +153,8 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
     CHECK_CUDECOMP(cudecompGetPencilInfo(handle, grid_desc, &pinfo_z, 2, nullptr));
 
     // Skip any decompositions with empty pencils
-    if (grid_desc->config.pdims[0] > std::min(grid_desc->config.gdims[0], grid_desc->config.gdims[1]) ||
-        grid_desc->config.pdims[1] > std::min(grid_desc->config.gdims[1], grid_desc->config.gdims[2])) {
+    if (grid_desc->config.pdims[0] > std::min(grid_desc->config.gdims_dist[0], grid_desc->config.gdims_dist[1]) ||
+        grid_desc->config.pdims[1] > std::min(grid_desc->config.gdims_dist[1], grid_desc->config.gdims_dist[2])) {
       continue;
     }
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -344,8 +344,9 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
     for (auto& event : grid_desc->events) { CHECK_CUDA(cudaEventCreateWithFlags(&event, cudaEventDisableTiming)); }
 
     // Disable decompositions with empty pencils
-    if (!autotune_pdims && (std::max(grid_desc->config.pdims[0], grid_desc->config.pdims[1]) >
-                            std::min(grid_desc->config.gdims[1], grid_desc->config.gdims[2]))) {
+    if (!autotune_pdims &&
+        (grid_desc->config.pdims[0] > std::min(grid_desc->config.gdims_dist[0], grid_desc->config.gdims_dist[1]) ||
+         grid_desc->config.pdims[1] > std::min(grid_desc->config.gdims_dist[1], grid_desc->config.gdims_dist[2]))) {
       THROW_NOT_SUPPORTED("grid descriptor settings yields a distribution with empty pencils");
     }
 

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -30,6 +30,7 @@ module cudecomp
   use, intrinsic :: iso_c_binding
   use, intrinsic :: iso_fortran_env, only: int64, real32, real64
   use cudafor
+  private :: cudafor
 
   ! enumerators
 
@@ -601,6 +602,7 @@ contains
   end function cudecompGetPencilInfo
 
   function cudecompGetHaloWorkspaceSize(handle, grid_desc, axis, halo_extents, workspace_size) result(res)
+    implicit none
     type(cudecompHandle) :: handle
     type(cudecompGridDesc) :: grid_desc
     integer :: axis


### PR DESCRIPTION
This PR fixes an additional instance of the erroneous empty pencil check that wasn't fixed in #11. Also updates the checks to use `gdims_dist` instead of `gdims`. 

This PR also includes some minor Fortran module clean up based on suggestions from @p-costa. 