### PR TITLE
Enable applying weights to individual transpose operation timings during autotuning 

### DIFF
--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -73,7 +73,7 @@ _________________________________
   :f logical autotune_transpose_backend: flag to enable transpose backend autotuning (default: false)
   :f logical autotune_halo_backend: flag to enable halo backend autotuning (default: false)
   :f logical transpose_use_inplace_buffers(4): flag to control whether transpose autotuning uses in-place or out-of-place buffers by operation, considering the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X (default: [false, false, false, false])
-  :f logical autotune_transpose_skip(4): flag to skip certain transpose operations during autotuning, considering the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X (default: [false, false, false, false])
+  :f real(c_double) transpose_op_weights(4): multiplicative weight to apply to trial time contribution by transpose operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X (default: [1.0, 1.0, 1.0, 1.0])
   :f integer halo_extents(3): extents for halo autotuning (default: [0, 0, 0])
   :f logical halo_periods(3): periodicity for halo autotuning (default: [false, false, false])
   :f integer halo_axis: which axis pencils to use for halo autotuning (default: 1, X-pencils)

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -230,28 +230,36 @@ By default, the entries are set to :code:`false` and out-of-place buffers are us
     options%transpose_use_inplace_buffers(3) = .true. ! use in-place buffers for Z-to-Y transpose
     options%transpose_use_inplace_buffers(4) = .true. ! use in-place buffers for Y-to-X transpose
 
-The :code:`autotune_transpose_skip` entry is an array of boolean flags that allows to skip certain
-transpose operations during autotuning. This option is meant for algorithms that only perform a subset
-of the four supported transposing operations. In this example, we autotune for the full set of
-operations, and therefore set all elements of :code:`autotune_transpose_skip` to :code:`false`.
+The :code:`transpose_op_weights` entry is an array of floating point weights that enable adjusting the
+contribution of the different transpose operations to the trial timings used by the autotuner. By default,
+the trial timings used by the autotuner are an unweighted sum of the X-to-Y, Y-to-Z, Z-to-Y, and Y-to-X transpose timings.
+The entries in :code:`transpose_op_weights` are multiplicative weights that are applied to the
+contribution of each transpose operation to the total trial timing.
+This option is meant for programs that may invoke the different transpose operations an unequal
+number of times and may want the autotuner to emphasize the more frequently invoked transpose operations
+when measuring the performance of a backend and process grid configuration. For example, setting
+the weight to zero for one of the transpose operations will indicate to the autotuner that the timing
+of that operation should not contribute to the trial time sum.
+In this example, we autotune using the full set of transpose
+operations, and therefore set all elements of :code:`transpose_op_weights` to :code:`1.0`.
 We should note that this is the default behavior, and thus there is no need to explicitly set
-the elements to :code:`false`.
+the elements to :code:`1.0` generally.
 
 .. tabs::
 
   .. code-tab:: c++
 
-    options.autotune_transpose_skip[0] = false; // do not skip X-to-Y transpose
-    options.autotune_transpose_skip[1] = false; // do not skip Y-to-Z transpose
-    options.autotune_transpose_skip[2] = false; // do not skip Z-to-Y transpose
-    options.autotune_transpose_skip[3] = false; // do not skip Y-to-X transpose
+    options.transpose_op_weights[0] = 1.0; // apply 1.0 multiplier to X-to-Y transpose timings
+    options.transpose_op_weights[1] = 1.0; // apply 1.0 multiplier to Y-to-Z transpose timings
+    options.transpose_op_weights[2] = 1.0; // apply 1.0 multiplier to Z-to-Y transpose timings
+    options.transpose_op_weights[3] = 1.0; // apply 1.0 multiplier to Y-to-X transpose timings
 
   .. code-tab:: fortran
 
