### PR TITLE
Add new transpose_mem_order configuration argument to enable more flexible pencil memory layouts.

### DIFF
--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -49,6 +49,8 @@ ________________________
   :f integer pdims(2): dimensions of process grid
   :f cudecompTransposeCommType transpose_comm_backend: communication backend to use for transpose communication (default: CUDECOMP_TRANSPOSE_COMM_MPI_P2P)
   :f logical transpose_axis_contiguous(3): flag (by axis) indicating if memory should be contiguous along pencil axis (default: [false, false, false])
+  :f integer transpose_mem_order(3, 3): user-specified memory ordering by axis, overrides transpose_axis_contiguous setting; second index specifies axis,
+                                        first index specifies memory order (default: unset)
   :f cudecompHaloCommType halo_comm_backend: communication backend to use for halo communication (default: CUDECOMP_HALO_COMM_MPI)
 
 ------

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -162,6 +162,36 @@ between signal elements in an FFT). In this example, we set this flag to true fo
 
     config%transpose_axis_contiguous = [.true., .true., .true.]
 
+Advanced users who require more flexibility in the memory layout of the pencil buffers can override the layouts available via
+ :code:`transpose_axis_contiguous` by setting the :code:`transpose_mem_order` array in the configuration structure. This array enables
+users to set arbitrary memory layout orders for the pencil buffers by axis. For example, a user can set this structure as follows to
+have pencil memory in :math:`[X, Y, Z]` order for the :math:`X`-pencil and :math:`[Z, Y, X]` order for the :math:`Y`- and :math:`Z`-pencils:
+
+.. tabs::
+
+  .. code-tab:: c++
+
+    config.transpose_mem_order[0][0] = 0;
+    config.transpose_mem_order[0][1] = 1;
+    config.transpose_mem_order[0][2] = 2;
+    config.transpose_mem_order[1][0] = 2;
+    config.transpose_mem_order[1][1] = 1;
+    config.transpose_mem_order[1][2] = 0;
+    config.transpose_mem_order[2][0] = 2;
+    config.transpose_mem_order[2][1] = 1;
+    config.transpose_mem_order[2][2] = 0;
+
+  .. code-tab:: fortran
+
+    config%transpose_mem_order(1, 1) = 0
+    config%transpose_mem_order(2, 1) = 1
+    config%transpose_mem_order(3, 1) = 2
+    config%transpose_mem_order(1, 2) = 2
+    config%transpose_mem_order(2, 2) = 1
+    config%transpose_mem_order(3, 2) = 0
+    config%transpose_mem_order(1, 3) = 2
+    config%transpose_mem_order(2, 3) = 1
+    config%transpose_mem_order(3, 3) = 0
 
 With the grid descriptor configuration structure created and populated, we can now create the grid descriptor. The last
 argument in :ref:`cudecompGridDescCreate-ref` is for an optional structure to set autotuning options. See :ref:`autotuning-section-ref`

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -163,7 +163,7 @@ between signal elements in an FFT). In this example, we set this flag to true fo
     config%transpose_axis_contiguous = [.true., .true., .true.]
 
 Advanced users who require more flexibility in the memory layout of the pencil buffers can override the layouts available via
- :code:`transpose_axis_contiguous` by setting the :code:`transpose_mem_order` array in the configuration structure. This array enables
+:code:`transpose_axis_contiguous` by setting the :code:`transpose_mem_order` array in the configuration structure. This array enables
 users to set arbitrary memory layout orders for the pencil buffers by axis. For example, a user can set this structure as follows to
 have pencil memory in :math:`[X, Y, Z]` order for the :math:`X`-pencil and :math:`[Z, Y, X]` order for the :math:`Y`- and :math:`Z`-pencils:
 
@@ -183,15 +183,15 @@ have pencil memory in :math:`[X, Y, Z]` order for the :math:`X`-pencil and :math
 
   .. code-tab:: fortran
 
