### PR TITLE
Add MPI_Barrier call in NCCL initialization code.

### DIFF
--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -64,6 +64,7 @@ static ncclComm_t ncclCommFromMPIComm(MPI_Comm mpi_comm) {
   ncclUniqueId id;
   if (rank == 0) CHECK_NCCL(ncclGetUniqueId(&id));
   CHECK_MPI(MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, mpi_comm));
+  CHECK_MPI(MPI_Barrier(mpi_comm));
   ncclComm_t nccl_comm;
   CHECK_NCCL(ncclCommInitRank(&nccl_comm, nranks, id, rank));
 


### PR DESCRIPTION
We've observed hangs in our NCCL initialization code during large scales test on some HPC clusters. The problematic code pattern is the following:
```
  CHECK_MPI(MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, mpi_comm));
  ncclComm_t nccl_comm;
  CHECK_NCCL(ncclCommInitRank(&nccl_comm, nranks, id, rank));
```
In some MPI implementations (in this case, HPCX with HCOLL collectives enabled), `MPI_Bcast` alone may not be enough to guarantee forward progress/completion of the broadcast and may instead defer progress to a future MPI API call (e.g., `MPI_Barrier`). Since `ncclCommInitRank` is blocking and does not invoke any MPI operations, the deferred progress can result in a deadlock with some ranks blocked indefinitely on the `MPI_Bcast` call. The suggested solution is to issue an `MPI_Barrier` immediately after the `MPI_Bcast` to force this operation to complete.