### PR TITLE
Add support for NCCL user buffer registration

### DIFF
--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -1,16 +1,16 @@
 .. _env-var-section-ref:
 
-cuDecomp Environment Variables
+Environment Variables
 ==============================
 
 The following section lists the environment variables available to configure the cuDecomp library.
 
 CUDECOMP_NCCL_ENABLE_UBR
 ------------------------
-(since v0.4.0)
+(since v0.4.0, requires NCCL v2.19 or newer)
 
-This variable controls whether cuDecomp registers its communication buffers with the NCCL library using :code:`ncclCommRegister`/:code:`ncclCommDeregister` (i.e., user buffer registration).
-Registration can improve NCCL send/receive performance in some scenarios. See `User Buffer Registration <https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html>`_
+:code:`CUDECOMP_NCCL_ENABLE_UBR` controls whether cuDecomp registers its communication buffers with the NCCL library using :code:`ncclCommRegister`/:code:`ncclCommDeregister` (i.e., user buffer registration).
+Registration can improve NCCL send/receive performance in some scenarios. See the `User Buffer Registration <https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html>`_
 section of the NCCL documentation for more details.
 
 Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -5,11 +5,11 @@ Environment Variables
 
 The following section lists the environment variables available to configure the cuDecomp library.
 
-CUDECOMP_NCCL_ENABLE_UBR
+CUDECOMP_ENABLE_NCCL_UBR
 ------------------------
 (since v0.4.0, requires NCCL v2.19 or newer)
 
-:code:`CUDECOMP_NCCL_ENABLE_UBR` controls whether cuDecomp registers its communication buffers with the NCCL library using :code:`ncclCommRegister`/:code:`ncclCommDeregister` (i.e., user buffer registration).
+:code:`CUDECOMP_ENABLE_NCCL_UBR` controls whether cuDecomp registers its communication buffers with the NCCL library using :code:`ncclCommRegister`/:code:`ncclCommDeregister` (i.e., user buffer registration).
 Registration can improve NCCL send/receive performance in some scenarios. See the `User Buffer Registration <https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html>`_
 section of the NCCL documentation for more details.
 

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -1,0 +1,17 @@
+.. _env-var-section-ref:
+
+cuDecomp Environment Variables
+==============================
+
+The following section lists the environment variables available to configure the cuDecomp library.
+
+CUDECOMP_NCCL_ENABLE_UBR
+------------------------
+(since v0.4.0)
+
+This variable controls whether cuDecomp registers its communication buffers with the NCCL library using :code:`ncclCommRegister`/:code:`ncclCommDeregister` (i.e., user buffer registration).
+Registration can improve NCCL send/receive performance in some scenarios. See `User Buffer Registration <https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html>`_
+section of the NCCL documentation for more details.
+
+Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Table of Contents
    basic_usage
    autotuning
    nvshmem
-   api
+   env_vars
 
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Table of Contents
    basic_usage
    autotuning
    nvshmem
+   api
    env_vars
 
 

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -36,6 +36,7 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <cuda_runtime.h>
@@ -59,6 +60,8 @@ struct cudecompHandle {
   int n_grid_descs_using_nccl = 0;      // Count of grid descriptors using NCCL
   ncclComm_t nccl_comm = nullptr;       // NCCL communicator (global)
   ncclComm_t nccl_local_comm = nullptr; // NCCL communicator (intranode)
+  bool nccl_enable_ubr = false;         // Flag to control NCCL user buffer registration usage
+  std::unordered_map<void*, std::vector<std::pair<ncclComm_t, void*>>> nccl_ubr_handles; // map of allocated buffer address to NCCL registration handle(s)
 
   cudaStream_t pl_stream = nullptr; // stream used for pipelined backends
 


### PR DESCRIPTION
In NCCL 2.19, the [User Buffer Registration](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html) feature was introduced, which allows users to register communication buffers with NCCL for improved performance in some scenarios. The feature initially only supported collectives, but starting in 2.20, support was extended to `ncclSend/ncclRecv` operations, which we use in the NCCL backends of cuDecomp.

This PR adds this capability as an opt-in feature via a new environment variable, `CUDECOMP_ENABLE_NCCL_UBR`. Enabling this feature allows cuDecomp to register workspace buffers for communication with NCCL (when workspace buffers are allocated with `cudecompMalloc`). 

Some initial testing has shown that this feature can improve the NCCL backend performance, but can require tuning of several NCCL environment variables for best results. For example, we've found `NCCL_PXN_DISABLE=1` and increasing `NCCL_NCHANNELS_PER_NET_PEER` above then current default of 2 improved the performance of the NCCL pipelined backend on a DGX H100 based cluster. On the other hand, we've seen usage of this feature degrade performance in some cases with the current NCCL release. Given these circumstances, I've made the feature opt-in for now. 