-    config%transpose_mem_order(1, 1) = 0
-    config%transpose_mem_order(2, 1) = 1
-    config%transpose_mem_order(3, 1) = 2
-    config%transpose_mem_order(1, 2) = 2
-    config%transpose_mem_order(2, 2) = 1
-    config%transpose_mem_order(3, 2) = 0
-    config%transpose_mem_order(1, 3) = 2
-    config%transpose_mem_order(2, 3) = 1
-    config%transpose_mem_order(3, 3) = 0
+    config%transpose_mem_order(1, 1) = 1
+    config%transpose_mem_order(2, 1) = 2
+    config%transpose_mem_order(3, 1) = 3
+    config%transpose_mem_order(1, 2) = 3
+    config%transpose_mem_order(2, 2) = 2
+    config%transpose_mem_order(3, 2) = 1
+    config%transpose_mem_order(1, 3) = 3
+    config%transpose_mem_order(2, 3) = 2
+    config%transpose_mem_order(3, 3) = 1
 
 With the grid descriptor configuration structure created and populated, we can now create the grid descriptor. The last
 argument in :ref:`cudecompGridDescCreate-ref` is for an optional structure to set autotuning options. See :ref:`autotuning-section-ref`

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -133,7 +133,9 @@ typedef struct {
                                                          ///< (default: CUDECOMP_TRANSPOSE_COMM_MPI_P2P)
   bool transpose_axis_contiguous[3]; ///< flag (by axis) indicating if memory should be contiguous along pencil axis
                                      ///< (default: [false, false, false])
-  int32_t transpose_mem_order[3][3]; ///< user specified memory ordering by axis
+  int32_t transpose_mem_order[3][3]; ///< user-specified memory ordering by axis, overrides transpose_axis_contiguous setting;
+                                     ///< first index specifies axis, second index specifies memory order
+                                     ///< setting (default: unset)
 
 
   // Halo settings

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -133,6 +133,8 @@ typedef struct {
                                                          ///< (default: CUDECOMP_TRANSPOSE_COMM_MPI_P2P)
   bool transpose_axis_contiguous[3]; ///< flag (by axis) indicating if memory should be contiguous along pencil axis
                                      ///< (default: [false, false, false])
+  int32_t transpose_mem_order[3][3]; ///< user specified memory ordering by axis
+
 
   // Halo settings
   cudecompHaloCommBackend_t

--- a/include/internal/halo.h
+++ b/include/internal/halo.h
@@ -67,17 +67,12 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
 
   if (halo_extents[dim] == 0) { return; }
 
-  // Select correct case based on pencil axis and transfer dim
+  // Select correct case based on pencil memory order and transfer dim
   int c;
-  if (grid_desc->config.transpose_axis_contiguous[ax]) {
-    for (int i = 0; i < 3; ++i) {
-      if (pinfo_h.order[i] == dim) {
-        c = i;
-        break;
-      }
-    }
+  if (dim != pinfo_h.order[0] && dim != pinfo_h.order[1]) {
+    c = 2;
   } else {
-    c = (dim == 2 && ax != 2) ? 2 : 1;
+    c = 1;
   }
 
   if (neighbors[0] == handle->rank && neighbors[1] == handle->rank) {

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -245,7 +245,6 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
     o2 = work + max_pencil_size_a;
   }
 
-  // Disable special cases for now
   // Adjust pointers to handle special cases
   if (!input_has_halos && !output_has_halos) {
     if (splits_a.size() == 1) {

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -241,6 +241,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
     o2 = work + max_pencil_size_a;
   }
 
+  // Disable special cases for now
+  #if 0
   // Adjust pointers to handle special cases
   if (!input_has_halos && !output_has_halos) {
     if (splits_a.size() == 1) {
@@ -316,6 +318,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       }
     }
   }
+#endif
 
   // Setup communication info
   std::vector<comm_count_t> send_offsets(splits_a.size());
@@ -335,59 +338,59 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   }
 
   if (o1 != i1) {
-    if (fwd && grid_desc->config.transpose_axis_contiguous[ax_b]) {
-      // Transpose
-      std::array<int64_t, 3> extents;
-      std::array<int64_t, 3> extents_h;
-      std::array<int64_t, 3> strides_in{1, 0, 0}, strides_out{1, 0, 0};
-      std::array<int, 3> order;
+    //if (fwd && grid_desc->config.transpose_axis_contiguous[ax_b]) {
+    //  // Transpose
+    //  std::array<int64_t, 3> extents;
+    //  std::array<int64_t, 3> extents_h;
+    //  std::array<int64_t, 3> strides_in{1, 0, 0}, strides_out{1, 0, 0};
+    //  std::array<int, 3> order;
 
-      for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-          if (pinfo_a.order[j] == pinfo_b.order[i]) {
-            order[i] = j;
-            break;
-          }
-        }
-      }
+    //  for (int i = 0; i < 3; ++i) {
+    //    for (int j = 0; j < 3; ++j) {
+    //      if (pinfo_a.order[j] == pinfo_b.order[i]) {
+    //        order[i] = j;
+    //        break;
+    //      }
+    //    }
+    //  }
 
-      for (int i = 0; i < 3; ++i) {
-        extents[i] = shape_g_a[pinfo_a.order[i]];
-        extents_h[i] = shape_g_a_h[pinfo_a.order[i]];
-      }
+    //  for (int i = 0; i < 3; ++i) {
+    //    extents[i] = shape_g_a[pinfo_a.order[i]];
+    //    extents_h[i] = shape_g_a_h[pinfo_a.order[i]];
+    //  }
 
-      for (int i = 1; i < 3; ++i) {
-        strides_in[i] = strides_in[i - 1] * extents_h[i - 1];
-        strides_out[i] = strides_out[i - 1] * extents[order[i - 1]];
-      }
+    //  for (int i = 1; i < 3; ++i) {
+    //    strides_in[i] = strides_in[i - 1] * extents_h[i - 1];
+    //    strides_out[i] = strides_out[i - 1] * extents[order[i - 1]];
+    //  }
 
-      if (pipelined) {
-        for (int j = 1; j < splits_a.size() + 1; ++j) {
-          int src_rank, dst_rank;
-          getAlltoallPeerRanks(grid_desc, comm_axis, j, src_rank, dst_rank);
-          if (j == splits_a.size()) dst_rank = comm_rank;
+    //  if (pipelined) {
+    //    for (int j = 1; j < splits_a.size() + 1; ++j) {
+    //      int src_rank, dst_rank;
+    //      getAlltoallPeerRanks(grid_desc, comm_axis, j, src_rank, dst_rank);
+    //      if (j == splits_a.size()) dst_rank = comm_rank;
 
-          size_t shift = offsets_a[dst_rank];
-          for (int i = 0; i < 3; ++i) {
-            if (pinfo_a_h.order[i] == ax_a) break;
-            shift *= shape_g_a_h[i];
-          }
+    //      size_t shift = offsets_a[dst_rank];
+    //      for (int i = 0; i < 3; ++i) {
+    //        if (pinfo_a_h.order[i] == ax_a) break;
+    //        shift *= shape_g_a_h[i];
+    //      }
 
-          T* src = i1 + shift + getPencilPtrOffset(pinfo_a_h, input_halo_extents);
-          T* dst = o1 + send_offsets[dst_rank];
-          for (int i = 0; i < 3; ++i) {
-            if (ax_a == pinfo_a.order[i]) extents[i] = splits_a[dst_rank];
-          }
-          localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
-          CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], stream));
-        }
-      } else {
-        T* src = i1 + getPencilPtrOffset(pinfo_a_h, input_halo_extents);
-        T* dst = o1;
-        localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
-      }
+    //      T* src = i1 + shift + getPencilPtrOffset(pinfo_a_h, input_halo_extents);
+    //      T* dst = o1 + send_offsets[dst_rank];
+    //      for (int i = 0; i < 3; ++i) {
+    //        if (ax_a == pinfo_a.order[i]) extents[i] = splits_a[dst_rank];
+    //      }
+    //      localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
+    //      CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], stream));
+    //    }
+    //  } else {
+    //    T* src = i1 + getPencilPtrOffset(pinfo_a_h, input_halo_extents);
+    //    T* dst = o1;
+    //    localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
+    //  }
 
-    } else {
+    //} else {
       // Pack
       int memcpy_count = 0;
       cudecompBatchedD2DMemcpy3DParams<T> memcpy_params;
@@ -399,7 +402,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
         size_t shift = offsets_a[dst_rank];
         for (int i = 0; i < 3; ++i) {
           if (pinfo_a_h.order[i] == ax_a) break;
-          shift *= shape_g_a_h[i];
+          shift *= shape_g_a_h[pinfo_a_h.order[i]];
         }
 
         T* src = i1 + shift + getPencilPtrOffset(pinfo_a_h, input_halo_extents);
@@ -425,7 +428,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
         }
         if (pipelined) CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], stream));
       }
