### PR TITLE
Dynamically load CUDA driver functions at runtime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ target_compile_options(cudecomp PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ptxas-optio
 target_sources(cudecomp
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/autotune.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/cuda_wrap.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels_rdc.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp.cc
@@ -195,21 +196,22 @@ if (CUDECOMP_ENABLE_NVSHMEM)
   list(APPEND NVSHMEM_VERSION ${CMAKE_MATCH_1})
   list(JOIN NVSHMEM_VERSION "." NVSHMEM_VERSION)
 
-  if (NVSHMEM_VERSION VERSION_LESS "2.7")
-    # NVSHMEM versions before 2.7 will  export NCCL symbols erroneously, need to define this flag
-    target_compile_definitions(cudecomp PRIVATE NVSHMEM_USE_NCCL)
-  endif()
-
   if (NVSHMEM_VERSION VERSION_LESS "2.5")
     target_link_libraries(cudecomp PRIVATE ${NVSHMEM_LIBRARY_DIR}/libnvshmem.a)
   else()
     target_link_libraries(cudecomp PRIVATE ${NVSHMEM_LIBRARY_DIR}/libnvshmem_host.so)
     target_link_libraries(cudecomp PRIVATE ${NVSHMEM_LIBRARY_DIR}/libnvshmem_device.a)
+  endif()
+
+  if (NVSHMEM_VERSION VERSION_LESS "2.7")
+    # NVSHMEM versions before 2.7 will export NCCL symbols erroneously, need to define this flag
+    target_compile_definitions(cudecomp PRIVATE NVSHMEM_USE_NCCL)
+  endif()
+
+  if (NVSHMEM_VERSION VERSION_LESS "2.11")
     target_link_libraries(cudecomp PUBLIC -L${NVHPC_CUDA_LIBRARY_DIR}/stubs -lnvidia-ml)
   endif()
 endif()
-
-target_link_libraries(cudecomp PUBLIC -L${NVHPC_CUDA_LIBRARY_DIR}/stubs -lcuda)
 
 set_target_properties(cudecomp PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp.h)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp.h ${CMAKE_BINARY_DIR}/include/cudecomp.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ if (CUDECOMP_ENABLE_NVSHMEM)
   if (NVSHMEM_VERSION VERSION_LESS "2.7")
     # NVSHMEM versions before 2.7 will export NCCL symbols erroneously, need to define this flag
     target_compile_definitions(cudecomp PRIVATE NVSHMEM_USE_NCCL)
+    target_link_libraries(cudecomp PUBLIC -L${NVHPC_CUDA_LIBRARY_DIR}/stubs -lcuda)
   endif()
 
   if (NVSHMEM_VERSION VERSION_LESS "2.11")

--- a/include/internal/checks.h
+++ b/include/internal/checks.h
@@ -64,10 +64,10 @@
 
 #define CHECK_CUDA_DRV(call)                                                                                           \
   do {                                                                                                                 \
-    CUresult err = call;                                                                                               \
+    CUresult err = cuFnTable.pfn_##call;                                                                               \
     if (CUDA_SUCCESS != err) {                                                                                         \
       const char* error_str;                                                                                           \
-      cuGetErrorString(err, &error_str);                                                                               \
+      cuFnTable.pfn_cuGetErrorString(err, &error_str);                                                                 \
       throw cudecomp::CudaError(__FILE__, __LINE__, error_str); }                                                      \
   } while (false)
 

--- a/include/internal/cuda_wrap.h
+++ b/include/internal/cuda_wrap.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CUDECOMP_CUDA_WRAP_H
+#define CUDECOMP_CUDA_WRAP_H
+
+#if CUDART_VERSION >= 11030
+#include <cudaTypedefs.h>
+#endif
+
+namespace cudecomp {
+
+struct cuFunctionTable {
+#if CUDART_VERSION >= 11030
+  PFN_cuDeviceGet pfn_cuDeviceGet = nullptr;
+  PFN_cuDeviceGetAttribute pfn_cuDeviceGetAttribute = nullptr;
+  PFN_cuGetErrorString pfn_cuGetErrorString = nullptr;
+  PFN_cuMemAddressFree pfn_cuMemAddressFree = nullptr;
+  PFN_cuMemAddressReserve pfn_cuMemAddressReserve = nullptr;
+  PFN_cuMemCreate pfn_cuMemCreate = nullptr;
+  PFN_cuMemGetAddressRange pfn_cuMemGetAddressRange = nullptr;
+  PFN_cuMemGetAllocationGranularity pfn_cuMemGetAllocationGranularity = nullptr;
+  PFN_cuMemMap pfn_cuMemMap = nullptr;
+  PFN_cuMemRetainAllocationHandle pfn_cuMemRetainAllocationHandle = nullptr;
+  PFN_cuMemRelease pfn_cuMemRelease = nullptr;
+  PFN_cuMemSetAccess pfn_cuMemSetAccess = nullptr;
+  PFN_cuMemUnmap pfn_cuMemUnmap = nullptr;
+#endif
+};
+
+extern cuFunctionTable cuFnTable;
+
+void initCuFunctionTable();
+
+} // namespace cudecomp
+
+#endif // CUDECOMP_CUDA_WRAP_H

--- a/src/cuda_wrap.cc
+++ b/src/cuda_wrap.cc
@@ -44,7 +44,7 @@
     }                                                                                                                    \
   } while(false)
 #else
