### PR TITLE
Update CMake NVSHMEM include search paths for NVSHMEM 3.x.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,9 @@ if (CUDECOMP_ENABLE_NVSHMEM)
   )
 
   # Get NVSHMEM version from header
-  if (EXISTS ${NVSHMEM_INCLUDE_DIR}/nvshmem_version.h)
+  if (EXISTS ${NVSHMEM_INCLUDE_DIR}/non_abi/nvshmem_version.h)
+    file(READ ${NVSHMEM_INCLUDE_DIR}/non_abi/nvshmem_version.h NVSHMEM_VERSION_RAW)
+  elseif (EXISTS ${NVSHMEM_INCLUDE_DIR}/nvshmem_version.h)
     file(READ ${NVSHMEM_INCLUDE_DIR}/nvshmem_version.h NVSHMEM_VERSION_RAW)
   else()
     file(READ ${NVSHMEM_INCLUDE_DIR}/common/nvshmem_version.h NVSHMEM_VERSION_RAW)


### PR DESCRIPTION
NVSHMEM 3.x updated their include directory structure which made our CMake build unable to locate the `nvshmem_version.h` header when configuring the build. This PR adds the new include path to fix this build error.