### PR TITLE
Add support for CUTENSOR 2.0.

### DIFF
--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -190,7 +190,7 @@ extern "C" {
 /**
  * @brief Initializes the cuDecomp library from an existing MPI communicator
  *
- * @param[out] handle A pointer to an uninitialized cutensorHandle_t
+ * @param[out] handle A pointer to an uninitialized cudecompHandle_t
  * @param[in] mpi_comm MPI communicator containing ranks to use with cuDecomp
  *
  * @return CUDECOMP_RESULT_SUCCESS on success or error code on failure.

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -63,6 +63,9 @@ struct cudecompHandle {
   cudaStream_t pl_stream = nullptr; // stream used for pipelined backends
 
   cutensorHandle_t cutensor_handle; // cuTENSOR handle;
+#if CUTENSOR_MAJOR >= 2
+  cutensorPlanPreference_t  cutensor_plan_pref; // cuTENSOR plan preference;
+#endif
 
   std::vector<std::array<char, MPI_MAX_PROCESSOR_NAME>> hostnames; // list of hostnames by rank
   std::vector<int32_t> rank_to_local_rank;                         // list of local rank mappings


### PR DESCRIPTION
The recently released NVIDIA HPC SDK 24.1 packages CUTENSOR 2.0 which breaks cuDecomp compilation. This PR adds support for the newer CUTENSOR 2.0 APIs to fix this.