-    }
+    //}
 
     if (o1 == output) {
       // o1 is output. Return.
@@ -448,92 +451,92 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   }
 
   // Unpack into output buffer
-  if (!fwd && grid_desc->config.transpose_axis_contiguous[ax_a]) {
-    // Transpose out
-    std::array<int64_t, 3> extents;
-    std::array<int64_t, 3> extents_h;
-    std::array<int64_t, 3> strides_in{1, 0, 0}, strides_out{1, 0, 0};
-    std::array<int, 3> order;
+  //if (!fwd && grid_desc->config.transpose_axis_contiguous[ax_a]) {
+  //  // Transpose out
+  //  std::array<int64_t, 3> extents;
+  //  std::array<int64_t, 3> extents_h;
+  //  std::array<int64_t, 3> strides_in{1, 0, 0}, strides_out{1, 0, 0};
+  //  std::array<int, 3> order;
 
-    for (int i = 0; i < 3; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        if (pinfo_a.order[j] == pinfo_b.order[i]) {
-          order[i] = j;
-          break;
-        }
-      }
+  //  for (int i = 0; i < 3; ++i) {
+  //    for (int j = 0; j < 3; ++j) {
+  //      if (pinfo_a.order[j] == pinfo_b.order[i]) {
+  //        order[i] = j;
+  //        break;
+  //      }
+  //    }
 
-      extents[i] = shape_g_b[pinfo_a.order[i]];
-      extents_h[i] = shape_g_b_h[pinfo_b_h.order[i]];
-      if (i > 0) {
-        strides_in[i] = strides_in[i - 1] * extents[i - 1];
-        strides_out[i] = strides_out[i - 1] * extents_h[i - 1];
-      }
-    }
+  //    extents[i] = shape_g_b[pinfo_a.order[i]];
+  //    extents_h[i] = shape_g_b_h[pinfo_b_h.order[i]];
+  //    if (i > 0) {
+  //      strides_in[i] = strides_in[i - 1] * extents[i - 1];
+  //      strides_out[i] = strides_out[i - 1] * extents_h[i - 1];
+  //    }
+  //  }
 
-    if (pipelined) {
-      bool nvshmem_synced = false;
-      for (int j = 0; j < splits_b.size(); ++j) {
-        int src_rank, dst_rank;
-        getAlltoallPeerRanks(grid_desc, comm_axis, j, src_rank, dst_rank);
-        if (j == 0) {
-          dst_rank = comm_rank;
-          src_rank = comm_rank;
-        }
+  //  if (pipelined) {
+  //    bool nvshmem_synced = false;
+  //    for (int j = 0; j < splits_b.size(); ++j) {
+  //      int src_rank, dst_rank;
+  //      getAlltoallPeerRanks(grid_desc, comm_axis, j, src_rank, dst_rank);
+  //      if (j == 0) {
+  //        dst_rank = comm_rank;
+  //        src_rank = comm_rank;
+  //      }
 
-        std::vector<int> dst_ranks{dst_rank};
-        std::vector<int> src_ranks{src_rank};
+  //      std::vector<int> dst_ranks{dst_rank};
+  //      std::vector<int> src_ranks{src_rank};
 
-        if (j != 0 && comm_info.homogeneous && comm_info.nnodes != 1) {
-          // Perform pipelining in pairs to intra-node comms behind inter-node transfers
-          if (j % 2 == 1) {
-            if (j + 1 < splits_b.size()) {
-              int src_rank_next, dst_rank_next;
-              getAlltoallPeerRanks(grid_desc, comm_axis, j + 1, src_rank_next, dst_rank_next);
-              dst_ranks.push_back(dst_rank_next);
-              src_ranks.push_back(src_rank_next);
-            }
-          } else {
-            // Skip alltoall, this transfer was paired with previous one.
-            dst_ranks.resize(0);
-            src_ranks.resize(0);
-          }
-        }
+  //      if (j != 0 && comm_info.homogeneous && comm_info.nnodes != 1) {
+  //        // Perform pipelining in pairs to intra-node comms behind inter-node transfers
+  //        if (j % 2 == 1) {
+  //          if (j + 1 < splits_b.size()) {
+  //            int src_rank_next, dst_rank_next;
+  //            getAlltoallPeerRanks(grid_desc, comm_axis, j + 1, src_rank_next, dst_rank_next);
+  //            dst_ranks.push_back(dst_rank_next);
+  //            src_ranks.push_back(src_rank_next);
+  //          }
+  //        } else {
+  //          // Skip alltoall, this transfer was paired with previous one.
+  //          dst_ranks.resize(0);
+  //          src_ranks.resize(0);
+  //        }
+  //      }
 
-        if (o2 != o1) {
-          cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                    recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced);
-        }
+  //      if (o2 != o1) {
+  //        cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
+  //                                  recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced);
+  //      }
 
-        if (o2 != o3) {
-          size_t shift = offsets_b[src_rank];
-          for (int i = 0; i < 3; ++i) {
-            if (pinfo_b_h.order[i] == ax_b) break;
-            shift *= shape_g_b_h[i];
-          }
+  //      if (o2 != o3) {
+  //        size_t shift = offsets_b[src_rank];
+  //        for (int i = 0; i < 3; ++i) {
+  //          if (pinfo_b_h.order[i] == ax_b) break;
+  //          shift *= shape_g_b_h[i];
+  //        }
 
-          T* src = o2 + recv_offsets[src_rank];
-          T* dst = o3 + shift + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
-          for (int i = 0; i < 3; ++i) {
-            if (ax_b == pinfo_a.order[i]) {
-              extents[i] = splits_b[src_rank];
-              break;
-            }
-          }
+  //        T* src = o2 + recv_offsets[src_rank];
+  //        T* dst = o3 + shift + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
+  //        for (int i = 0; i < 3; ++i) {
+  //          if (ax_b == pinfo_a.order[i]) {
+  //            extents[i] = splits_b[src_rank];
+  //            break;
+  //          }
+  //        }
 
-          localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
-        }
-      }
-    } else {
-      if (o2 != o3) {
-        T* src = o2;
-        T* dst = o3 + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
-        localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
-      }
-    }
-  } else if ((!fwd && grid_desc->config.transpose_axis_contiguous[ax_b]) ||
-             (fwd && grid_desc->config.transpose_axis_contiguous[ax_a] &&
-              !grid_desc->config.transpose_axis_contiguous[ax_b])) {
+  //        localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
+  //      }
+  //    }
+  //  } else {
+  //    if (o2 != o3) {
+  //      T* src = o2;
+  //      T* dst = o3 + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
+  //      localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
+  //    }
+  //  }
+  //} else if ((!fwd && grid_desc->config.transpose_axis_contiguous[ax_b]) ||
+  //           (fwd && grid_desc->config.transpose_axis_contiguous[ax_a] &&
+  //            !grid_desc->config.transpose_axis_contiguous[ax_b])) {
     // Split transpose
     std::array<int64_t, 3> extents;
     std::array<int64_t, 3> extents_h;
@@ -595,7 +598,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
         size_t shift = offsets_b[src_rank];
         for (int i = 0; i < 3; ++i) {
           if (pinfo_b_h.order[i] == ax_b) break;
-          shift *= shape_g_b_h[i];
+          shift *= shape_g_b_h[pinfo_b_h.order[i]];
         }
 
         T* src = o2 + recv_offsets[src_rank];
@@ -603,72 +606,72 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
         localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
       }
     }
