### PR TITLE
Add opt-in support for fabric-registered workspace allocations via cuMem* APIs. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,8 +207,9 @@ if (CUDECOMP_ENABLE_NVSHMEM)
     target_link_libraries(cudecomp PRIVATE ${NVSHMEM_LIBRARY_DIR}/libnvshmem_device.a)
     target_link_libraries(cudecomp PUBLIC -L${NVHPC_CUDA_LIBRARY_DIR}/stubs -lnvidia-ml)
   endif()
-  target_link_libraries(cudecomp PUBLIC -L${NVHPC_CUDA_LIBRARY_DIR}/stubs -lcuda)
 endif()
+
+target_link_libraries(cudecomp PUBLIC -L${NVHPC_CUDA_LIBRARY_DIR}/stubs -lcuda)
 
 set_target_properties(cudecomp PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp.h)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp.h ${CMAKE_BINARY_DIR}/include/cudecomp.h)

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -15,3 +15,11 @@ section of the NCCL documentation for more details.
 
 Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.
 
+CUDECOMP_ENABLE_CUMEM
+------------------------
+(since v0.5.0, requires CUDA 12.3 driver/toolkit or newer)
+
+:code:`CUDECOMP_ENABLE_CUMEM` controls whether cuDecomp uses :code:`cuMem*` APIs to allocate fabric-registered workspace buffers via :code:`cudecompMalloc`. This option can improve the performance of
+some MPI distributions on multi-node NVLink (MNNVL) capable systems.
+
+Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.

--- a/include/internal/checks.h
+++ b/include/internal/checks.h
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <string>
 
+#include <cuda.h>
 #include <cuda_runtime.h>
 #include <cufft.h>
 #include <cutensor.h>
@@ -59,6 +60,15 @@
   do {                                                                                                                 \
     cudaError_t err = call;                                                                                            \
     if (cudaSuccess != err) { throw cudecomp::CudaError(__FILE__, __LINE__, cudaGetErrorString(err)); }                \
+  } while (false)
+
+#define CHECK_CUDA_DRV(call)                                                                                           \
+  do {                                                                                                                 \
+    CUresult err = call;                                                                                               \
+    if (CUDA_SUCCESS != err) {                                                                                         \
+      const char* error_str;                                                                                           \
+      cuGetErrorString(err, &error_str);                                                                               \
+      throw cudecomp::CudaError(__FILE__, __LINE__, error_str); }                                                      \
   } while (false)
 
 #define CHECK_CUDA_LAUNCH()                                                                                            \

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -84,6 +84,8 @@ struct cudecompHandle {
   bool nvshmem_vmm;                                      // Flag to track if NVSHMEM is using VMM allocations
   std::unordered_map<void*, size_t> nvshmem_allocations; // Table to record NVSHMEM allocations
   size_t nvshmem_allocation_size = 0;                    // Total of NVSHMEM allocations
+
+  bool cuda_cumem_enable = false; // Flag to control whether cuMem* APIs are used for cudecompMalloc/Free
 };
 
 // Structure with information about row/column communicator

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -200,14 +200,10 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       if (need_nvshmem) {
 #ifdef ENABLE_NVSHMEM
         if (work && work != work_nvshmem) {
-          CHECK_CUDA(cudaFree(work));
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-          if (nccl_work_ubr_handles[0]) {
-            CHECK_NCCL(ncclCommDeregister(handle->nccl_comm, nccl_work_ubr_handles[0]));
-            CHECK_NCCL(ncclCommDeregister(handle->nccl_local_comm, nccl_work_ubr_handles[1]));
-            nccl_work_ubr_handles = {nullptr, nullptr};
-          }
-#endif
+          auto tmp = grid_desc->config.transpose_comm_backend;
+          grid_desc->config.transpose_comm_backend = (need_nccl) ? CUDECOMP_TRANSPOSE_COMM_NCCL : CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
+          CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
+          grid_desc->config.transpose_comm_backend = tmp;
         }
         // Temporarily set backend to force nvshmem_malloc patch in cudecompMalloc/Free
         auto tmp = grid_desc->config.transpose_comm_backend;
@@ -216,6 +212,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
         CHECK_CUDECOMP(cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work_nvshmem), work_sz));
         grid_desc->config.transpose_comm_backend = tmp;
 