-    options%autotune_transpose_skip(1) = .false. ! do not skip X-to-Y transpose
-    options%autotune_transpose_skip(2) = .false. ! do not skip Y-to-Z transpose
-    options%autotune_transpose_skip(3) = .false. ! do not skip Z-to-Y transpose
-    options%autotune_transpose_skip(4) = .false. ! do not skip Y-to-X transpose
+    options%transpose_op_weights(1) = 1.0 ! apply 1.0 multiplier to X-to-Y transpose timings
+    options%transpose_op_weights(2) = 1.0 ! apply 1.0 multiplier to Y-to-Z transpose timings
+    options%transpose_op_weights(3) = 1.0 ! apply 1.0 multiplier to Z-to-Y transpose timings
+    options%transpose_op_weights(4) = 1.0 ! apply 1.0 multiplier to Y-to-X transpose timings
 
 Lastly, these are the options specific to halo communication backend autotuning.
 

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -238,8 +238,9 @@ contribution of each transpose operation to the total trial timing.
 This option is meant for programs that may invoke the different transpose operations an unequal
 number of times and may want the autotuner to emphasize the more frequently invoked transpose operations
 when measuring the performance of a backend and process grid configuration. For example, setting
-the weight to zero for one of the transpose operations will indicate to the autotuner that the timing
-of that operation should not contribute to the trial time sum.
+the weight to :code:`0.0` for one of the transpose operations will indicate to the autotuner that the timing
+of that operation should not contribute to the trial time sum. On a related note, the autotuner will skip running
+any transpose operation with a weight of :code:`0.0` for efficiency.
 In this example, we autotune using the full set of transpose
 operations, and therefore set all elements of :code:`transpose_op_weights` to :code:`1.0`.
 We should note that this is the default behavior, and thus there is no need to explicitly set

--- a/examples/cc/basic_usage/basic_usage_autotune.cu
+++ b/examples/cc/basic_usage/basic_usage_autotune.cu
@@ -156,10 +156,10 @@ int main(int argc, char** argv) {
   options.transpose_use_inplace_buffers[1] = true;
   options.transpose_use_inplace_buffers[2] = true;
   options.transpose_use_inplace_buffers[3] = true;
-  options.autotune_transpose_skip[0] = false;
-  options.autotune_transpose_skip[1] = false;
-  options.autotune_transpose_skip[2] = false;
-  options.autotune_transpose_skip[3] = false;
+  options.transpose_op_weights[0] = 1.0;
+  options.transpose_op_weights[1] = 1.0;
+  options.transpose_op_weights[2] = 1.0;
+  options.transpose_op_weights[3] = 1.0;
 
   // Halo communication backend autotuning options
   options.autotune_halo_backend = true;

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -115,10 +115,10 @@ program main
   options%transpose_use_inplace_buffers(2) = .true.
   options%transpose_use_inplace_buffers(3) = .true.
   options%transpose_use_inplace_buffers(4) = .true.
-  options%autotune_transpose_skip(1) = .false.
-  options%autotune_transpose_skip(2) = .false.
-  options%autotune_transpose_skip(3) = .false.
-  options%autotune_transpose_skip(4) = .false.
+  options%transpose_op_weights(1) = 1.0
+  options%transpose_op_weights(2) = 1.0
+  options%transpose_op_weights(3) = 1.0
+  options%transpose_op_weights(4) = 1.0
 
   ! Halo communication backend autotuning options
   options%autotune_halo_backend = .true.

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -157,14 +157,14 @@ typedef struct {
                                     ///< configuration (default: 0.0)
 
   // Transpose-specific options
-  bool autotune_transpose_backend;    ///< flag to enable transpose backend autotuning (default: false)
+  bool autotune_transpose_backend;       ///< flag to enable transpose backend autotuning (default: false)
   bool transpose_use_inplace_buffers[4]; ///< flag to control whether transpose autotuning uses in-place or out-of-place
                                          ///< buffers during autotuning by transpose operation, considering
                                          ///< the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X
                                          ///< (default: [false, false, false, false])
-  bool autotune_transpose_skip[4];    ///< flag to skip certain transpose operations during autotuning, considering
-                                      ///< the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X
-                                      ///< (default: [false, false, false, false])
+  double transpose_op_weights[4];        ///< multiplicative weight to apply to trial time contribution by transpose operation
+                                         ///< in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X
+                                         ///< (default: [1.0, 1.0, 1.0, 1.0])
 
   // Halo-specific options
   bool autotune_halo_backend; ///< flag to enable halo backend autotuning (default: false)

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -247,14 +247,22 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
 
       // Warmup
       for (int i = 0; i < options->n_warmup_trials; ++i) {
-        CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[0] ? data : data2, w,
-                                             options->dtype, nullptr, nullptr, 0));
-        CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, data, options->transpose_use_inplace_buffers[1] ? data : data2, w,
-                                             options->dtype, nullptr, nullptr, 0));
-        CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[2] ? data : data2, w,
-                                             options->dtype, nullptr, nullptr, 0));
-        CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, data, options->transpose_use_inplace_buffers[3] ? data : data2, w,
-                                             options->dtype, nullptr, nullptr, 0));
+        if (options->transpose_op_weights[0] != 0.0) {
+          CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[0] ? data : data2, w,
+                                               options->dtype, nullptr, nullptr, 0));
+        }
+        if (options->transpose_op_weights[1] != 0.0) {
+          CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, data, options->transpose_use_inplace_buffers[1] ? data : data2, w,
+                                               options->dtype, nullptr, nullptr, 0));
+        }
+        if (options->transpose_op_weights[2] != 0.0) {
+          CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[2] ? data : data2, w,
+                                               options->dtype, nullptr, nullptr, 0));
+        }
+        if (options->transpose_op_weights[3] != 0.0) {
+          CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, data, options->transpose_use_inplace_buffers[3] ? data : data2, w,
+                                               options->dtype, nullptr, nullptr, 0));
+        }
       }
 
       // Trials