-  } else {
-    // Unpack
-    bool nvshmem_synced = false;
-    int memcpy_count = 0;
-    cudecompBatchedD2DMemcpy3DParams<T> memcpy_params;
-    for (int j = 0; j < splits_a.size(); ++j) {
-      int src_rank, dst_rank;
-      getAlltoallPeerRanks(grid_desc, comm_axis, j, src_rank, dst_rank);
-      if (j == 0) {
-        dst_rank = comm_rank;
-        src_rank = comm_rank;
-      }
+  //} else {
+  //  // Unpack
+  //  bool nvshmem_synced = false;
+  //  int memcpy_count = 0;
+  //  cudecompBatchedD2DMemcpy3DParams<T> memcpy_params;
+  //  for (int j = 0; j < splits_a.size(); ++j) {
+  //    int src_rank, dst_rank;
+  //    getAlltoallPeerRanks(grid_desc, comm_axis, j, src_rank, dst_rank);
+  //    if (j == 0) {
+  //      dst_rank = comm_rank;
+  //      src_rank = comm_rank;
+  //    }
 
-      std::vector<int> dst_ranks{dst_rank};
-      std::vector<int> src_ranks{src_rank};
+  //    std::vector<int> dst_ranks{dst_rank};
+  //    std::vector<int> src_ranks{src_rank};
 
-      if (j != 0 && comm_info.homogeneous && comm_info.nnodes != 1) {
-        // Perform pipelining in pairs to intra-node comms behind inter-node transfers
-        if (j % 2 == 1) {
-          if (j + 1 < splits_b.size()) {
-            int src_rank_next, dst_rank_next;
-            getAlltoallPeerRanks(grid_desc, comm_axis, j + 1, src_rank_next, dst_rank_next);
-            dst_ranks.push_back(dst_rank_next);
-            src_ranks.push_back(src_rank_next);
-          }
-        } else {
-          // Skip alltoall, this transfer was paired with previous one.
-          dst_ranks.resize(0);
-          src_ranks.resize(0);
-        }
-      }
+  //    if (j != 0 && comm_info.homogeneous && comm_info.nnodes != 1) {
+  //      // Perform pipelining in pairs to intra-node comms behind inter-node transfers
+  //      if (j % 2 == 1) {
+  //        if (j + 1 < splits_b.size()) {
+  //          int src_rank_next, dst_rank_next;
+  //          getAlltoallPeerRanks(grid_desc, comm_axis, j + 1, src_rank_next, dst_rank_next);
+  //          dst_ranks.push_back(dst_rank_next);
+  //          src_ranks.push_back(src_rank_next);
+  //        }
+  //      } else {
+  //        // Skip alltoall, this transfer was paired with previous one.
+  //        dst_ranks.resize(0);
+  //        src_ranks.resize(0);
+  //      }
+  //    }
 
-      if (o2 != o1) {
-        cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                  recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced);
-      }
+  //    if (o2 != o1) {
+  //      cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
+  //                                recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced);
+  //    }
 
-      if (o2 != o3) {
-        size_t shift = offsets_b[src_rank];
-        for (int i = 0; i < 3; ++i) {
-          if (pinfo_b_h.order[i] == ax_b) break;
-          shift *= shape_g_b_h[i];
-        }
+  //    if (o2 != o3) {
+  //      size_t shift = offsets_b[src_rank];
+  //      for (int i = 0; i < 3; ++i) {
+  //        if (pinfo_b_h.order[i] == ax_b) break;
+  //        shift *= shape_g_b_h[i];
+  //      }
 
-        T* src = o2 + recv_offsets[src_rank];
-        T* dest = o3 + shift + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
-        memcpy_params.src[memcpy_count] = src;
-        memcpy_params.dest[memcpy_count] = dest;
-        memcpy_params.src_strides[1][memcpy_count] = (ax_b == pinfo_b.order[0]) ? splits_b[src_rank] : pinfo_b.shape[0];
-        memcpy_params.src_strides[0][memcpy_count] =
-            memcpy_params.src_strides[1][memcpy_count] *
-            ((ax_b == pinfo_b.order[1]) ? splits_b[src_rank] : pinfo_b.shape[1]);
-        memcpy_params.dest_strides[0][memcpy_count] = pinfo_b_h.shape[0] * pinfo_b_h.shape[1];
-        memcpy_params.dest_strides[1][memcpy_count] = pinfo_b_h.shape[0];
-        memcpy_params.extents[2][memcpy_count] = (ax_b == pinfo_b.order[0]) ? splits_b[src_rank] : pinfo_b.shape[0];
-        memcpy_params.extents[1][memcpy_count] = (ax_b == pinfo_b.order[1]) ? splits_b[src_rank] : pinfo_b.shape[1];
-        memcpy_params.extents[0][memcpy_count] = (ax_b == pinfo_b.order[2]) ? splits_b[src_rank] : pinfo_b.shape[2];
-        memcpy_count++;
-        if (memcpy_count == memcpy_limit || j == splits_a.size() - 1) {
-          memcpy_params.ncopies = memcpy_count;
-          cudecomp_batched_d2d_memcpy_3d(memcpy_params, stream);
-          memcpy_count = 0;
-        }
-      }
-    }
-  }
+  //      T* src = o2 + recv_offsets[src_rank];
+  //      T* dest = o3 + shift + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
+  //      memcpy_params.src[memcpy_count] = src;
+  //      memcpy_params.dest[memcpy_count] = dest;
+  //      memcpy_params.src_strides[1][memcpy_count] = (ax_b == pinfo_b.order[0]) ? splits_b[src_rank] : pinfo_b.shape[0];
+  //      memcpy_params.src_strides[0][memcpy_count] =
+  //          memcpy_params.src_strides[1][memcpy_count] *
+  //          ((ax_b == pinfo_b.order[1]) ? splits_b[src_rank] : pinfo_b.shape[1]);
+  //      memcpy_params.dest_strides[0][memcpy_count] = pinfo_b_h.shape[0] * pinfo_b_h.shape[1];
+  //      memcpy_params.dest_strides[1][memcpy_count] = pinfo_b_h.shape[0];
+  //      memcpy_params.extents[2][memcpy_count] = (ax_b == pinfo_b.order[0]) ? splits_b[src_rank] : pinfo_b.shape[0];
+  //      memcpy_params.extents[1][memcpy_count] = (ax_b == pinfo_b.order[1]) ? splits_b[src_rank] : pinfo_b.shape[1];
+  //      memcpy_params.extents[0][memcpy_count] = (ax_b == pinfo_b.order[2]) ? splits_b[src_rank] : pinfo_b.shape[2];
+  //      memcpy_count++;
+  //      if (memcpy_count == memcpy_limit || j == splits_a.size() - 1) {
+  //        memcpy_params.ncopies = memcpy_count;
+  //        cudecomp_batched_d2d_memcpy_3d(memcpy_params, stream);
+  //        memcpy_count = 0;
+  //      }
+  //    }
+  //  }
+  //}
 }
 
 template <typename T>

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <iostream>
 #include <numeric>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -157,6 +158,25 @@ static void checkConfig(cudecompHandle_t handle, const cudecompGridDescConfig_t*
     if (config->pdims[0] != 0 || config->pdims[1] != 0) { THROW_INVALID_USAGE("pdims values are invalid"); }
   } else if (pdims_prod != handle->nranks) {
     THROW_INVALID_USAGE("product of pdims values must equal number of ranks");
+  }
+
+  bool mem_order_set = true;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      if (config->transpose_mem_order[i][j] < 0) mem_order_set = false;
+    }
+  }
+
+  if (mem_order_set) {
+    for (int i = 0; i < 3; ++i) {
+      std::set<int32_t> order_vals;
+      for (int j = 0; j < 3; ++j) {
+        order_vals.insert(config->transpose_mem_order[i][j]);
+      }
+      if (order_vals.size() != 3 || *order_vals.begin() != 0 || *order_vals.rbegin() != 2) {
+        THROW_INVALID_USAGE("transpose_mem_order setting is invalid");
+      }
+    }
   }
 }
 