+        // Check if there is enough memory for separate non-NVSHMEM allocated work buffer
         auto ret = cudaMalloc(&work, work_sz);
         if (ret == cudaErrorMemoryAllocation) {
           if (handle->rank == 0) {
@@ -226,33 +223,21 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
           work = work_nvshmem;
           cudaGetLastError(); // Reset CUDA error state
         } else {
-          CHECK_CUDA(ret);
-          if (need_nccl && handle->nccl_enable_ubr) {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-            CHECK_NCCL(ncclCommRegister(handle->nccl_comm, work, work_sz, &nccl_work_ubr_handles[0]));
-            CHECK_NCCL(ncclCommRegister(handle->nccl_local_comm, work, work_sz, &nccl_work_ubr_handles[1]));
-#endif
-          }
+          CHECK_CUDA(cudaFree(work));
+          auto tmp = grid_desc->config.transpose_comm_backend;
+          grid_desc->config.transpose_comm_backend = (need_nccl) ? CUDECOMP_TRANSPOSE_COMM_NCCL : CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
+          cudecompResult_t ret = cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work), work_sz);
+          grid_desc->config.transpose_comm_backend = tmp;
         }
 #endif
       } else {
+        auto tmp = grid_desc->config.transpose_comm_backend;
+        grid_desc->config.transpose_comm_backend = (need_nccl) ? CUDECOMP_TRANSPOSE_COMM_NCCL : CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
         if (work) {
-          CHECK_CUDA(cudaFree(work));
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-          if (nccl_work_ubr_handles[0]) {
-            CHECK_NCCL(ncclCommDeregister(handle->nccl_comm, nccl_work_ubr_handles[0]));
-            CHECK_NCCL(ncclCommDeregister(handle->nccl_local_comm, nccl_work_ubr_handles[1]));
-            nccl_work_ubr_handles = {nullptr, nullptr};
-          }
-#endif
+          CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
         }
-        CHECK_CUDA(cudaMalloc(&work, work_sz));
-        if (need_nccl && handle->nccl_enable_ubr) {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-          CHECK_NCCL(ncclCommRegister(handle->nccl_comm, work, work_sz, &nccl_work_ubr_handles[0]));
-          CHECK_NCCL(ncclCommRegister(handle->nccl_local_comm, work, work_sz, &nccl_work_ubr_handles[1]));
-#endif
-        }
+        CHECK_CUDECOMP(cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work), work_sz));
+        grid_desc->config.transpose_comm_backend = tmp;
       }
     }
 
@@ -439,14 +424,10 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
   // Free test data and workspace
   if (need_nvshmem) {
     if (work != work_nvshmem) {
-      CHECK_CUDA(cudaFree(work));
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-      if (nccl_work_ubr_handles[0]) {
-        CHECK_NCCL(ncclCommDeregister(handle->nccl_comm, nccl_work_ubr_handles[0]));
-        CHECK_NCCL(ncclCommDeregister(handle->nccl_local_comm, nccl_work_ubr_handles[1]));
-        nccl_work_ubr_handles = {nullptr, nullptr};
-      }
-#endif
+      auto tmp = grid_desc->config.transpose_comm_backend;
+      grid_desc->config.transpose_comm_backend = (need_nccl) ? CUDECOMP_TRANSPOSE_COMM_NCCL : CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
+      CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
+      grid_desc->config.transpose_comm_backend = tmp;
     }
 #ifdef ENABLE_NVSHMEM
     // Temporarily set backend to force nvshmem_malloc patch in cudecompMalloc/Free
@@ -456,14 +437,10 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
     grid_desc->config.transpose_comm_backend = tmp;
 #endif
   } else {
-    CHECK_CUDA(cudaFree(work));
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-    if (nccl_work_ubr_handles[0]) {
-      CHECK_NCCL(ncclCommDeregister(handle->nccl_comm, nccl_work_ubr_handles[0]));
-      CHECK_NCCL(ncclCommDeregister(handle->nccl_local_comm, nccl_work_ubr_handles[1]));
-      nccl_work_ubr_handles = {nullptr, nullptr};
-    }
-#endif
+    auto tmp = grid_desc->config.transpose_comm_backend;
+    grid_desc->config.transpose_comm_backend = (need_nccl) ? CUDECOMP_TRANSPOSE_COMM_NCCL : CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
+    CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
+    grid_desc->config.transpose_comm_backend = tmp;
   }
 
   CHECK_CUDA(cudaFree(data));