@@ -270,29 +278,39 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       double ts = MPI_Wtime();
       for (int i = 0; i < options->n_trials; ++i) {
         CHECK_CUDA(cudaEventRecord(events[0], 0));
-        CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[0] ? data : data2, w,
-                                             options->dtype, nullptr, nullptr, 0));
+        if (options->transpose_op_weights[0] != 0.0) {
+          CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[0] ? data : data2, w,
+                                               options->dtype, nullptr, nullptr, 0));
+        }
         CHECK_CUDA(cudaEventRecord(events[1], 0));
-        CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, data, options->transpose_use_inplace_buffers[1] ? data : data2, w,
-                                             options->dtype, nullptr, nullptr, 0));
+        if (options->transpose_op_weights[1] != 0.0) {
+          CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, data, options->transpose_use_inplace_buffers[1] ? data : data2, w,
+                                               options->dtype, nullptr, nullptr, 0));
+        }
         CHECK_CUDA(cudaEventRecord(events[2], 0));
-        CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[2] ? data : data2, w,
-                                             options->dtype, nullptr, nullptr, 0));
+        if (options->transpose_op_weights[2] != 0.0) {
+          CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[2] ? data : data2, w,
+                                               options->dtype, nullptr, nullptr, 0));
+        }
         CHECK_CUDA(cudaEventRecord(events[3], 0));
-        CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, data, options->transpose_use_inplace_buffers[3] ? data : data2, w,
-                                             options->dtype, nullptr, nullptr, 0));
+        if (options->transpose_op_weights[3] != 0.0) {
+          CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, data, options->transpose_use_inplace_buffers[3] ? data : data2, w,
+                                               options->dtype, nullptr, nullptr, 0));
+        }
         CHECK_CUDA(cudaEventRecord(events[4], 0));
         CHECK_CUDA(cudaDeviceSynchronize());
         CHECK_MPI(MPI_Barrier(handle->mpi_comm));
 
-        CHECK_CUDA(cudaEventElapsedTime(&trial_xy_times[i], events[0], events[1]));
-        CHECK_CUDA(cudaEventElapsedTime(&trial_yz_times[i], events[1], events[2]));
-        CHECK_CUDA(cudaEventElapsedTime(&trial_zy_times[i], events[2], events[3]));
-        CHECK_CUDA(cudaEventElapsedTime(&trial_yx_times[i], events[3], events[4]));
+        if (options->transpose_op_weights[0] != 0.0) CHECK_CUDA(cudaEventElapsedTime(&trial_xy_times[i], events[0], events[1]));
+        if (options->transpose_op_weights[1] != 0.0) CHECK_CUDA(cudaEventElapsedTime(&trial_yz_times[i], events[1], events[2]));
+        if (options->transpose_op_weights[2] != 0.0) CHECK_CUDA(cudaEventElapsedTime(&trial_zy_times[i], events[2], events[3]));
+        if (options->transpose_op_weights[3] != 0.0) CHECK_CUDA(cudaEventElapsedTime(&trial_yx_times[i], events[3], events[4]));
+
         trial_times[i] = trial_xy_times[i] +
                          trial_yz_times[i] +
                          trial_zy_times[i] +
                          trial_yx_times[i];
