### PR TITLE
Move NVSHMEM kernels into separate file to limit application of -rdc=true.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,12 +139,19 @@ if (CMAKE_VERSION VERSION_LESS 3.18)
 else()
   set_target_properties(cudecomp PROPERTIES CUDA_ARCHITECTURES "${CUDECOMP_CUDA_CC_LIST}")
 endif()
+
+target_compile_options(cudecomp PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ptxas-options=-v >)
+
 target_sources(cudecomp
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/autotune.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels_rdc.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp.cc
 )
+
+set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels_rdc.cu PROPERTIES COMPILE_FLAGS -rdc=true)
+set_target_properties(cudecomp PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 target_include_directories(cudecomp
   PRIVATE
@@ -201,8 +208,6 @@ if (CUDECOMP_ENABLE_NVSHMEM)
     target_link_libraries(cudecomp PUBLIC -L${NVHPC_CUDA_LIBRARY_DIR}/stubs -lnvidia-ml)
   endif()
   target_link_libraries(cudecomp PUBLIC -L${NVHPC_CUDA_LIBRARY_DIR}/stubs -lcuda)
-  set_target_properties(cudecomp PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-  set_target_properties(cudecomp PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 endif()
 
 set_target_properties(cudecomp PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp.h)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ TESTDIR=${PWD}/tests
 EXAMPLEDIR=${PWD}/examples
 BENCHMARKDIR=${PWD}/benchmark
 
-OBJ=${BUILDDIR}/cudecomp.o ${BUILDDIR}/cudecomp_kernels.o ${BUILDDIR}/autotune.o
+OBJ=${BUILDDIR}/cudecomp.o ${BUILDDIR}/cudecomp_kernels.o ${BUILDDIR}/cudecomp_kernels_rdc.o ${BUILDDIR}/autotune.o
 TESTS_CC=${TESTDIR}/cc/test ${TESTDIR}/cc/fft_test
 TESTS_F90=${TESTDIR}/fortran/test ${TESTDIR}/fortran/fft_test
 
@@ -95,9 +95,13 @@ ${BUILDDIR}/%.o: src/%.cc  include/*.h include/internal/*.h
 	@mkdir -p ${BUILDDIR}
 	${MPICXX} -fPIC ${DEFINES} ${CXXFLAGS} ${INCLUDES} -c -o $@ $<
 
-${BUILDDIR}/%.o: src/%.cu  include/internal/*.cuh
+${BUILDDIR}/cudecomp_kernels_rdc.o: src/cudecomp_kernels_rdc.cu  include/internal/*.cuh
 	@mkdir -p ${BUILDDIR}
 	${NVCC} -rdc=true -Xcompiler -fPIC ${DEFINES} ${NVFLAGS} ${INCLUDES} -c -o $@ $<
+
+${BUILDDIR}/%.o: src/%.cu  include/internal/*.cuh
+	@mkdir -p ${BUILDDIR}
+	${NVCC} -Xcompiler -fPIC ${DEFINES} ${NVFLAGS} ${INCLUDES} -c -o $@ $<
 
 ${CUDECOMPMOD}: src/cudecomp_m.cuf 
 	@mkdir -p ${BUILDDIR}/include
@@ -105,7 +109,7 @@ ${CUDECOMPMOD}: src/cudecomp_m.cuf
 
 ${CUDECOMPLIB}: ${OBJ}
 	@mkdir -p ${BUILDDIR}/lib
-	${NVCC} -rdc=true -shared ${NVFLAGS} ${INCLUDES} ${LIBS} -o $@ $^ ${STATIC_LIBS}
+	${NVCC} -shared ${NVFLAGS} ${INCLUDES} ${LIBS} -o $@ $^ ${STATIC_LIBS}
 
 ${CUDECOMPFLIB}: ${CUDECOMPMOD}
 	@mkdir -p ${BUILDDIR}/lib

--- a/src/cudecomp_kernels.cu
+++ b/src/cudecomp_kernels.cu
@@ -35,30 +35,6 @@
 
 namespace cudecomp {
 
-#ifdef ENABLE_NVSHMEM
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
-  CHECK_CUDA_LAUNCH();
-}
-
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
-  CHECK_CUDA_LAUNCH();
-}
-
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
-                                cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
-  CHECK_CUDA_LAUNCH();
-}
-
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
-                                cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
-  CHECK_CUDA_LAUNCH();
-}
-#endif
-
 void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<float>& params, cudaStream_t stream) {
   size_t N = params.extents[0][0] * params.extents[1][0] * params.extents[2][0];
   for (int i = 1; i < params.ncopies; ++i) {

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cuda/std/complex>
+
+#include "internal/checks.h"
+#include "internal/cudecomp_kernels.cuh"
+
+namespace cudecomp {
+
+#ifdef ENABLE_NVSHMEM
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream) {
+  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+  CHECK_CUDA_LAUNCH();
+}
+
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream) {
+  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+  CHECK_CUDA_LAUNCH();
+}
+
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
+                                cudaStream_t stream) {
+  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+  CHECK_CUDA_LAUNCH();
+}
+
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+                                cudaStream_t stream) {
+  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+  CHECK_CUDA_LAUNCH();
+}
+#endif
+
+} // namespace cudecomp


### PR DESCRIPTION
This PR splits compilation of CUDA kernels in cuDecomp into two files (`cudecomp_kernels.cu` and `cudecomp_kernels_rdc.cu`) to limit the application of `-rdc=true` to only kernels that require that flag (e.g. kernels that use NVSHMEM device functions). It was observed that the combination of `-rdc=true` and `__launch_bounds__` on our batched memcopy kernels caused an unexpectedly high increase in registers. Compiling those kernels without `-rdc=true` resolves this issue and improves memcopy kernel occupancy/performance.