@@ -329,6 +349,33 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
     grid_desc->config = *config;
     auto comm_backend = grid_desc->config.transpose_comm_backend;
     auto halo_comm_backend = grid_desc->config.halo_comm_backend;
+
+    // Check for transpose_mem_order settings (overrides transpose_axis_contiguous setting)
+    bool mem_order_set = true;
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        if (grid_desc->config.transpose_mem_order[i][j] < 0) mem_order_set = false;
+      }
+    }
+
+    // If transpose_mem_order not used, set based on transpose_axis_contiguous settings)
+    if (!mem_order_set) {
+      for (int axis = 0; axis < 3; ++axis) {
+        for (int i = 0; i < 3; ++i) {
+          if (grid_desc->config.transpose_axis_contiguous[axis]) {
+            grid_desc->config.transpose_mem_order[axis][i] = (axis + i) % 3;
+          } else {
+            grid_desc->config.transpose_mem_order[axis][i] = i;
+          }
+        }
+      }
+    }
+
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        printf("transpose_mem_order[%d][%d] = %d\n", i, j, grid_desc->config.transpose_mem_order[i][j]);
+      }
+    }
 
     grid_desc->config.transpose_axis_contiguous[0] = false; // For x-axis, always set to false.
 
@@ -541,7 +588,12 @@ cudecompResult_t cudecompGridDescConfigSetDefaults(cudecompGridDescConfig_t* con
 
     // Transpose Options
     config->transpose_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
-    for (int i = 0; i < 3; ++i) { config->transpose_axis_contiguous[i] = false; }
+    for (int i = 0; i < 3; ++i) {
+      config->transpose_axis_contiguous[i] = false;
+      for (int j = 0; j < 3; ++j) {
+        config->transpose_mem_order[i][j] = -1;
+      }
+    }
 
     // Halo Options
     config->halo_comm_backend = CUDECOMP_HALO_COMM_MPI;
@@ -603,11 +655,12 @@ cudecompResult_t cudecompGetPencilInfo(cudecompHandle_t handle, cudecompGridDesc
 
     // Setup order (and inverse)
     for (int i = 0; i < 3; ++i) {
-      if (grid_desc->config.transpose_axis_contiguous[axis]) {
-        pencil_info->order[i] = (axis + i) % 3;
-      } else {
-        pencil_info->order[i] = i;
-      }
+      //if (grid_desc->config.transpose_axis_contiguous[axis]) {
+      //  pencil_info->order[i] = (axis + i) % 3;
+      //} else {
+      //  pencil_info->order[i] = i;
+      //}
+      pencil_info->order[i] = grid_desc->config.transpose_mem_order[axis][i];
       invorder[pencil_info->order[i]] = i;
     }
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -368,12 +368,6 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
       }
     }
 