+
         trial_times_w[i] = options->transpose_op_weights[0] * trial_xy_times[i] +
                            options->transpose_op_weights[1] * trial_yz_times[i] +
                            options->transpose_op_weights[2] * trial_zy_times[i] +
@@ -318,6 +336,15 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       auto zy_times = processTimings(handle, trial_zy_times);
       auto yx_times = processTimings(handle, trial_yx_times);
 
+      const char *t_skipped[4];
+      for (int i = 0; i < 4; ++i) {
+        if (options->transpose_op_weights[i] == 0.0) {
+          t_skipped[i] = " (skipped)";
+        } else {
+          t_skipped[i] = "";
+        }
+      }
+
       if (handle->rank == 0) {
         if (skip_case) {
           printf("CUDECOMP:\tgrid: %d x %d, backend: %s \n"
@@ -328,16 +355,17 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
           printf("CUDECOMP:\tgrid: %d x %d, backend: %s \n"
                  "CUDECOMP:\tTotal time min/max/avg/std [ms]: %f/%f/%f/%f\n"
                  "CUDECOMP:\t           min/max/avg/std [ms]: %f/%f/%f/%f (weighted)\n"
-                 "CUDECOMP:\tTransposeXY time min/max/avg/std [ms]: %f/%f/%f/%f\n"
-                 "CUDECOMP:\tTransposeYZ time min/max/avg/std [ms]: %f/%f/%f/%f\n"
-                 "CUDECOMP:\tTransposeZY time min/max/avg/std [ms]: %f/%f/%f/%f\n"
-                 "CUDECOMP:\tTransposeYX time min/max/avg/std [ms]: %f/%f/%f/%f\n",
+                 "CUDECOMP:\tTransposeXY time min/max/avg/std [ms]: %f/%f/%f/%f%s\n"
+                 "CUDECOMP:\tTransposeYZ time min/max/avg/std [ms]: %f/%f/%f/%f%s\n"
+                 "CUDECOMP:\tTransposeZY time min/max/avg/std [ms]: %f/%f/%f/%f%s\n"
+                 "CUDECOMP:\tTransposeYX time min/max/avg/std [ms]: %f/%f/%f/%f%s\n",
                  grid_desc->config.pdims[0], grid_desc->config.pdims[1],
                  cudecompTransposeCommBackendToString(grid_desc->config.transpose_comm_backend), times[0], times[1],
                  times[2], times[3], times_w[0], times_w[1], times_w[2], times_w[3],
-                 xy_times[0], xy_times[1], xy_times[2], xy_times[3], yz_times[0], yz_times[1],
-                 yz_times[2], yz_times[3], zy_times[0], zy_times[1], zy_times[2], zy_times[3],
-                 yx_times[0], yx_times[1], yx_times[2], yx_times[3]);
+                 xy_times[0], xy_times[1], xy_times[2], xy_times[3], t_skipped[0], yz_times[0], yz_times[1],
+                 yz_times[2], yz_times[3], t_skipped[1], zy_times[0], zy_times[1], zy_times[2], zy_times[3], t_skipped[2],
+                 yx_times[0], yx_times[1], yx_times[2], yx_times[3], t_skipped[3]);
+
         }
       }
 

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -247,26 +247,19 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
 
       // Warmup
       for (int i = 0; i < options->n_warmup_trials; ++i) {
-        if (!options->autotune_transpose_skip[0]) {
-          CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[0] ? data : data2, w,
-                                               options->dtype, nullptr, nullptr, 0));
-        }
-        if (!options->autotune_transpose_skip[1]) {
-          CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, data, options->transpose_use_inplace_buffers[1] ? data : data2, w,
-                                               options->dtype, nullptr, nullptr, 0));
-        }
-        if (!options->autotune_transpose_skip[2]) {
-          CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[2] ? data : data2, w,
-                                               options->dtype, nullptr, nullptr, 0));
-        }
-        if (!options->autotune_transpose_skip[3]) {
-          CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, data, options->transpose_use_inplace_buffers[3] ? data : data2, w,
-                                               options->dtype, nullptr, nullptr, 0));
-        }
+        CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[0] ? data : data2, w,
+                                             options->dtype, nullptr, nullptr, 0));
+        CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, data, options->transpose_use_inplace_buffers[1] ? data : data2, w,
+                                             options->dtype, nullptr, nullptr, 0));
+        CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[2] ? data : data2, w,
+                                             options->dtype, nullptr, nullptr, 0));
+        CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, data, options->transpose_use_inplace_buffers[3] ? data : data2, w,
+                                             options->dtype, nullptr, nullptr, 0));
       }
 
       // Trials