@@ -602,14 +579,10 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       if (need_nvshmem) {
 #ifdef ENABLE_NVSHMEM
         if (work && work != work_nvshmem) {
-          CHECK_CUDA(cudaFree(work));
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-          if (nccl_work_ubr_handles[0]) {
-            CHECK_NCCL(ncclCommDeregister(handle->nccl_comm, nccl_work_ubr_handles[0]));
-            CHECK_NCCL(ncclCommDeregister(handle->nccl_local_comm, nccl_work_ubr_handles[1]));
-            nccl_work_ubr_handles = {nullptr, nullptr};
-          }
-#endif
+          auto tmp = grid_desc->config.halo_comm_backend;
+          grid_desc->config.halo_comm_backend = (need_nccl) ? CUDECOMP_HALO_COMM_NCCL : CUDECOMP_HALO_COMM_MPI;
+          CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
+          grid_desc->config.halo_comm_backend = tmp;
         }
         // Temporarily set backend to force nvshmem_malloc patch in cudecompMalloc/Free
         auto tmp = grid_desc->config.halo_comm_backend;
@@ -618,6 +591,7 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
         CHECK_CUDECOMP(cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work_nvshmem), work_sz));
         grid_desc->config.halo_comm_backend = tmp;
 
+        // Check if there is enough memory for separate non-NVSHMEM allocated work buffer
         auto ret = cudaMalloc(&work, work_sz);
         if (ret == cudaErrorMemoryAllocation) {
           if (handle->rank == 0) {
@@ -628,33 +602,21 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
           work = work_nvshmem;
           cudaGetLastError(); // Reset CUDA error state
         } else {
-          CHECK_CUDA(ret);
-          if (need_nccl && handle->nccl_enable_ubr) {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-            CHECK_NCCL(ncclCommRegister(handle->nccl_comm, work, work_sz, &nccl_work_ubr_handles[0]));
-            CHECK_NCCL(ncclCommRegister(handle->nccl_local_comm, work, work_sz, &nccl_work_ubr_handles[1]));
-#endif
-          }
+          CHECK_CUDA(cudaFree(work));
+          auto tmp = grid_desc->config.halo_comm_backend;
+          grid_desc->config.halo_comm_backend = (need_nccl) ? CUDECOMP_HALO_COMM_NCCL : CUDECOMP_HALO_COMM_MPI;
+          cudecompResult_t ret = cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work), work_sz);
+          grid_desc->config.halo_comm_backend = tmp;
         }
 #endif
       } else {
+        auto tmp = grid_desc->config.halo_comm_backend;
+        grid_desc->config.halo_comm_backend = (need_nccl) ? CUDECOMP_HALO_COMM_NCCL : CUDECOMP_HALO_COMM_MPI;
         if (work) {
-          CHECK_CUDA(cudaFree(work));
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-          if (nccl_work_ubr_handles[0]) {
-            CHECK_NCCL(ncclCommDeregister(handle->nccl_comm, nccl_work_ubr_handles[0]));
-            CHECK_NCCL(ncclCommDeregister(handle->nccl_local_comm, nccl_work_ubr_handles[1]));
-            nccl_work_ubr_handles = {nullptr, nullptr};
-          }
-#endif
+          CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
         }
-        CHECK_CUDA(cudaMalloc(&work, work_sz));
-        if (need_nccl && handle->nccl_enable_ubr) {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-          CHECK_NCCL(ncclCommRegister(handle->nccl_comm, work, work_sz, &nccl_work_ubr_handles[0]));
-          CHECK_NCCL(ncclCommRegister(handle->nccl_local_comm, work, work_sz, &nccl_work_ubr_handles[1]));
-#endif
-        }
+        CHECK_CUDECOMP(cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work), work_sz));
+        grid_desc->config.halo_comm_backend = tmp;
       }
     }
 
