### PR TITLE
Fix scaling overflow for large grids in R2C benchmark. Correct compilation defines for single precision C2C benchmark.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -30,7 +30,7 @@ endforeach()
 target_compile_definitions(benchmark_r2c PRIVATE R2C)
 target_compile_definitions(benchmark_c2c PRIVATE C2C)
 target_compile_definitions(benchmark_r2c_f PRIVATE R2C USE_FLOAT)
-target_compile_definitions(benchmark_c2c_f PRIVATE R2C USE_FLOAT)
+target_compile_definitions(benchmark_c2c_f PRIVATE C2C USE_FLOAT)
 
 install(
   TARGETS ${benchmark_targets}

--- a/benchmark/benchmark.cu
+++ b/benchmark/benchmark.cu
@@ -563,7 +563,7 @@ int main(int argc, char** argv) {
 
     // Note: excluding scaling from timing
 #ifdef R2C
-    scale<<<(pinfo_x_r.size + 1024 - 1) / 1024, 1024>>>(output_r, 1.0 / (gx * gy * gz), pinfo_x_r);
+    scale<<<(pinfo_x_r.size + 1024 - 1) / 1024, 1024>>>(output_r, 1.0 / fftsize, pinfo_x_r);
     if (out_of_place) std::swap(input, output);
     if (out_of_place) std::swap(input_r, output_r);
 #else


### PR DESCRIPTION
In some recent experimentation, I found that the R2C benchmark correctness checks can fail on large grids due to overflow of the FFT scaling factors. Additionally, it was found that the CMake build for the single precision C2C benchmark was adding the `-DR2C` define, causing it to erroneously build the R2C test. This PR fixes both issues.