-      std::vector<double> trial_times(options->n_trials);
+      std::vector<float> trial_times(options->n_trials);
+      std::vector<float> trial_times_w(options->n_trials);
       std::vector<float> trial_xy_times(options->n_trials);
       std::vector<float> trial_yz_times(options->n_trials);
       std::vector<float> trial_zy_times(options->n_trials);
@@ -277,64 +270,53 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       double ts = MPI_Wtime();
       for (int i = 0; i < options->n_trials; ++i) {
         CHECK_CUDA(cudaEventRecord(events[0], 0));
-        if (!options->autotune_transpose_skip[0]) {
-          CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[0] ? data : data2, w,
-                                               options->dtype, nullptr, nullptr, 0));
-        }
+        CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[0] ? data : data2, w,
+                                             options->dtype, nullptr, nullptr, 0));
         CHECK_CUDA(cudaEventRecord(events[1], 0));
-        if (!options->autotune_transpose_skip[1]) {
-          CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, data, options->transpose_use_inplace_buffers[1] ? data : data2, w,
-                                               options->dtype, nullptr, nullptr, 0));
-        }
+        CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, data, options->transpose_use_inplace_buffers[1] ? data : data2, w,
+                                             options->dtype, nullptr, nullptr, 0));
         CHECK_CUDA(cudaEventRecord(events[2], 0));
-        if (!options->autotune_transpose_skip[2]) {
-          CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[2] ? data : data2, w,
-                                               options->dtype, nullptr, nullptr, 0));
-        }
+        CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, data, options->transpose_use_inplace_buffers[2] ? data : data2, w,
+                                             options->dtype, nullptr, nullptr, 0));
         CHECK_CUDA(cudaEventRecord(events[3], 0));
-        if (!options->autotune_transpose_skip[3]) {
-          CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, data, options->transpose_use_inplace_buffers[3] ? data : data2, w,
-                                               options->dtype, nullptr, nullptr, 0));
-        }
+        CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, data, options->transpose_use_inplace_buffers[3] ? data : data2, w,
+                                             options->dtype, nullptr, nullptr, 0));
         CHECK_CUDA(cudaEventRecord(events[4], 0));
         CHECK_CUDA(cudaDeviceSynchronize());
         CHECK_MPI(MPI_Barrier(handle->mpi_comm));
-        double te = MPI_Wtime();
-        trial_times[i] = te - ts;
+
+        CHECK_CUDA(cudaEventElapsedTime(&trial_xy_times[i], events[0], events[1]));
+        CHECK_CUDA(cudaEventElapsedTime(&trial_yz_times[i], events[1], events[2]));
+        CHECK_CUDA(cudaEventElapsedTime(&trial_zy_times[i], events[2], events[3]));
+        CHECK_CUDA(cudaEventElapsedTime(&trial_yx_times[i], events[3], events[4]));
+        trial_times[i] = trial_xy_times[i] +
+                         trial_yz_times[i] +
+                         trial_zy_times[i] +
+                         trial_yx_times[i];
+        trial_times_w[i] = options->transpose_op_weights[0] * trial_xy_times[i] +
+                           options->transpose_op_weights[1] * trial_yz_times[i] +
+                           options->transpose_op_weights[2] * trial_zy_times[i] +
+                           options->transpose_op_weights[3] * trial_yx_times[i];
 
         if (i == 0) {
-          double t_avg = trial_times[0];
-          CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &t_avg, 1, MPI_DOUBLE, MPI_SUM, handle->mpi_comm));
-          t_avg /= handle->nranks;
+          std::vector<float> t0 = {trial_times_w[0]};
+          auto times = processTimings(handle, t0);
+          auto t_avg = times[2];
 
