### PR TITLE
Extend transpose shortcut handling to cases with halos.

### DIFF
--- a/tests/cc/transpose_test.cc
+++ b/tests/cc/transpose_test.cc
@@ -143,11 +143,11 @@ static void usage(const char* pname) {
           "\t--gdz\n"
           "\t\tZ-dimension gdim_dist setting, set to gz - gdz. (default: 0) \n"
           "\t--hex\n"
-          "\t\tX-dimension halo_extents setting. (default: 0) \n"
+          "\t\tX-pencil halo_extents setting. (default: 0 0 0) \n"
           "\t--hey\n"
-          "\t\tY-dimension halo_extents setting. (default: 0) \n"
+          "\t\tY-pencil halo_extents setting. (default: 0 0 0) \n"
           "\t--hez\n"
-          "\t\tZ-dimension halo_extents setting. (default: 0) \n"
+          "\t\tZ-pencil halo_extents setting. (default: 0 0 0) \n"
           "\t--mem_order\n"
           "\t\ttranspose_mem_order setting. (default: unset) \n"
           "\t-m|--use-managed-memory\n"
@@ -179,7 +179,9 @@ int main(int argc, char** argv) {
   cudecompTransposeCommBackend_t comm_backend = static_cast<cudecompTransposeCommBackend_t>(0);
   std::array<bool, 3> axis_contiguous{};
   std::array<int, 3> gdims_dist{};
-  std::array<int, 3> halo_extents{};
+  std::array<int, 3> halo_extents_x{};
+  std::array<int, 3> halo_extents_y{};
+  std::array<int, 3> halo_extents_z{};
   bool out_of_place = false;
   bool use_managed_memory = false;
   std::array<int, 9> mem_order{-1, -1, -1, -1, -1, -1, -1, -1, -1};
@@ -224,9 +226,27 @@ int main(int argc, char** argv) {
     case '4': gdims_dist[0] = atoi(optarg); break;
     case '5': gdims_dist[1] = atoi(optarg); break;
     case '6': gdims_dist[2] = atoi(optarg); break;
-    case '7': halo_extents[0] = atoi(optarg); break;
-    case '8': halo_extents[1] = atoi(optarg); break;
-    case '9': halo_extents[2] = atoi(optarg); break;
+    case '7':
+      optind--;
+      for (int i = 0; i < 3; ++i) {
+        halo_extents_x[i] = atoi(argv[optind]);
+        optind++;
+      }
+      break;
+    case '8':
+      optind--;
+      for (int i = 0; i < 3; ++i) {
+        halo_extents_y[i] = atoi(argv[optind]);
+        optind++;
+      }
+      break;
+    case '9':
+      optind--;
+      for (int i = 0; i < 3; ++i) {
+        halo_extents_z[i] = atoi(argv[optind]);
+        optind++;
+      }
+      break;
     case 'o': out_of_place = true; break;
     case 'm': use_managed_memory = true; break;
     case 'q':
@@ -300,15 +320,15 @@ int main(int argc, char** argv) {
 
   // Get x-pencil information
   cudecompPencilInfo_t pinfo_x;
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, &pinfo_x, 0, halo_extents.data()));
+  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, &pinfo_x, 0, halo_extents_x.data()));
 
   // Get y-pencil information
   cudecompPencilInfo_t pinfo_y;
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, &pinfo_y, 1, halo_extents.data()));
+  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, &pinfo_y, 1, halo_extents_y.data()));
 
   // Get z-pencil information
   cudecompPencilInfo_t pinfo_z;
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, &pinfo_z, 2, halo_extents.data()));
+  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, &pinfo_z, 2, halo_extents_z.data()));
 
   // Get workspace size
   int64_t workspace_num_elements;

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -145,7 +145,7 @@ program main
   integer :: comm_backend
   logical :: axis_contiguous(3)
   integer :: gdims_dist(3)
-  integer :: halo_extents(3)
+  integer :: halo_extents_x(3), halo_extents_y(3), halo_extents_z(3)
   integer :: mem_order(3, 3)
   logical :: out_of_place, use_managed_memory
   integer :: pr, pc
@@ -194,7 +194,9 @@ program main
   comm_backend = 0
   axis_contiguous(:) = .false.
   gdims_dist(:) = 0
-  halo_extents(:) = 0
+  halo_extents_x(:) = 0
+  halo_extents_y(:) = 0
+  halo_extents_z(:) = 0
   mem_order(:,:) = -1
   out_of_place = .false.
   use_managed_memory = .false.
@@ -259,17 +261,23 @@ program main
         read(arg, *) gdims_dist(3)
         skip_count = 1
       case('--hex')
-        call get_command_argument(i+1, arg)
-        read(arg, *) halo_extents(1)
-        skip_count = 1
+        do j = 1, 3
+          call get_command_argument(i+j, arg)
+          read(arg, *) halo_extents_x(j)
+        enddo
+        skip_count = 3
       case('--hey')