@@ -788,14 +750,10 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
   // Free test data and workspace
   if (need_nvshmem) {
     if (work != work_nvshmem) {
-      CHECK_CUDA(cudaFree(work));
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-      if (nccl_work_ubr_handles[0]) {
-        CHECK_NCCL(ncclCommDeregister(handle->nccl_comm, nccl_work_ubr_handles[0]));
-        CHECK_NCCL(ncclCommDeregister(handle->nccl_local_comm, nccl_work_ubr_handles[1]));
-        nccl_work_ubr_handles = {nullptr, nullptr};
-      }
-#endif
+      auto tmp = grid_desc->config.halo_comm_backend;
+      grid_desc->config.halo_comm_backend = (need_nccl) ? CUDECOMP_HALO_COMM_NCCL : CUDECOMP_HALO_COMM_MPI;
+      CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
+      grid_desc->config.halo_comm_backend = tmp;
     }
 #ifdef ENABLE_NVSHMEM
     // Temporarily set backend to force nvshmem_malloc patch in cudecompMalloc/Free
@@ -805,14 +763,10 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
     grid_desc->config.halo_comm_backend = tmp;
 #endif
   } else {
-    CHECK_CUDA(cudaFree(work));
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-    if (nccl_work_ubr_handles[0]) {
-      CHECK_NCCL(ncclCommDeregister(handle->nccl_comm, nccl_work_ubr_handles[0]));
-      CHECK_NCCL(ncclCommDeregister(handle->nccl_local_comm, nccl_work_ubr_handles[1]));
-      nccl_work_ubr_handles = {nullptr, nullptr};
-    }
-#endif
+    auto tmp = grid_desc->config.halo_comm_backend;
+    grid_desc->config.halo_comm_backend = (need_nccl) ? CUDECOMP_HALO_COMM_NCCL : CUDECOMP_HALO_COMM_MPI;
+    CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
+    grid_desc->config.halo_comm_backend = tmp;
   }
 
   CHECK_CUDA(cudaFree(data));

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -100,9 +100,6 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
 
   std::vector<cudecompTransposeCommBackend_t> comm_backend_list;
   bool need_nccl = false;
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-  std::array<void*, 2> nccl_work_ubr_handles{nullptr, nullptr};
-#endif
   bool need_nvshmem = false;
   if (autotune_comm) {
     comm_backend_list = {CUDECOMP_TRANSPOSE_COMM_MPI_P2P, CUDECOMP_TRANSPOSE_COMM_MPI_P2P_PL,
@@ -492,9 +489,6 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
 
   std::vector<cudecompHaloCommBackend_t> comm_backend_list;
   bool need_nccl = false;
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-  std::array<void*, 2> nccl_work_ubr_handles{nullptr, nullptr};
-#endif
   bool need_nvshmem = false;
   if (autotune_comm) {
     comm_backend_list = {CUDECOMP_HALO_COMM_MPI, CUDECOMP_HALO_COMM_MPI_BLOCKING};

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -205,7 +205,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
           CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
           grid_desc->config.transpose_comm_backend = tmp;
         }
-        // Temporarily set backend to force nvshmem_malloc patch in cudecompMalloc/Free
+        // Temporarily set backend to force nvshmem_malloc path in cudecompMalloc/Free
         auto tmp = grid_desc->config.transpose_comm_backend;
         grid_desc->config.transpose_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM;
         if (work_nvshmem) CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work_nvshmem));
@@ -430,7 +430,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       grid_desc->config.transpose_comm_backend = tmp;
     }
 #ifdef ENABLE_NVSHMEM
-    // Temporarily set backend to force nvshmem_malloc patch in cudecompMalloc/Free
+    // Temporarily set backend to force nvshmem_malloc path in cudecompMalloc/Free
     auto tmp = grid_desc->config.transpose_comm_backend;
     grid_desc->config.transpose_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM;
     CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work_nvshmem));
@@ -584,7 +584,7 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
           CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work));
           grid_desc->config.halo_comm_backend = tmp;
         }
-        // Temporarily set backend to force nvshmem_malloc patch in cudecompMalloc/Free
+        // Temporarily set backend to force nvshmem_malloc path in cudecompMalloc/Free
         auto tmp = grid_desc->config.halo_comm_backend;
         grid_desc->config.halo_comm_backend = CUDECOMP_HALO_COMM_NVSHMEM;
         if (work_nvshmem) CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work_nvshmem));
@@ -756,7 +756,7 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       grid_desc->config.halo_comm_backend = tmp;
     }
 #ifdef ENABLE_NVSHMEM
-    // Temporarily set backend to force nvshmem_malloc patch in cudecompMalloc/Free
+    // Temporarily set backend to force nvshmem_malloc path in cudecompMalloc/Free
     auto tmp = grid_desc->config.halo_comm_backend;
     grid_desc->config.halo_comm_backend = CUDECOMP_HALO_COMM_NVSHMEM;
     CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work_nvshmem));

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -828,7 +828,6 @@ cudecompResult_t cudecompMalloc(cudecompHandle_t handle, cudecompGridDesc_t grid
         // Check for RDMA support
         int flag;
         CHECK_CUDA_DRV(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED, cu_dev));
-        printf("flag %d\n", flag);
         if (flag) prop.allocFlags.gpuDirectRDMACapable = 1;
 
         // Align allocation size to required granularity


### PR DESCRIPTION
This PR adds opt-in support for fabric-registered workspace allocations via `cuMem*` APIs. This type of workspace buffer allocation improves the performance of some MPI implementations when operating on multi-node NVLink (MNNVL) systems. Support for buffers allocated via this path varies across MPI implementations and can have detrimental performance on non-MNNVL equipped systems. As such, it is not enabled by default.

To use this feature, users can set a new environment variable option `CUDECOMP_ENABLE_CUMEM=1`. 