-    //for (int i = 0; i < 3; ++i) {
-    //  for (int j = 0; j < 3; ++j) {
-    //    printf("transpose_mem_order[%d][%d] = %d\n", i, j, grid_desc->config.transpose_mem_order[i][j]);
-    //  }
-    //}
-
     grid_desc->config.transpose_axis_contiguous[0] = false; // For x-axis, always set to false.
 
     if (grid_desc->config.gdims_dist[0] > grid_desc->config.gdims[0] ||
@@ -652,11 +646,6 @@ cudecompResult_t cudecompGetPencilInfo(cudecompHandle_t handle, cudecompGridDesc
 
     // Setup order (and inverse)
     for (int i = 0; i < 3; ++i) {
-      //if (grid_desc->config.transpose_axis_contiguous[axis]) {
-      //  pencil_info->order[i] = (axis + i) % 3;
-      //} else {
-      //  pencil_info->order[i] = i;
-      //}
       pencil_info->order[i] = grid_desc->config.transpose_mem_order[axis][i];
       invorder[pencil_info->order[i]] = i;
     }

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -371,11 +371,11 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
       }
     }
 
-    for (int i = 0; i < 3; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        printf("transpose_mem_order[%d][%d] = %d\n", i, j, grid_desc->config.transpose_mem_order[i][j]);
-      }
-    }
+    //for (int i = 0; i < 3; ++i) {
+    //  for (int j = 0; j < 3; ++j) {
+    //    printf("transpose_mem_order[%d][%d] = %d\n", i, j, grid_desc->config.transpose_mem_order[i][j]);
+    //  }
+    //}
 
     grid_desc->config.transpose_axis_contiguous[0] = false; // For x-axis, always set to false.
 

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -118,7 +118,7 @@ module cudecomp
     ! Transpose Options
     integer(c_int32_t) :: transpose_comm_backend
     logical(c_bool) :: transpose_axis_contiguous(3) ! flag (by axis) indicating whether pencil memory should be contiguous along pencil axis
-    integer(c_int32_t) :: transpose_mem_order(3,3) ! user specificed memory order by axis
+    integer(c_int32_t) :: transpose_mem_order(3,3) ! user-specified memory ordering by axis, overrides transpose_axis_contiguous setting
 
     ! Halo Options
     integer(c_int32_t) :: halo_comm_backend ! communication backend to use for halo communication

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -118,6 +118,7 @@ module cudecomp
     ! Transpose Options
     integer(c_int32_t) :: transpose_comm_backend
     logical(c_bool) :: transpose_axis_contiguous(3) ! flag (by axis) indicating whether pencil memory should be contiguous along pencil axis
+    integer(c_int32_t) :: transpose_mem_order(3,3) ! user specificed memory order by axis
 
     ! Halo Options
     integer(c_int32_t) :: halo_comm_backend ! communication backend to use for halo communication
@@ -573,6 +574,9 @@ contains
     type(cudecompGridDescAutotuneOptions), optional :: options
     integer(c_int) :: res
 
+    ! Adjust transpose mem order entries for zero-based indexing
+    config%transpose_mem_order = config%transpose_mem_order - 1
+
     if (present(options)) then
       ! Adjust halo axis entry for zero-based axis indexing
       options%halo_axis = options%halo_axis - 1
@@ -582,6 +586,9 @@ contains
     else
       res = cudecompGridDescCreateC_nullopt(handle, grid_desc, config, C_NULL_PTR)
     endif
+
+    ! Adjust transpose mem order entries for one-based indexing
+    config%transpose_mem_order = config%transpose_mem_order + 1
   end function cudecompGridDescCreate
 
   ! General functions

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -270,14 +270,14 @@ module cudecomp
   end interface
 
   interface
-    function cudecompGetGridDescConfig(handle, grid_desc, config) &
+    function cudecompGetGridDescConfigC(handle, grid_desc, config) &
       bind(C, name="cudecompGetGridDescConfig") result(res)
       import
       type(cudecompHandle), value :: handle
       type(cudecompGridDesc), value :: grid_desc
       type(cudecompGridDescConfig) :: config
       integer(c_int) :: res
-    end function cudecompGetGridDescConfig
+    end function cudecompGetGridDescConfigC
   end interface
 
   interface
@@ -611,6 +611,19 @@ contains
     pencil_info%lo = pencil_info%lo + 1
     pencil_info%hi = pencil_info%hi + 1
   end function cudecompGetPencilInfo
+
+  function cudecompGetGridDescConfig(handle, grid_desc, config) result(res)
+    type(cudecompHandle), value :: handle
+    type(cudecompGridDesc), value :: grid_desc
+    type(cudecompGridDescConfig) :: config
+    integer(c_int) :: res
+
+    res = cudecompGetGridDescConfigC(handle, grid_desc, config)
+
+    ! Adjust transpose mem order entries for one-based indexing
+    config%transpose_mem_order = config%transpose_mem_order + 1
+
+  end function cudecompGetGridDescConfig
 
   function cudecompGetHaloWorkspaceSize(handle, grid_desc, axis, halo_extents, workspace_size) result(res)
     implicit none

--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -198,6 +198,7 @@ program main
   integer :: gdims_dist(3)
   integer :: halo_extents(3)
   logical :: halo_periods(3)
+  integer :: mem_order(3, 3)
   logical :: use_managed_memory
   integer :: pr, pc
   integer :: axis
@@ -225,8 +226,8 @@ program main
   ARRTYPE, pointer, device:: input(:)
   integer :: dtype = DTYPE
 
-  integer :: i, j, k, idt, iarg
-  logical :: skip_next
+  integer :: i, j, k, l, idt, iarg
+  integer :: skip_count
   character(len=16) :: arg
 
   call MPI_Init(ierr)
@@ -251,10 +252,10 @@ program main
   axis = 1
   use_managed_memory = .false.
 
-  skip_next = .false.
+  skip_count = 0
   do i = 1, command_argument_count()
-    if (skip_next) then
-      skip_next = .false.
+    if (skip_count > 0) then
+      skip_count = skip_count - 1
       cycle
     end if
     call get_command_argument(i, arg)
@@ -262,89 +263,99 @@ program main
       case('--gx')
         call get_command_argument(i+1, arg)
         read(arg, *) gx
-        skip_next = .true.
+        skip_count = 1
       case('--gy')
         call get_command_argument(i+1, arg)
         read(arg, *) gy
-        skip_next = .true.
+        skip_count = 1
       case('--gz')
         call get_command_argument(i+1, arg)
         read(arg, *) gz
-        skip_next = .true.
+        skip_count = 1
       case('--backend')
         call get_command_argument(i+1, arg)
         read(arg, *) comm_backend
-        skip_next = .true.
+        skip_count = 1
       case('--pr')
         call get_command_argument(i+1, arg)
         read(arg, *) pr