-        call get_command_argument(i+1, arg)
-        read(arg, *) halo_extents(2)
-        skip_count = 1
+        do j = 1, 3
+          call get_command_argument(i+j, arg)
+          read(arg, *) halo_extents_y(j)
+        enddo
+        skip_count = 3
       case('--hez')
-        call get_command_argument(i+1, arg)
-        read(arg, *) halo_extents(3)
-        skip_count = 1
+        do j = 1, 3
+          call get_command_argument(i+j, arg)
+          read(arg, *) halo_extents_z(j)
+        enddo
+        skip_count = 3
       case('--mem_order')
         l = 1
         do j = 1, 3
@@ -335,13 +343,13 @@ program main
   endif
 
   ! Get x-pencil information
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_x, 1, halo_extents))
+  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_x, 1, halo_extents_x))
 
   ! Get y-pencil information
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_y, 2, halo_extents))
+  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_y, 2, halo_extents_y))
 
   ! Get z-pencil information
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_z, 3, halo_extents))
+  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_z, 3, halo_extents_z))
 
   ! Get workspace size
   CHECK_CUDECOMP_EXIT(cudecompGetTransposeWorkspaceSize(handle, grid_desc, workspace_num_elements))
@@ -447,7 +455,7 @@ program main
   CHECK_CUDECOMP_EXIT(cudecompTransposeYToX(handle, grid_desc, input, output, work_d, dtype, pinfo_y%halo_extents, pinfo_x%halo_extents))
   data = output
   if (compare_pencils(xref, data, pinfo_x)) then
-    print*, "FAILED cudecompTranposeXToY"
+    print*, "FAILED cudecompTranposeYToX"
     call exit(1)
   endif
 

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -29,9 +29,9 @@ transpose_test_base: &transpose_test_base
   gdy: [0]
   gdz: [0]
 
-  hex: [0]
-  hey: [0]
-  hez: [0]
+  hex: ["0 0 0"]
+  hey: ["0 0 0"]
+  hez: ["0 0 0"]
 
   out_of_place: [True, False]
   managed_memory : [True, False]
@@ -59,23 +59,20 @@ transpose_test_acmix: &transpose_test_acmix
   acy: [0, 1]
   acz: [0, 1]
 
-transpose_test_acfalse_halo: &transpose_test_acfalse_halo
+transpose_test_halo: &transpose_test_halo
   <<: *transpose_test_base
+  args : ['backend',
+          'gx', 'gy', 'gz',
+          'gdx', 'gdy', 'gdz',
+          'hex' ,'hey', 'hez']
+
   backend: [1, 2] # Limit this testing to one normal and one pipelined backend
   dtypes: ['C64'] # Limit to one data type
-  acx: [0]
-  acy: [0]
-  acz: [0]
+  test_mem_order: true
 
-  hex: [0, 1]
-  hey: [0, 1]
-  hez: [0, 1]
-
-transpose_test_actrue_halo: &transpose_test_actrue_halo
-  <<: *transpose_test_acfalse_halo
-  acx: [1]
-  acy: [1]
-  acz: [1]
+  hex: ["0 0 0", "1 1 1"]
+  hey: ["1 1 1"]
+  hez: ["0 0 0", "1 1 1"]
 
 transpose_test_acfalse_gdimdist: &transpose_test_acfalse_gdimdist
   <<: *transpose_test_base
@@ -117,12 +114,8 @@ transpose_test_acmix_cc:
   <<: *transpose_test_acmix
   executable_prefix: 'cc/transpose_test'
 
-transpose_test_acfalse_halo_cc:
-  <<: *transpose_test_acfalse_halo
-  executable_prefix: 'cc/transpose_test'
-
-transpose_test_actrue_halo_cc:
-  <<: *transpose_test_actrue_halo
+transpose_test_halo_cc:
+  <<: *transpose_test_halo
   executable_prefix: 'cc/transpose_test'
 
 transpose_test_acfalse_gdimdist_cc:
@@ -152,13 +145,8 @@ transpose_test_acmix_fortran:
   executable_prefix: 'fortran/transpose_test'
   fortran_indexing: true
 
-transpose_test_acfalse_halo_fortran:
-  <<: *transpose_test_acfalse_halo
-  executable_prefix: 'fortran/transpose_test'
-  fortran_indexing: true
-
-transpose_test_actrue_halo_fortran:
-  <<: *transpose_test_actrue_halo
+transpose_test_halo_fortran:
+  <<: *transpose_test_halo
   executable_prefix: 'fortran/transpose_test'
   fortran_indexing: true
 


### PR DESCRIPTION
#49 generalized the internal transpose logic to handle more flexible memory layouts. As a further extension of that generalization effort, this PR extends the transpose shortcut cases (e.g. direct transpositions from input to output array for out-of-place single rank transposes)  to handle input and output buffers with halos. Previously, these shortcuts were disabled whenever halo regions supplied in the input/output tensors.

This PR also includes some tidying up of the halo code. It also adds an error check for cases where halo regions span more than a single neighboring process. 