-#define LOAD_SYM(symbol, table)                                                                                          \
+#define LOAD_SYM(symbol)                                                                                                 \
   do {                                                                                                                   \
     CHECK_CUDA(cudaGetDriverEntryPoint(#symbol, (void **) (&cuFnTable.pfn_##symbol), cudaEnableDefault));                \
   } while(false)

--- a/src/cuda_wrap.cc
+++ b/src/cuda_wrap.cc
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cuda_runtime.h>
+
+#include "internal/checks.h"
+#include "internal/cuda_wrap.h"
+#include "internal/exceptions.h"
+
+#if CUDART_VERSION >= 12000
+#define LOAD_SYM(symbol)                                                                                                 \
+  do {                                                                                                                   \
+    cudaDriverEntryPointQueryResult driverStatus = cudaDriverEntryPointSymbolNotFound;                                   \
+    CHECK_CUDA(cudaGetDriverEntryPoint(#symbol, (void **) (&cuFnTable.pfn_##symbol), cudaEnableDefault, &driverStatus)); \
+    if (driverStatus != cudaDriverEntryPointSuccess) {                                                                   \
+      THROW_CUDA_ERROR("cudaGetDriverEntryPoint failed.");                                                               \
+    }                                                                                                                    \
+  } while(false)
+#else
+#define LOAD_SYM(symbol, table)                                                                                          \
+  do {                                                                                                                   \
+    CHECK_CUDA(cudaGetDriverEntryPoint(#symbol, (void **) (&cuFnTable.pfn_##symbol), cudaEnableDefault));                \
+  } while(false)
+#endif
+
+namespace cudecomp {
+
+cuFunctionTable cuFnTable; // global table of required CUDA driver functions
+
+void initCuFunctionTable() {
+#if CUDART_VERSION >= 11030
+  LOAD_SYM(cuDeviceGet);
+  LOAD_SYM(cuDeviceGetAttribute);
+  LOAD_SYM(cuGetErrorString);
+  LOAD_SYM(cuMemAddressFree);
+  LOAD_SYM(cuMemAddressReserve);
+  LOAD_SYM(cuMemCreate);
+  LOAD_SYM(cuMemGetAddressRange);
+  LOAD_SYM(cuMemGetAllocationGranularity);
+  LOAD_SYM(cuMemMap);
+  LOAD_SYM(cuMemRetainAllocationHandle);
+  LOAD_SYM(cuMemRelease);
+  LOAD_SYM(cuMemSetAccess);
+  LOAD_SYM(cuMemUnmap);
+#endif
+}
+
+} // namespace cudecomp
+
+#undef LOAD_SYM


### PR DESCRIPTION
This is a follow up PR to #50, which introduced the usage of CUDA driver functions within cuDecomp. That PR introduced a shared library link against `libcuda.so`, which can cause issues for some users when building on systems without NVIDIA GPUs/drivers installed. Also, as implemented, it requires downstream user applications using cuDecomp to also add a link against `-lcuda`, which is not ideal.

This PR loads any CUDA driver symbols dynamically at runtime, which alleviates the need for a compile time link to `libcuda`. This is the standard practice in many other libraries, include NCCL and NVSHMEM.