### PR TITLE
Remove unneeded 4 GPU restriction on Fortran autotune example.

### DIFF
--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -74,11 +74,6 @@ program main
   call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
   call MPI_Comm_size(MPI_COMM_WORLD, nranks, ierr)
 
-  if (nranks /= 4) then
-    print*, "ERROR: This example requires 4 ranks to run. Exiting..."
-    call exit(1)
-  endif
-
   call MPI_Comm_split_Type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, local_comm, ierr)
   call MPI_Comm_rank(local_comm, local_rank, ierr)
   ierr = cudaSetDevice(local_rank)


### PR DESCRIPTION
From some comments in #16, I realized there was an extraneous 4 GPU restriction in the basic autotuning example in Fortran. This PR removes the unneeded rank count check.