-        skip_next = .true.
+        skip_count = 1
       case('--pc')
         call get_command_argument(i+1, arg)
         read(arg, *) pc
-        skip_next = .true.
+        skip_count = 1
       case('--acx')
         call get_command_argument(i+1, arg)
         read(arg, *) iarg
         axis_contiguous(1) = iarg
-        skip_next = .true.
+        skip_count = 1
       case('--acy')
         call get_command_argument(i+1, arg)
         read(arg, *) iarg
         axis_contiguous(2) = iarg
-        skip_next = .true.
+        skip_count = 1
       case('--acz')
         call get_command_argument(i+1, arg)
         read(arg, *) iarg
         axis_contiguous(3) = iarg
-        skip_next = .true.
+        skip_count = 1
       case('--gdx')
         call get_command_argument(i+1, arg)
         read(arg, *) gdims_dist(1)
-        skip_next = .true.
+        skip_count = 1
       case('--gdy')
         call get_command_argument(i+1, arg)
         read(arg, *) gdims_dist(2)
-        skip_next = .true.
+        skip_count = 1
       case('--gdz')
         call get_command_argument(i+1, arg)
         read(arg, *) gdims_dist(3)
-        skip_next = .true.
+        skip_count = 1
       case('--hex')
         call get_command_argument(i+1, arg)
         read(arg, *) halo_extents(1)
-        skip_next = .true.
+        skip_count = 1
       case('--hey')
         call get_command_argument(i+1, arg)
         read(arg, *) halo_extents(2)
-        skip_next = .true.
+        skip_count = 1
       case('--hez')
         call get_command_argument(i+1, arg)
         read(arg, *) halo_extents(3)
-        skip_next = .true.
+        skip_count = 1
       case('--hpx')
         call get_command_argument(i+1, arg)
         read(arg, *) iarg
         halo_periods(1) = iarg
-        skip_next = .true.
+        skip_count = 1
       case('--hpy')
         call get_command_argument(i+1, arg)
         read(arg, *) iarg
         halo_periods(2) = iarg
-        skip_next = .true.
+        skip_count = 1
       case('--hpz')
         call get_command_argument(i+1, arg)
         read(arg, *) iarg
         halo_periods(3) = iarg
-        skip_next = .true.
+        skip_count = 1
       case('--ax')
         call get_command_argument(i+1, arg)
         read(arg, *) axis
-        skip_next = .true.
+        skip_count = 1
+      case('--mem_order')
+        l = 1
+        do j = 1, 3
+          do k = 1, 3
+            call get_command_argument(i+l, arg)
+            read(arg, *) mem_order(k, j)
+            l = l + 1
+          enddo
+        enddo
+        skip_count = 9
       case('-m')
         use_managed_memory = .true.
       case(' ')
-        skip_next = .true.
+        skip_count = 1
       case default
         print*, "Unknown argument."
         call exit(1)
@@ -373,6 +384,7 @@ program main
   config%gdims = gdims
   config%gdims_dist = gdims_dist
   config%transpose_axis_contiguous = axis_contiguous
+  config%transpose_mem_order = mem_order
 
   CHECK_CUDECOMP_EXIT(cudecompGridDescAutotuneOptionsSetDefaults(options))
   options%halo_extents = halo_extents

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -36,6 +36,8 @@ transpose_test_base: &transpose_test_base
   out_of_place: [True, False]
   managed_memory : [True, False]
   run_autotuning : False
+  test_mem_order: False
+  fortran_indexing: False
 
 transpose_test_acfalse: &transpose_test_acfalse
   <<: *transpose_test_base
@@ -93,6 +95,16 @@ transpose_test_actrue_gdimdist: &transpose_test_actrue_gdimdist
   acy: [1]
   acz: [1]
 
+transpose_test_mem_order: &transpose_test_mem_order
+  <<: *transpose_test_base
+  backend: [1, 2] # Limit this testing to one normal and one pipelined backend
+  dtypes: ['C64'] # Limit to one data type
+  test_mem_order: true
+  args : ['backend',
+          'gx', 'gy', 'gz',
+          'gdx', 'gdy', 'gdz',
+          'hex' ,'hey', 'hez']
+
 transpose_test_acfalse_cc:
   <<: *transpose_test_acfalse
   executable_prefix: 'cc/transpose_test'
@@ -121,33 +133,49 @@ transpose_test_actrue_gdimdist_cc:
   <<: *transpose_test_actrue_gdimdist
   executable_prefix: 'cc/transpose_test'
 
+transpose_test_mem_order_cc:
+  <<: *transpose_test_mem_order
+  executable_prefix: 'cc/transpose_test'
+
 transpose_test_acfalse_fortran:
   <<: *transpose_test_acfalse
   executable_prefix: 'fortran/transpose_test'
+  fortran_indexing: true
 
 transpose_test_actrue_fortran:
   <<: *transpose_test_actrue
   executable_prefix: 'fortran/transpose_test'
+  fortran_indexing: true
 
 transpose_test_acmix_fortran:
   <<: *transpose_test_acmix
   executable_prefix: 'fortran/transpose_test'
+  fortran_indexing: true
 
 transpose_test_acfalse_halo_fortran:
   <<: *transpose_test_acfalse_halo
   executable_prefix: 'fortran/transpose_test'
+  fortran_indexing: true
 
 transpose_test_actrue_halo_fortran:
   <<: *transpose_test_actrue_halo
   executable_prefix: 'fortran/transpose_test'
+  fortran_indexing: true
 
 transpose_test_acfalse_gdimdist_fortran:
   <<: *transpose_test_acfalse_gdimdist
   executable_prefix: 'fortran/transpose_test'
+  fortran_indexing: true
 
 transpose_test_actrue_gdimdist_fortran:
   <<: *transpose_test_actrue_gdimdist
   executable_prefix: 'fortran/transpose_test'
+  fortran_indexing: true
+
+transpose_test_mem_order_fortran:
+  <<: *transpose_test_mem_order
+  executable_prefix: 'fortran/transpose_test'
+  fortran_indexing: true
 
 halo_test_base: &halo_test_base
   <<: *base
@@ -187,6 +215,8 @@ halo_test_base: &halo_test_base
   managed_memory : [True, False]
   out_of_place : [False]
   run_autotuning : False
+  test_mem_order: False
+  fortran_indexing: False
 
 halo_test_acfalse: &halo_test_acfalse
   <<: *halo_test_base