-          if (options->skip_threshold * (t_avg * 1000.) > t_best) {
+          if (options->skip_threshold * t_avg > t_best) {
             // Performance of first iteration of this configuration meets skip threshold. Skipping.
             skip_case = true;
             break;
           }
         }
-
-        if (!options->autotune_transpose_skip[0]) CHECK_CUDA(cudaEventElapsedTime(&trial_xy_times[i], events[0], events[1]));
-        if (!options->autotune_transpose_skip[1]) CHECK_CUDA(cudaEventElapsedTime(&trial_yz_times[i], events[1], events[2]));
-        if (!options->autotune_transpose_skip[2]) CHECK_CUDA(cudaEventElapsedTime(&trial_zy_times[i], events[2], events[3]));
-        if (!options->autotune_transpose_skip[3]) CHECK_CUDA(cudaEventElapsedTime(&trial_yx_times[i], events[3], events[4]));
-        ts = te;
       }
 
-      auto times = processTimings(handle, trial_times, 1000.);
+      auto times = processTimings(handle, trial_times);
+      auto times_w = processTimings(handle, trial_times_w);
       auto xy_times = processTimings(handle, trial_xy_times);
       auto yz_times = processTimings(handle, trial_yz_times);
       auto zy_times = processTimings(handle, trial_zy_times);
       auto yx_times = processTimings(handle, trial_yx_times);
-
-      const char *t_skipped[4];
-      for (int i = 0; i < 4; ++i) {
-        if (options->autotune_transpose_skip[i]) {
-          t_skipped[i] = " (skipped)";
-        } else {
-          t_skipped[i] = "";
-        }
-      }
 
       if (handle->rank == 0) {
         if (skip_case) {
@@ -345,25 +327,27 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
         } else {
           printf("CUDECOMP:\tgrid: %d x %d, backend: %s \n"
                  "CUDECOMP:\tTotal time min/max/avg/std [ms]: %f/%f/%f/%f\n"
-                 "CUDECOMP:\tTransposeXY time min/max/avg/std [ms]: %f/%f/%f/%f%s\n"
-                 "CUDECOMP:\tTransposeYZ time min/max/avg/std [ms]: %f/%f/%f/%f%s\n"
-                 "CUDECOMP:\tTransposeZY time min/max/avg/std [ms]: %f/%f/%f/%f%s\n"
-                 "CUDECOMP:\tTransposeYX time min/max/avg/std [ms]: %f/%f/%f/%f%s\n",
+                 "CUDECOMP:\t           min/max/avg/std [ms]: %f/%f/%f/%f (weighted)\n"
+                 "CUDECOMP:\tTransposeXY time min/max/avg/std [ms]: %f/%f/%f/%f\n"
+                 "CUDECOMP:\tTransposeYZ time min/max/avg/std [ms]: %f/%f/%f/%f\n"
+                 "CUDECOMP:\tTransposeZY time min/max/avg/std [ms]: %f/%f/%f/%f\n"
+                 "CUDECOMP:\tTransposeYX time min/max/avg/std [ms]: %f/%f/%f/%f\n",
                  grid_desc->config.pdims[0], grid_desc->config.pdims[1],
                  cudecompTransposeCommBackendToString(grid_desc->config.transpose_comm_backend), times[0], times[1],
-                 times[2], times[3], xy_times[0], xy_times[1], xy_times[2], xy_times[3], t_skipped[0], yz_times[0], yz_times[1],
-                 yz_times[2], yz_times[3], t_skipped[1], zy_times[0], zy_times[1], zy_times[2], zy_times[3], t_skipped[2],
-                 yx_times[0], yx_times[1], yx_times[2], yx_times[3], t_skipped[3]);
+                 times[2], times[3], times_w[0], times_w[1], times_w[2], times_w[3],
+                 xy_times[0], xy_times[1], xy_times[2], xy_times[3], yz_times[0], yz_times[1],
+                 yz_times[2], yz_times[3], zy_times[0], zy_times[1], zy_times[2], zy_times[3],
+                 yx_times[0], yx_times[1], yx_times[2], yx_times[3]);
         }
       }
 
       if (skip_case) continue;
 
