### PR TITLE
Address narrowing conversion errors/warnings.

### DIFF
--- a/include/internal/halo.h
+++ b/include/internal/halo.h
@@ -153,7 +153,7 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     memcpy_params.ncopies = 2;
     cudecomp_batched_d2d_memcpy_3d(memcpy_params, stream);
 
-    std::array<comm_count_t, 2> counts{halo_size, halo_size};
+    std::array<comm_count_t, 2> counts{static_cast<comm_count_t>(halo_size), static_cast<comm_count_t>(halo_size)};
     std::array<size_t, 2> offsets{};
     offsets[1] = halo_size;
 
@@ -200,7 +200,7 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     std::array<int32_t, 3> lx{};
 
     size_t halo_size = shape_g_h[(dim + 1) % 3] * shape_g_h[(dim + 2) % 3] * halo_extents[dim];
-    std::array<comm_count_t, 2> counts{halo_size, halo_size};
+    std::array<comm_count_t, 2> counts{static_cast<comm_count_t>(halo_size), static_cast<comm_count_t>(halo_size)};
     std::array<size_t, 2> send_offsets;
     std::array<size_t, 2> recv_offsets;
 

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -79,7 +79,8 @@ template <typename T> static std::vector<T> processTimings(cudecompHandle_t hand
   t_var /= handle->nranks;
   double t_std = std::sqrt(t_var);
 
-  return {t_min * scale, t_max * scale, t_avg * scale, t_std * scale};
+  return {static_cast<T>(t_min) * scale, static_cast<T>(t_max) * scale, static_cast<T>(t_avg) * scale,
+          static_cast<T>(t_std) * scale};
 }
 
 } // namespace


### PR DESCRIPTION
This PR addresses some narrowing conversion errors/warnings. In particular, the returned initializer list in `processTimings` is actually ill-formed C++ code and will be an error in future NVHPC compilers. 