@@ -242,6 +272,18 @@ halo_test_actrue_gdimdist: &halo_test_actrue_gdimdist
   acy: [1]
   acz: [1]
 
+halo_test_mem_order: &halo_test_mem_order
+  <<: *halo_test_base
+  backend: [1] # Limit this testing to one backend
+  dtypes: ['C64'] # Limit to one data type
+  test_mem_order: true
+  args : ['backend',
+          'gx', 'gy', 'gz',
+          'gdx', 'gdy', 'gdz',
+          'hex' ,'hey', 'hez',
+          'hpx', 'hpy', 'hpz',
+          'ax']
+
 halo_test_acfalse_cc:
   <<: *halo_test_acfalse
   executable_prefix: 'cc/halo_test'
@@ -266,32 +308,47 @@ halo_test_actrue_gdimdist_cc:
   <<: *halo_test_actrue_gdimdist
   executable_prefix: 'cc/halo_test'
 
+halo_test_mem_order_cc:
+  <<: *halo_test_mem_order
+  executable_prefix: 'cc/halo_test'
+
 halo_test_acfalse_fortran:
   <<: *halo_test_acfalse
   ax: [1, 2, 3]
   executable_prefix: 'fortran/halo_test'
+  fortran_indexing: true
 
 halo_test_actrue_fortran:
   <<: *halo_test_actrue
   ax: [1, 2, 3]
   executable_prefix: 'fortran/halo_test'
+  fortran_indexing: true
 
 halo_test_acfalse_halomix_fortran:
   <<: *halo_test_acfalse_halomix
   ax: [1, 2, 3]
   executable_prefix: 'fortran/halo_test'
+  fortran_indexing: true
 
 halo_test_actrue_halomix_fortran:
   <<: *halo_test_actrue_halomix
   ax: [1, 2, 3]
   executable_prefix: 'fortran/halo_test'
+  fortran_indexing: true
 
 halo_test_acfalse_gdimdist_fortran:
   <<: *halo_test_acfalse_gdimdist
   ax: [1, 2, 3]
   executable_prefix: 'fortran/halo_test'
+  fortran_indexing: true
 
 halo_test_actrue_gdimdist_fortran:
   <<: *halo_test_actrue_gdimdist
   ax: [1, 2, 3]
   executable_prefix: 'fortran/halo_test'
+  fortran_indexing: true
+
+halo_test_mem_order_fortran:
+  <<: *halo_test_mem_order
+  executable_prefix: 'fortran/halo_test'
+  fortran_indexing: true

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -44,7 +44,20 @@ def should_skip_case(arg_dict):
 
   return skip
 
+def generate_mem_order_args(zero_indexed):
+   if zero_indexed:
+     orders_ax = [" ".join(x) for x in itertools.permutations(["0", "1", "2"])]
+   else:
+     orders_ax = [" ".join(x) for x in itertools.permutations(["1", "2", "3"])]
+   args = [" ".join(x) for x in itertools.product(orders_ax, orders_ax, orders_ax)]
+
+   return args
+
 def generate_command_lines(config, args):
+  if (config["test_mem_order"]):
+    config['args'].append("mem_order")
+    config['mem_order'] = generate_mem_order_args(not config["fortran_indexing"])
+
   generic_cmd = f"{args.launcher_cmd}"
   generic_cmd += " {0}"
 
@@ -80,6 +93,7 @@ def generate_command_lines(config, args):
         extra_flags.append(['-o' if x else '' for x in config['out_of_place']])
         for extras in itertools.product(*extra_flags):
           cmds.append(f"{cmd} {' '.join(filter(lambda x: x != '', extras))}")
+
 
   return cmds
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -49,7 +49,7 @@ def generate_mem_order_args(zero_indexed):
      orders_ax = [" ".join(x) for x in itertools.permutations(["0", "1", "2"])]
    else:
      orders_ax = [" ".join(x) for x in itertools.permutations(["1", "2", "3"])]
-   args = [" ".join(x) for x in itertools.product(orders_ax, orders_ax, orders_ax)]
+   args = [" ".join([x, y, x]) for x, y in itertools.product(orders_ax, orders_ax)]
 
    return args
 


### PR DESCRIPTION
In cuDecomp, users currently have only two options for memory layout orders for their pencil data buffers:
1. `[X, Y, Z]` corresponding to `transpose_axis_contiguous[axis] = false`
2.  a prescribed cyclically-permuted layout such that the memory is contiguous along the pencil axis when `transpose_axis_contiguous[axis] = true` (e.g., `[Y, Z, X]` for the Y-axis pencil). 

This can limit the ease of application of cuDecomp to codes that have established their own memory orderings that do not match what is currently available.

This PR enables users to more flexibly set their own desired pencil buffer memory layouts by pencil axis via a new `transpose_mem_order` entry in the `cudecompGridDescConfig` structure. This new entry overrides the setting from `transpose_axis_contiguous`. 

From the updated documentation:
Advanced users who require more flexibility in the memory layout of the pencil buffers can override the layouts available via
`transpose_axis_contiguous` by setting the`transpose_mem_order` array in the configuration structure. This array enables
users to set arbitrary memory layout orders for the pencil buffers by axis. For example, a user can set this structure as follows to have pencil memory in `[X, Y, Z]` order for the X-pencil and `[Z, Y, X]` order for the Y- and Z-pencils:

In C++:
```

    config.transpose_mem_order[0][0] = 0;
    config.transpose_mem_order[0][1] = 1;
    config.transpose_mem_order[0][2] = 2;
    config.transpose_mem_order[1][0] = 2;
    config.transpose_mem_order[1][1] = 1;
    config.transpose_mem_order[1][2] = 0;
    config.transpose_mem_order[2][0] = 2;
    config.transpose_mem_order[2][1] = 1;
    config.transpose_mem_order[2][2] = 0;

```

In Fortran:
```
    config%transpose_mem_order(1, 1) = 1
    config%transpose_mem_order(2, 1) = 2
    config%transpose_mem_order(3, 1) = 3
    config%transpose_mem_order(1, 2) = 3
    config%transpose_mem_order(2, 2) = 2
    config%transpose_mem_order(3, 2) = 1
    config%transpose_mem_order(1, 3) = 3
    config%transpose_mem_order(2, 3) = 2
    config%transpose_mem_order(3, 3) = 1
```