-      if (times[2] < t_best) {
+      if (times_w[2] < t_best) {
         pdims_best[0] = grid_desc->config.pdims[0];
         pdims_best[1] = grid_desc->config.pdims[1];
         comm_backend_best = grid_desc->config.transpose_comm_backend;
-        t_best = times[2];
+        t_best = times_w[2];
       }
     }
 
@@ -409,7 +393,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
   grid_desc->config.pdims[1] = pdims_best[1];
 
   if (handle->rank == 0) {
-    printf("CUDECOMP: SELECTED: grid: %d x %d, backend: %s, Avg. time %f\n", grid_desc->config.pdims[0],
+    printf("CUDECOMP: SELECTED: grid: %d x %d, backend: %s, Avg. time (weighted) [ms]: %f\n", grid_desc->config.pdims[0],
            grid_desc->config.pdims[1], cudecompTransposeCommBackendToString(grid_desc->config.transpose_comm_backend),
            t_best);
   }
@@ -691,7 +675,7 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
   grid_desc->config.pdims[1] = pdims_best[1];
 
   if (handle->rank == 0) {
-    printf("CUDECOMP: SELECTED: grid: %d x %d, halo backend: %s, Avg. time [s] %f\n", grid_desc->config.pdims[0],
+    printf("CUDECOMP: SELECTED: grid: %d x %d, halo backend: %s, Avg. time [ms]: %f\n", grid_desc->config.pdims[0],
            grid_desc->config.pdims[1], cudecompHaloCommBackendToString(grid_desc->config.halo_comm_backend), t_best);
   }
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -545,7 +545,7 @@ cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAuto
     options->autotune_transpose_backend = false;
     for (int i = 0; i < 4; ++i) {
       options->transpose_use_inplace_buffers[i] = false;
-      options->autotune_transpose_skip[i] = false;
+      options->transpose_op_weights[i] = 1.0;
     }
 
     // Halo-specific options

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -139,7 +139,7 @@ module cudecomp
     ! Transpose-specific options
     logical(c_bool) :: autotune_transpose_backend ! flag to enable transpose backend autotuning
     logical(c_bool) :: transpose_use_inplace_buffers(4) ! flag to control whether transpose autotuning uses in-place or out-of-place buffers
-    logical(c_bool) :: autotune_transpose_skip(4) ! flag to skip certain transpose operations during autotuning
+    real(c_double) :: transpose_op_weights(4) ! multiplicative weight to apply to trial time contribution by transpose operation
 
     ! Halo-specific options
     logical(c_bool) :: autotune_halo_backend ! flag to enable halo backend autotuning


### PR DESCRIPTION
This PR introduces a new `transpose_op_weights` entry in the autotuning options struct that enables users to have the autotuner emphasize, or ignore, particular transpose operations during autotuning. As noted in the updated docs:

> The `transpose_op_weights` entry is an array of floating point weights that enable adjusting the
contribution of the different transpose operations to the trial timings used by the autotuner. By default,
the trial timings used by the autotuner are an unweighted sum of the X-to-Y, Y-to-Z, Z-to-Y, and Y-to-X transpose timings.
The entries `transpose_op_weights` are multiplicative weights that are applied to the
contribution of each transpose operation to the total trial timing. This option is meant for programs that may invoke the different transpose operations an unequal number of times and may want the autotuner to emphasize the more frequently invoked transpose operations when measuring the performance of a backend and process grid configuration.

This feature overlaps with the `autotune_transpose_skip` option introduced in #16. Setting the weight value for a transpose operation to `0.0` will indicate to the autotuner that that operation should be ignored (i.e. it is equivalent to setting the corresponding `autotune_tranpose_skip`  value to `true`). The only difference in the current implementation is that the operation will still be run during autotuning; however, it will not contribute to the trial timing used for decision making. Since this feature is more general and captures the behavior of this existing feature, I've opted to remove the `autotune_transpose_skip` option in this PR. 