### PR TITLE
Enable autotuner to skip slow configurations via new skip_threshold option

### DIFF
--- a/benchmark/benchmark.cu
+++ b/benchmark/benchmark.cu
@@ -108,6 +108,9 @@ static void usage(const char* pname) {
           "\t-t|--ntrials <NTRIALS>\n"
           "\t\tNumber of trial iterations. (default: 5) \n"
           "\n"
+          "\t-k|--skip-threshold <THRESHOLD>\n"
+          "\t\tAutotuner skip threshold setting. (default: 0.0) \n"
+          "\n"
           "\t-b|--backend <INTEGER>\n"
           "\t\tCommunication backend to use. Choices: 0:AUTOTUNE, 1:MPI_P2P, 2:MPI_P2P_PL, 3:MPI_A2A, 4:NCCL, "
           "5:NCCL_PL, 6:NVSHMEM, 7:NVSHMEM_PL. (default: 0) \n"
@@ -147,6 +150,7 @@ int main(int argc, char** argv) {
   int nwarmup = 3;
   int ntrials = 5;
   bool skip_correctness_tests = false;
+  double skip_threshold = 0.0;
 
   while (1) {
     static struct option long_options[] = {{"gx", required_argument, 0, 'x'},
@@ -160,6 +164,7 @@ int main(int argc, char** argv) {
                                            {"acz", required_argument, 0, '3'},
                                            {"nwarmup", required_argument, 0, 'w'},
                                            {"ntrials", required_argument, 0, 't'},
+                                           {"skip-threshold", required_argument, 0, 'k'},
                                            {"out-of-place", no_argument, 0, 'o'},
                                            {"use-managed-memory", no_argument, 0, 'm'},
                                            {"skip-correctness-tests", no_argument, 0, 's'},
@@ -167,7 +172,7 @@ int main(int argc, char** argv) {
                                            {0, 0, 0, 0}};
 
     int option_index = 0;
-    int ch = getopt_long(argc, argv, "x:y:z:b:r:c:1:2:3:w:t:b:omsh", long_options, &option_index);
+    int ch = getopt_long(argc, argv, "x:y:z:b:r:c:1:2:3:w:t:k:b:omsh", long_options, &option_index);
     if (ch == -1) break;
 
     switch (ch) {
@@ -182,6 +187,7 @@ int main(int argc, char** argv) {
     case '3': axis_contiguous[2] = atoi(optarg); break;
     case 'w': nwarmup = atoi(optarg); break;
     case 't': ntrials = atoi(optarg); break;
+    case 'k': skip_threshold = atoi(optarg); break;
     case 'b': comm_backend = static_cast<cudecompTransposeCommBackend_t>(atoi(optarg)); break;
     case 'o': out_of_place = true; break;
     case 'm': use_managed_memory = true; break;
@@ -221,6 +227,7 @@ int main(int argc, char** argv) {
   } else {
     options.autotune_transpose_backend = true;
   }
+  options.skip_threshold = skip_threshold;
 
 #ifdef R2C
   cudecompGridDesc_t grid_desc_c; // complex grid

--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -69,7 +69,7 @@ _________________________________
   :f logical allow_uneven_distributions: flag to control whether autotuning allows process grids that result in uneven distributions of elements across processes (default: true)
   :f logical disable_nccl_backends: flag to disable NCCL backend options during autotuning (default: false)
   :f logical disable_nvshmem_backends: flag to disable NVSHMEM backend options during autotuning (default: false)
-  :f real(c_double) skip_threshold: threshold used to skip testing slow configurations; skip configuration if skip_threshold * t > t_best, where t is the duration of the first timed trial for a configuration and t_best is the current best average configuration trial time. (default: 0.0)
+  :f real(c_double) skip_threshold: threshold used to skip testing slow configurations; skip configuration if :code:`skip_threshold * t > t_best`, where :code:`t` is the duration of the first timed trial for the configuration and :code:`t_best` is the average trial time of the current best configuration. (default: 0.0)
   :f logical autotune_transpose_backend: flag to enable transpose backend autotuning (default: false)
   :f logical autotune_halo_backend: flag to enable halo backend autotuning (default: false)
   :f logical transpose_use_inplace_buffers: flag to control whether transpose autotuning uses in-place or out-of-place buffers (default: false)

--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -69,7 +69,7 @@ _________________________________
   :f logical allow_uneven_distributions: flag to control whether autotuning allows process grids that result in uneven distributions of elements across processes (default: true)
   :f logical disable_nccl_backends: flag to disable NCCL backend options during autotuning (default: false)
   :f logical disable_nvshmem_backends: flag to disable NVSHMEM backend options during autotuning (default: false)
-  :f real(c_double) skip_threshold: threshold used to skip testing slow configurations; skip configuration if :code:`skip_threshold * t > t_best`, where :code:`t` is the duration of the first timed trial for the configuration and :code:`t_best` is the average trial time of the current best configuration. (default: 0.0)
+  :f real(c_double) skip_threshold: threshold used to skip testing slow configurations; skip configuration if :code:`skip_threshold * t > t_best`, where :code:`t` is the duration of the first timed trial for the configuration and :code:`t_best` is the average trial time of the current best configuration (default: 0.0)
   :f logical autotune_transpose_backend: flag to enable transpose backend autotuning (default: false)
   :f logical autotune_halo_backend: flag to enable halo backend autotuning (default: false)
   :f logical transpose_use_inplace_buffers: flag to control whether transpose autotuning uses in-place or out-of-place buffers (default: false)

--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -62,11 +62,14 @@ _________________________________
 
   A data structure defining autotuning options for grid descriptor creation.
 
+  :f integer n_warmup_trials: number of warmup trials to run for each tested configuration during autotuning
+  :f integer n_trials: number of timed trials to run for each tested configuration during autotuning
   :f cudecompAutotuneGridMode grid_mode: which communication (transpose/halo) to use to autotune process grid (default: CUDECOMP_AUTOTUNE_GRID_TRANSPOSE)
   :f cudecompDataType dtype: datatype to use during autotuning (default: CUDECOMP_DOUBLE)
   :f logical allow_uneven_distributions: flag to control whether autotuning allows process grids that result in uneven distributions of elements across processes (default: true)
   :f logical disable_nccl_backends: flag to disable NCCL backend options during autotuning (default: false)
   :f logical disable_nvshmem_backends: flag to disable NVSHMEM backend options during autotuning (default: false)
+  :f real(c_double) skip_threshold: threshold used to skip testing slow configurations; skip configuration if skip_threshold * t > t_best, where t is the duration of the first timed trial for a configuration and t_best is the current best average configuration trial time. (default: 0.0)
   :f logical autotune_transpose_backend: flag to enable transpose backend autotuning (default: false)
   :f logical autotune_halo_backend: flag to enable halo backend autotuning (default: false)
   :f logical transpose_use_inplace_buffers: flag to control whether transpose autotuning uses in-place or out-of-place buffers (default: false)

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -89,7 +89,7 @@ Create an uninitialized autotune option struct and initialize it to defaults usi
 First, let's go over general autotuning options that effect process grid and communication backend autotuning.
 
 The :code:`n_warmup_trials` and :code:`n_trials` entries in the options struct control the number of warmup
-and timed trials run for each tested configuration. Here we set them to their default values.
+and timed trials run for each tested configuration respectively. Here we set them to their default values.
 
 .. tabs::
 
@@ -134,9 +134,9 @@ By default, these flags are set to false and NCCL and NVSHMEM backends are enabl
 
 The :code:`skip_threshold` entry allows the autotuner to rapidly skip slow performing configurations. In particular,
 the autotuner will skip testing a configuration if :code:`skip_threshold * t > t_best`, where :code:`t` is the duration
-of the first timed trial for a configuration and :code:`t_best` is the current best average configuration trial time. By default,
-the threshold is set to zero, which disables any skipping. More aggresive skipping can be useful in cases where the default
-exhaustive testing of configurations is too expensive.
+of the first timed trial for the configuration and :code:`t_best` is the average trial time of the current best configuration. 
+By default, the threshold is set to zero which disables any skipping. More aggresive skipping can be useful in cases where exhaustive
+testing of all possible configurations is too expensive.
 
 .. tabs::
 

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -135,7 +135,7 @@ By default, these flags are set to false and NCCL and NVSHMEM backends are enabl
 The :code:`skip_threshold` entry allows the autotuner to rapidly skip slow performing configurations. In particular,
 the autotuner will skip testing a configuration if :code:`skip_threshold * t > t_best`, where :code:`t` is the duration
 of the first timed trial for the configuration and :code:`t_best` is the average trial time of the current best configuration. 
-By default, the threshold is set to zero which disables any skipping. More aggresive skipping can be useful in cases where exhaustive
+By default, the threshold is set to zero which disables any skipping. More aggressive skipping can be useful in cases where exhaustive
 testing of all possible configurations is too expensive.
 
 .. tabs::

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -88,6 +88,22 @@ Create an uninitialized autotune option struct and initialize it to defaults usi
 
 First, let's go over general autotuning options that effect process grid and communication backend autotuning.
 
+The :code:`n_warmup_trials` and :code:`n_trials` entries in the options struct control the number of warmup
+and timed trials run for each tested configuration. Here we set them to their default values.
+
+.. tabs::
+
+  .. code-tab:: c++
+
+    options.n_warmup_trials = 3;
+    options.n_trials = 5;
+
+  .. code-tab:: fortran
+
+    options%n_warmup_trials = 3
+    options%n_trials = 5
+
+
 The :code:`dtype` entry in the options struct controls which data type cuDecomp will use for autotuning.
 
 .. tabs::
@@ -115,6 +131,22 @@ By default, these flags are set to false and NCCL and NVSHMEM backends are enabl
 
     options%disable_nccl_backends = .false.
     options%disable_nvshmem_backends = .false.
+
+The :code:`skip_threshold` entry allows the autotuner to rapidly skip slow performing configurations. In particular,
+the autotuner will skip testing a configuration if :code:`skip_threshold * t > t_best`, where :code:`t` is the duration
+of the first timed trial for a configuration and :code:`t_best` is the current best average configuration trial time. By default,
+the threshold is set to zero, which disables any skipping. More aggresive skipping can be useful in cases where the default
+exhaustive testing of configurations is too expensive.
+
+.. tabs::
+
+  .. code-tab:: c++
+
+    options.skip_threshold = 0.0;
+
+  .. code-tab:: fortran
+
+    options%skip_threshold = 0.0
 
 Moving on, these are the options specific to process grid autotuning.
 

--- a/examples/cc/basic_usage/basic_usage_autotune.cu
+++ b/examples/cc/basic_usage/basic_usage_autotune.cu
@@ -139,9 +139,12 @@ int main(int argc, char** argv) {
   CHECK_CUDECOMP_EXIT(cudecompGridDescAutotuneOptionsSetDefaults(&options));
 
   // General options
+  options.n_warmup_trials = 3;
+  options.n_trials = 5;
   options.dtype = CUDECOMP_DOUBLE;
   options.disable_nccl_backends = false;
   options.disable_nvshmem_backends = false;
+  options.skip_threshold = 0.0;
 
   // Process grid autotuning options
   options.grid_mode = CUDECOMP_AUTOTUNE_GRID_TRANSPOSE;

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -98,9 +98,12 @@ program main
   call CHECK_CUDECOMP_EXIT(istat)
 
   ! General options
+  options%n_warmup_trials = 3
+  options%n_trials = 5
   options%dtype = CUDECOMP_DOUBLE
   options%disable_nccl_backends = .false.
   options%disable_nvshmem_backends = .false.
+  options%skip_threshold = 0.0
 
   ! Process grid autotuning options
   options%grid_mode = CUDECOMP_AUTOTUNE_GRID_TRANSPOSE

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -140,6 +140,10 @@ typedef struct {
  */
 typedef struct {
   // General options
+  int32_t n_warmup_trials;          ///< number of warmup trials to run for each tested configuration during autotuning
+                                    ///< (default: 3)
+  int32_t n_trials;                 ///< number of timed trials to run for each tested configuration during autotuning
+                                    ///< (default: 5)
   cudecompAutotuneGridMode_t grid_mode; ///< which communication (transpose/halo) to use to autotune process grid
                                         ///< (default: CUDECOMP_AUTOTUNE_GRID_TRANSPOSE)
   cudecompDataType_t dtype;             ///< datatype to use during autotuning (default: CUDECOMP_DOUBLE)
@@ -147,6 +151,10 @@ typedef struct {
                                     ///< distributions of elements across processes (default: true)
   bool disable_nccl_backends;       ///< flag to disable NCCL backend options during autotuning (default: false)
   bool disable_nvshmem_backends;    ///< flag to disable NVSHMEM backend options during autotuning (default: false)
+  double skip_threshold;            ///< threshold used to skip testing slow configurations; skip configuration
+                                    ///< if skip_threshold * t > t_best, where t is the duration of the first timed trial
+                                    ///< for a configuration and t_best is the current best average configuration
+                                    ///< trial time. (default: 0.0)
 
   // Transpose-specific options
   bool autotune_transpose_backend;    ///< flag to enable transpose backend autotuning (default: false)

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -154,7 +154,7 @@ typedef struct {
   double skip_threshold;            ///< threshold used to skip testing slow configurations; skip configuration
                                     ///< if `skip_threshold * t > t_best`, where `t` is the duration of the first timed trial
                                     ///< for the configuration and `t_best` is the average trial time of the current best
-                                    ///< configuration. (default: 0.0)
+                                    ///< configuration (default: 0.0)
 
   // Transpose-specific options
   bool autotune_transpose_backend;    ///< flag to enable transpose backend autotuning (default: false)

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -152,9 +152,9 @@ typedef struct {
   bool disable_nccl_backends;       ///< flag to disable NCCL backend options during autotuning (default: false)
   bool disable_nvshmem_backends;    ///< flag to disable NVSHMEM backend options during autotuning (default: false)
   double skip_threshold;            ///< threshold used to skip testing slow configurations; skip configuration
-                                    ///< if skip_threshold * t > t_best, where t is the duration of the first timed trial
-                                    ///< for a configuration and t_best is the current best average configuration
-                                    ///< trial time. (default: 0.0)
+                                    ///< if `skip_threshold * t > t_best`, where `t` is the duration of the first timed trial
+                                    ///< for the configuration and `t_best` is the average trial time of the current best
+                                    ///< configuration. (default: 0.0)
 
   // Transpose-specific options
   bool autotune_transpose_backend;    ///< flag to enable transpose backend autotuning (default: false)

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -519,11 +519,14 @@ cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAuto
     if (!options) { THROW_INVALID_USAGE("options argument cannot be null"); }
 
     // General options
+    options->n_warmup_trials = 3;
+    options->n_trials = 5;
     options->grid_mode = CUDECOMP_AUTOTUNE_GRID_TRANSPOSE;
     options->dtype = CUDECOMP_DOUBLE;
     options->allow_uneven_decompositions = true;
     options->disable_nccl_backends = false;
     options->disable_nvshmem_backends = false;
+    options->skip_threshold = 0.0;
 
     // Transpose-specific options
     options->autotune_transpose_backend = false;

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -127,11 +127,14 @@ module cudecomp
   ! Structure defining autotuning options for grid descriptor creation
   type, bind(c) :: cudecompGridDescAutotuneOptions
     ! General options
+    integer(c_int32_t) :: n_warmup_trials ! number of warmup trials to run for each tested configuration during autotuning
+    integer(c_int32_t) :: n_trials ! number of timed trials to run for each tested configuration during autotuning
     integer(c_int32_t) :: grid_mode ! which communication (transpose/halo) to use to autotune process grid
     integer(c_int32_t) :: dtype ! datatype to use during autotuning
     logical(c_bool) :: allow_uneven_decompositions ! flag to control whether autotuning allows uneven decompositions (based on gdims_dist if provided, gdims otherwise)
     logical(c_bool) :: disable_nccl_backends ! flag to disable NCCL backend options during autotuning
     logical(c_bool) :: disable_nvshmem_backends ! flag to disable NVSHMEM backend options during autotuning
+    real(c_double) :: skip_threshold ! threshold used to skip testing slow configurations
 
     ! Transpose-specific options
     logical(c_bool) :: autotune_transpose_backend ! flag to enable transpose backend autotuning


### PR DESCRIPTION
This PR introduces a new `skip_threshold` field to the cuDecomp autotune options struct. As noted in the updated autotuning doc page:

> The `skip_threshold` entry allows the autotuner to rapidly skip slow performing configurations. In particular,
> the autotuner will skip testing a configuration if `skip_threshold * t > t_best`, where `t` is the duration
> of the first timed trial for the configuration and `t_best` is the average trial time of the current best configuration. 
> By default, the threshold is set to zero which disables any skipping. More aggressive skipping can be useful in cases where exhaustive testing of all possible configurations is too expensive.

This feature is particularly useful when running large scale cases that have many process grid and communication backends to test. In these cases, exhaustive autotuning can take up too much wall time. This feature enables more lightweight autotuning in these scenarios. 

For increased configurability, this PR also enables modifying the number of warmup and timed trials used for autotuning via new fields `n_warmup_trials` and `n_trials` which used to be hardcoded to 3 and 5 respectively. 
