### PR TITLE
Enable per operation setting for in-place usage when autotuning.

### DIFF
--- a/benchmark/benchmark.cu
+++ b/benchmark/benchmark.cu
@@ -220,7 +220,9 @@ int main(int argc, char** argv) {
   cudecompGridDescAutotuneOptions_t options;
   CHECK_CUDECOMP_EXIT(cudecompGridDescAutotuneOptionsSetDefaults(&options));
   options.dtype = get_cudecomp_datatype(complex_t(0));
-  options.transpose_use_inplace_buffers = !out_of_place;
+  for (int i = 0; i < 4; ++i) {
+    options.transpose_use_inplace_buffers[i] = !out_of_place;
+  }
 
   if (comm_backend != 0) {
     config.transpose_comm_backend = comm_backend;

--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -72,7 +72,7 @@ _________________________________
   :f real(c_double) skip_threshold: threshold used to skip testing slow configurations; skip configuration if :code:`skip_threshold * t > t_best`, where :code:`t` is the duration of the first timed trial for the configuration and :code:`t_best` is the average trial time of the current best configuration (default: 0.0)
   :f logical autotune_transpose_backend: flag to enable transpose backend autotuning (default: false)
   :f logical autotune_halo_backend: flag to enable halo backend autotuning (default: false)
-  :f logical transpose_use_inplace_buffers: flag to control whether transpose autotuning uses in-place or out-of-place buffers (default: false)
+  :f logical transpose_use_inplace_buffers(4): flag to control whether transpose autotuning uses in-place or out-of-place buffers by operation, considering the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X (default: [false, false, false, false])
   :f logical autotune_transpose_skip(4): flag to skip certain transpose operations during autotuning, considering the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X (default: [false, false, false, false])
   :f integer halo_extents(3): extents for halo autotuning (default: [0, 0, 0])
   :f logical halo_periods(3): periodicity for halo autotuning (default: [false, false, false])

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -195,8 +195,8 @@ this example, we set it to true to enable transpose backend autotuning.
 
     options%autotune_transpose_backend = .true.
 
-The :code:`transpose_use_inplace_buffers` entry is a boolean flag that controls whether the transpose
-communication during autotuning is performed in-place or out-of-place. This choice can impact transpose
+The :code:`transpose_use_inplace_buffers` entry is an array of boolean flags that controls whether the transpose
+communication during autotuning is performed in-place or out-of-place, on a per operation basis. This choice can impact transpose
 performance due to some optimized paths that skip intermediate local operations in some situations,
 depending on the input/output buffer locations.
 
@@ -211,18 +211,24 @@ contain the same data elements from the global grid. Since the transpose is in-p
 is already the output buffer, and no operation is performed. In contrast, an out-of-place transpose
 would require a copy of data between the input and output buffers.
 
-In this example, we use in-place buffers so we can set this flag to :code:`true`. By default, this
-flag is :code:`false`.
+In this example, we use in-place buffers for all transpose operations so we can set all elements of :code:`transpose_use_inplace_buffers` to :code:`true`.
+By default, the entries are set to :code:`false` and out-of-place buffers are used during autotuning.
 
 .. tabs::
 
   .. code-tab:: c++
 
-    options.transpose_use_inplace_buffers = true;
+    options.transpose_use_inplace_buffers[0] = true; // use in-place buffers for X-to-Y transpose
+    options.transpose_use_inplace_buffers[1] = true; // use in-place buffers for Y-to-Z transpose
+    options.transpose_use_inplace_buffers[2] = true; // use in-place buffers for Z-to-Y transpose
+    options.transpose_use_inplace_buffers[3] = true; // use in-place buffers for Y-to-X transpose
 
   .. code-tab:: fortran
 
-    options%transpose_use_inplace_buffers = .true.
+    options.transpose_use_inplace_buffers(0) = .true. ! use in-place buffers for X-to-Y transpose
+    options.transpose_use_inplace_buffers(1) = .true. ! use in-place buffers for Y-to-Z transpose
+    options.transpose_use_inplace_buffers(2) = .true. ! use in-place buffers for Z-to-Y transpose
+    options.transpose_use_inplace_buffers(3) = .true. ! use in-place buffers for Y-to-X transpose
 
 The :code:`autotune_transpose_skip` entry is an array of boolean flags that allows to skip certain
 transpose operations during autotuning. This option is meant for algorithms that only perform a subset

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -225,10 +225,10 @@ By default, the entries are set to :code:`false` and out-of-place buffers are us
 
   .. code-tab:: fortran
 
-    options%transpose_use_inplace_buffers(0) = .true. ! use in-place buffers for X-to-Y transpose
-    options%transpose_use_inplace_buffers(1) = .true. ! use in-place buffers for Y-to-Z transpose
-    options%transpose_use_inplace_buffers(2) = .true. ! use in-place buffers for Z-to-Y transpose
-    options%transpose_use_inplace_buffers(3) = .true. ! use in-place buffers for Y-to-X transpose
+    options%transpose_use_inplace_buffers(1) = .true. ! use in-place buffers for X-to-Y transpose
+    options%transpose_use_inplace_buffers(2) = .true. ! use in-place buffers for Y-to-Z transpose
+    options%transpose_use_inplace_buffers(3) = .true. ! use in-place buffers for Z-to-Y transpose
+    options%transpose_use_inplace_buffers(4) = .true. ! use in-place buffers for Y-to-X transpose
 
 The :code:`autotune_transpose_skip` entry is an array of boolean flags that allows to skip certain
 transpose operations during autotuning. This option is meant for algorithms that only perform a subset

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -225,10 +225,10 @@ By default, the entries are set to :code:`false` and out-of-place buffers are us
 
   .. code-tab:: fortran
 
-    options.transpose_use_inplace_buffers(0) = .true. ! use in-place buffers for X-to-Y transpose
-    options.transpose_use_inplace_buffers(1) = .true. ! use in-place buffers for Y-to-Z transpose
-    options.transpose_use_inplace_buffers(2) = .true. ! use in-place buffers for Z-to-Y transpose
-    options.transpose_use_inplace_buffers(3) = .true. ! use in-place buffers for Y-to-X transpose
+    options%transpose_use_inplace_buffers(0) = .true. ! use in-place buffers for X-to-Y transpose
+    options%transpose_use_inplace_buffers(1) = .true. ! use in-place buffers for Y-to-Z transpose
+    options%transpose_use_inplace_buffers(2) = .true. ! use in-place buffers for Z-to-Y transpose
+    options%transpose_use_inplace_buffers(3) = .true. ! use in-place buffers for Y-to-X transpose
 
 The :code:`autotune_transpose_skip` entry is an array of boolean flags that allows to skip certain
 transpose operations during autotuning. This option is meant for algorithms that only perform a subset

--- a/examples/cc/basic_usage/basic_usage_autotune.cu
+++ b/examples/cc/basic_usage/basic_usage_autotune.cu
@@ -152,7 +152,10 @@ int main(int argc, char** argv) {
 
   // Transpose communication backend autotuning options
   options.autotune_transpose_backend = true;
-  options.transpose_use_inplace_buffers = true;
+  options.transpose_use_inplace_buffers[0] = true;
+  options.transpose_use_inplace_buffers[1] = true;
+  options.transpose_use_inplace_buffers[2] = true;
+  options.transpose_use_inplace_buffers[3] = true;
   options.autotune_transpose_skip[0] = false;
   options.autotune_transpose_skip[1] = false;
   options.autotune_transpose_skip[2] = false;

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -111,10 +111,10 @@ program main
 
   ! Transpose communication backend autotuning options
   options%autotune_transpose_backend = .true.
-  options%transpose_use_inplace_buffers(0) = .true.
   options%transpose_use_inplace_buffers(1) = .true.
   options%transpose_use_inplace_buffers(2) = .true.
   options%transpose_use_inplace_buffers(3) = .true.
+  options%transpose_use_inplace_buffers(4) = .true.
   options%autotune_transpose_skip(1) = .false.
   options%autotune_transpose_skip(2) = .false.
   options%autotune_transpose_skip(3) = .false.

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -111,7 +111,10 @@ program main
 
   ! Transpose communication backend autotuning options
   options%autotune_transpose_backend = .true.
-  options%transpose_use_inplace_buffers = .true.
+  options.transpose_use_inplace_buffers(0) = .true.
+  options.transpose_use_inplace_buffers(1) = .true.
+  options.transpose_use_inplace_buffers(2) = .true.
+  options.transpose_use_inplace_buffers(3) = .true.
   options%autotune_transpose_skip(1) = .false.
   options%autotune_transpose_skip(2) = .false.
   options%autotune_transpose_skip(3) = .false.

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -111,10 +111,10 @@ program main
 
   ! Transpose communication backend autotuning options
   options%autotune_transpose_backend = .true.
-  options.transpose_use_inplace_buffers(0) = .true.
-  options.transpose_use_inplace_buffers(1) = .true.
-  options.transpose_use_inplace_buffers(2) = .true.
-  options.transpose_use_inplace_buffers(3) = .true.
+  options%transpose_use_inplace_buffers(0) = .true.
+  options%transpose_use_inplace_buffers(1) = .true.
+  options%transpose_use_inplace_buffers(2) = .true.
+  options%transpose_use_inplace_buffers(3) = .true.
   options%autotune_transpose_skip(1) = .false.
   options%autotune_transpose_skip(2) = .false.
   options%autotune_transpose_skip(3) = .false.

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -158,8 +158,10 @@ typedef struct {
 
   // Transpose-specific options
   bool autotune_transpose_backend;    ///< flag to enable transpose backend autotuning (default: false)
-  bool transpose_use_inplace_buffers; ///< flag to control whether transpose autotuning uses in-place or out-of-place
-                                      ///< buffers (default: false)
+  bool transpose_use_inplace_buffers[4]; ///< flag to control whether transpose autotuning uses in-place or out-of-place
+                                         ///< buffers during autotuning by transpose operation, considering
+                                         ///< the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X
+                                         ///< (default: [false, false, false, false])
   bool autotune_transpose_skip[4];    ///< flag to skip certain transpose operations during autotuning, considering
                                       ///< the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X
                                       ///< (default: [false, false, false, false])

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -122,7 +122,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
 
 
   bool need_data2 = false;
-  for (int i = 0; i < 4; ++ i) {
+  for (int i = 0; i < 4; ++i) {
     if (!options->transpose_use_inplace_buffers[i]) need_data2 = true;
   }
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -543,8 +543,8 @@ cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAuto
 
     // Transpose-specific options
     options->autotune_transpose_backend = false;
-    options->transpose_use_inplace_buffers = false;
     for (int i = 0; i < 4; ++i) {
+      options->transpose_use_inplace_buffers[i] = false;
       options->autotune_transpose_skip[i] = false;
     }
 

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -138,7 +138,7 @@ module cudecomp
 
     ! Transpose-specific options
     logical(c_bool) :: autotune_transpose_backend ! flag to enable transpose backend autotuning
-    logical(c_bool) :: transpose_use_inplace_buffers ! flag to control whether transpose autotuning uses in-place or out-of-place buffers
+    logical(c_bool) :: transpose_use_inplace_buffers(4) ! flag to control whether transpose autotuning uses in-place or out-of-place buffers
     logical(c_bool) :: autotune_transpose_skip(4) ! flag to skip certain transpose operations during autotuning
 
     ! Halo-specific options

--- a/tests/cc/transpose_test.cc
+++ b/tests/cc/transpose_test.cc
@@ -266,7 +266,9 @@ int main(int argc, char** argv) {
   cudecompGridDescAutotuneOptions_t options;
   CHECK_CUDECOMP_EXIT(cudecompGridDescAutotuneOptionsSetDefaults(&options));
   options.dtype = get_cudecomp_datatype(real_t(0));
-  options.transpose_use_inplace_buffers = !out_of_place;
+  for (int i = 0; i < 4; ++i) {
+    options.transpose_use_inplace_buffers[i] = !out_of_place;
+  }
 
   if (comm_backend != 0) {
     config.transpose_comm_backend = comm_backend;


### PR DESCRIPTION
This PR continues work to make the autotuning process more flexible by enabling a per operation in-place buffer setting for transpose autotuning. Formerly, there was a single flag in `cudecompGridDescAutotuneOptions` (`transpose_use_inplace_buffers`) which applied to all transpose operations during autotuning. However, some applications may mix in-place and out-of-place usage (e.g., use in-place for X-to-Y and Y-to-X transposes while using out-of-place for Y-to-Z and Z-to-Y). To enable this, I've modified the `transpose_use_inplace_buffers` to be an array of 4 boolean flags (one per operation) rather than a single flag. 

Note that this is a **breaking API change** for C/C++ programs, where any setting of `transpose_use_inplace_buffers` must be updated to set individual array entries. In Fortran programs, existing usage like `options%transpose_use_inplace_buffers = .true.` should still work as expected.