### PR TITLE
Improve multi-node NVLink topology detection and communication ordering using NVML utilities.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ target_sources(cudecomp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels_rdc.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/nvml_wrap.cc
 )
 
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels_rdc.cu PROPERTIES COMPILE_FLAGS -rdc=true)

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -106,7 +106,8 @@ typedef enum {
   CUDECOMP_RESULT_CUTENSOR_ERROR = 5, ///< An error occured in the cuTENSOR library
   CUDECOMP_RESULT_MPI_ERROR = 6,      ///< An error occurred in the MPI library
   CUDECOMP_RESULT_NCCL_ERROR = 7,     ///< An error occured in the NCCL library
-  CUDECOMP_RESULT_NVSHMEM_ERROR = 8   ///< An error occured in the NVSHMEM library
+  CUDECOMP_RESULT_NVSHMEM_ERROR = 8,  ///< An error occured in the NVSHMEM library
+  CUDECOMP_RESULT_NVML_ERROR = 9      ///< An error occured in the NVML library
 } cudecompResult_t;
 
 /**

--- a/include/internal/checks.h
+++ b/include/internal/checks.h
@@ -41,6 +41,7 @@
 #include <cutensor.h>
 #include <mpi.h>
 #include <nccl.h>
+#include <nvml.h>
 
 #include "internal/exceptions.h"
 
@@ -110,6 +111,12 @@
         throw cudecomp::MpiError(__FILE__, __LINE__, os.str().c_str());                                                \
       }                                                                                                                \
     }                                                                                                                  \
+  } while (false)
+
+#define CHECK_NVML(call)                                                                                               \
+  do {                                                                                                                 \
+    nvmlReturn_t err = nvmlFnTable.pfn_##call;                                                                         \
+    if (NVML_SUCCESS != err) { throw cudecomp::NvmlError(__FILE__, __LINE__, nvmlFnTable.pfn_nvmlErrorString(err)); }  \
   } while (false)
 
 // Checks with exit (test usage)

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -162,13 +162,13 @@ cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   }
   case CUDECOMP_TRANSPOSE_COMM_NCCL: {
     auto comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info : grid_desc->col_comm_info;
-    // For fully intranode alltoall, use distinct NCCL local comm instead of global comm as it is faster.
-    auto comm = (comm_info.nnodes == 1) ? handle->nccl_local_comm : handle->nccl_comm;
+    // For fully intra-group alltoall, use distinct NCCL local comm instead of global comm as it is faster.
+    auto comm = (comm_info.ngroups == 1) ? handle->nccl_local_comm : handle->nccl_comm;
 
     CHECK_NCCL(ncclGroupStart());
     for (int i = 0; i < send_counts.size(); ++i) {
       int peer_rank_global = getGlobalRank(grid_desc, comm_axis, i);
-      if (comm_info.nnodes == 1) { peer_rank_global = handle->rank_to_clique_rank[peer_rank_global]; }
+      if (comm_info.ngroups == 1) { peer_rank_global = handle->rank_to_clique_rank[peer_rank_global]; }
       if (send_counts[i] != 0) {
         CHECK_NCCL(ncclSend(send_buff + send_offsets[i], send_counts[i] * sizeof(T), ncclChar, peer_rank_global, comm,
                             stream));
@@ -342,8 +342,8 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
   }
   case CUDECOMP_TRANSPOSE_COMM_NCCL_PL: {
     auto comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info : grid_desc->col_comm_info;
-    // For fully intranode alltoall, use distinct NCCL local comm instead of global comm as it is faster.
-    auto comm = (comm_info.nnodes == 1) ? handle->nccl_local_comm : handle->nccl_comm;
+    // For fully intra-group alltoall, use distinct NCCL local comm instead of global comm as it is faster.
+    auto comm = (comm_info.ngroups == 1) ? handle->nccl_local_comm : handle->nccl_comm;
     auto pl_stream = handle->pl_stream;
     int self_rank = comm_info.rank;
 
@@ -365,7 +365,7 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
         }
         int src_rank_global = getGlobalRank(grid_desc, comm_axis, src_rank);
         int dst_rank_global = getGlobalRank(grid_desc, comm_axis, dst_rank);
-        if (comm_info.nnodes == 1) {
+        if (comm_info.ngroups == 1) {
           src_rank_global = handle->rank_to_clique_rank[src_rank_global];
           dst_rank_global = handle->rank_to_clique_rank[dst_rank_global];
         }

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -168,7 +168,7 @@ cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     CHECK_NCCL(ncclGroupStart());
     for (int i = 0; i < send_counts.size(); ++i) {
       int peer_rank_global = getGlobalRank(grid_desc, comm_axis, i);
-      if (comm_info.nnodes == 1) { peer_rank_global = handle->rank_to_local_rank[peer_rank_global]; }
+      if (comm_info.nnodes == 1) { peer_rank_global = handle->rank_to_clique_rank[peer_rank_global]; }
       if (send_counts[i] != 0) {
         CHECK_NCCL(ncclSend(send_buff + send_offsets[i], send_counts[i] * sizeof(T), ncclChar, peer_rank_global, comm,
                             stream));
@@ -366,8 +366,8 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
         int src_rank_global = getGlobalRank(grid_desc, comm_axis, src_rank);
         int dst_rank_global = getGlobalRank(grid_desc, comm_axis, dst_rank);
         if (comm_info.nnodes == 1) {
-          src_rank_global = handle->rank_to_local_rank[src_rank_global];
-          dst_rank_global = handle->rank_to_local_rank[dst_rank_global];
+          src_rank_global = handle->rank_to_clique_rank[src_rank_global];
+          dst_rank_global = handle->rank_to_clique_rank[dst_rank_global];
         }
         if (send_counts[dst_rank] != 0) {
           CHECK_NCCL(ncclSend(send_buff + send_offsets[dst_rank], send_counts[dst_rank] * sizeof(T), ncclChar,

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -48,18 +48,22 @@
 // cuDecomp handle containing general information
 struct cudecompHandle {
 
-  MPI_Comm mpi_comm; // MPI communicator
+  MPI_Comm mpi_comm = MPI_COMM_NULL; // MPI communicator
   int32_t rank;      // MPI rank
   int32_t nranks;    // MPI size
 
-  MPI_Comm mpi_local_comm; // MPI local communicator
+  MPI_Comm mpi_local_comm = MPI_COMM_NULL; // MPI local communicator
   int32_t local_rank;      // MPI rank
   int32_t local_nranks;    // MPI size
+
+  MPI_Comm mpi_clique_comm = MPI_COMM_NULL; // MPI MNNVL clique local communicator
+  int32_t clique_rank;      // MPI rank
+  int32_t clique_nranks;    // MPI size
 
   // Entries for NCCL management
   int n_grid_descs_using_nccl = 0;      // Count of grid descriptors using NCCL
   ncclComm_t nccl_comm = nullptr;       // NCCL communicator (global)
-  ncclComm_t nccl_local_comm = nullptr; // NCCL communicator (intranode)
+  ncclComm_t nccl_local_comm = nullptr; // NCCL communicator (intranode, or intra-clique on MNNVL systems)
   bool nccl_enable_ubr = false;         // Flag to control NCCL user buffer registration usage
   std::unordered_map<void*, std::vector<std::pair<ncclComm_t, void*>>>
       nccl_ubr_handles; // map of allocated buffer address to NCCL registration handle(s)
@@ -88,6 +92,7 @@ struct cudecompHandle {
   // Multi-node NVLINK (MNNVL)
   bool cuda_cumem_enable = false; // Flag to control whether cuMem* APIs are used for cudecompMalloc/Free
   std::vector<unsigned int> rank_to_cliqueId; // list of rank to MNNVL clique mappings
+  std::vector<int> rank_to_clique_rank; // list of rank to MNNVL clique rank mappings
 };
 
 // Structure with information about row/column communicator

--- a/include/internal/exceptions.h
+++ b/include/internal/exceptions.h
@@ -134,6 +134,13 @@ public:
   cudecompResult_t getResult() const override { return CUDECOMP_RESULT_NVSHMEM_ERROR; }
 };
 
+class NvmlError : public BaseException {
+public:
+  NvmlError(const char* file, int line, const char* extra_info = nullptr)
+      : BaseException(file, line, "NVML error.", extra_info){};
+  cudecompResult_t getResult() const override { return CUDECOMP_RESULT_NVML_ERROR; }
+};
+
 } // namespace cudecomp
 
 #endif // CUDECOMP_EXCEPTIONS_H

--- a/include/internal/hashes.h
+++ b/include/internal/hashes.h
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CUDECOMP_HASHES_H
+#define CUDECOMP_HASHES_H
+
+#include <utility>
+
+#define MAGIC 0x9e3779b9
+
+template <typename T, size_t N> struct std::hash<std::array<T, N>> {
+  size_t operator()(const std::array<T, N>& in) const {
+    size_t hash_value = 0;
+    for (const auto& val : in) {
+      hash_value ^= std::hash<T>{}(val) + MAGIC + (hash_value << 6) + (hash_value >> 2);
+    }
+    return hash_value;
+  }
+};
+
+template <typename U, typename V> struct std::hash<std::pair<U, V>> {
+  size_t operator()(const std::pair<U, V>& in) const {
+    size_t hash_value = 0;
+    hash_value ^= std::hash<U>{}(in.first) + MAGIC + (hash_value << 6) + (hash_value >> 2);
+    hash_value ^= std::hash<V>{}(in.second) + MAGIC + (hash_value << 6) + (hash_value >> 2);
+    return hash_value;
+  }
+};
+
+#undef MAGIC
+
+#endif // CUDECOMP_HASHES_H

--- a/include/internal/nvml_wrap.h
+++ b/include/internal/nvml_wrap.h
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CUDECOMP_NVML_WRAP_H
+#define CUDECOMP_NVML_WRAP_H
+
+#include <cuda_runtime.h>
+#include <nvml.h>
+
+namespace cudecomp {
+
+struct nvmlFunctionTable {
+  nvmlReturn_t (*pfn_nvmlInit)(void) = nullptr;
+  nvmlReturn_t (*pfn_nvmlShutdown)(void) = nullptr;
+  const char* (*pfn_nvmlErrorString)(nvmlReturn_t result) = nullptr;
+  nvmlReturn_t (*pfn_nvmlDeviceGetHandleByPciBusId)(const char* pciBusId, nvmlDevice_t* device) = nullptr;
+#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12030
+  nvmlReturn_t (*pfn_nvmlDeviceGetGpuFabricInfoV)(nvmlDevice_t device, nvmlGpuFabricInfoV_t* gpuFabricInfo) = nullptr;
+#endif
+};
+
+extern nvmlFunctionTable nvmlFnTable;
+
+void initNvmlFunctionTable();
+
+bool nvmlHasFabricSupport();
+
+} // namespace cudecomp
+
+#endif // CUDECOMP_NVML_WRAP_H

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -524,8 +524,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
           std::vector<int> dst_ranks{dst_rank};
           std::vector<int> src_ranks{src_rank};
 
-          if (j != 0 && comm_info.homogeneous && comm_info.nnodes != 1) {
-            // Perform pipelining in pairs to intra-node comms behind inter-node transfers
+          if (j != 0 && comm_info.ngroups != 1) {
+            // Perform pipelining in pairs to hide intra-group comms behind inter-group transfers
             if (j % 2 == 1) {
               if (j + 1 < splits_b.size()) {
                 int src_rank_next, dst_rank_next;
@@ -618,8 +618,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
         std::vector<int> dst_ranks{dst_rank};
         std::vector<int> src_ranks{src_rank};
 
-        if (j != 0 && comm_info.homogeneous && comm_info.nnodes != 1) {
-          // Perform pipelining in pairs to intra-node comms behind inter-node transfers
+        if (j != 0 && comm_info.ngroups != 1) {
+          // Perform pipelining in pairs to hide intra-group comms behind inter-group transfers
           if (j % 2 == 1) {
             if (j + 1 < splits_b.size()) {
               int src_rank_next, dst_rank_next;
@@ -673,8 +673,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       std::vector<int> dst_ranks{dst_rank};
       std::vector<int> src_ranks{src_rank};
 
-      if (j != 0 && comm_info.homogeneous && comm_info.nnodes != 1) {
-        // Perform pipelining in pairs to intra-node comms behind inter-node transfers
+      if (j != 0 && comm_info.ngroups != 1) {
+        // Perform pipelining in pairs to hide intra-group comms behind inter-group transfers
         if (j % 2 == 1) {
           if (j + 1 < splits_b.size()) {
             int src_rank_next, dst_rank_next;

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -247,7 +247,7 @@ static void gatherGlobalMPIInfo(cudecompHandle_t& handle) {
   if (handle->rank_to_mnnvl_info.size() != 0) {
     // cliqueIds returned in fabricInfo are not unique across MNNVL domains (defined by clusterUuid).
     // Define a modified clique id that assigns a unique index to each (clusterUuid, cliqueId) pair.
-    std::unordered_map<mnnvl_info, int> clique_ids;
+    std::unordered_map<mnnvl_info, unsigned int> clique_ids;
     clique_ids = getUniqueIds(handle->rank_to_mnnvl_info);
 
     // Populate rank to MNNVL clique mappings
@@ -257,7 +257,7 @@ static void gatherGlobalMPIInfo(cudecompHandle_t& handle) {
     }
 
     // Create clique local MPI communicator
-    CHECK_MPI(MPI_Comm_split(handle->mpi_comm, handle->rank_to_clique[handle->rank], handle->rank, &handle->mpi_clique_comm));
+    CHECK_MPI(MPI_Comm_split(handle->mpi_comm, static_cast<int>(handle->rank_to_clique[handle->rank]), handle->rank, &handle->mpi_clique_comm));
     CHECK_MPI(MPI_Comm_rank(handle->mpi_clique_comm, &handle->clique_rank));
     CHECK_MPI(MPI_Comm_size(handle->mpi_clique_comm, &handle->clique_nranks));
 

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -79,6 +79,7 @@ module cudecomp
     enumerator :: CUDECOMP_RESULT_MPI_ERROR = 6
     enumerator :: CUDECOMP_RESULT_NCCL_ERROR = 7
     enumerator :: CUDECOMP_RESULT_NVSHMEM_ERROR = 8
+    enumerator :: CUDECOMP_RESULT_NVML_ERROR = 9
   end enum
 
   ! types

--- a/src/nvml_wrap.cc
+++ b/src/nvml_wrap.cc
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cuda_runtime.h>
+#include <dlfcn.h>
+
+#include "internal/checks.h"
+#include "internal/nvml_wrap.h"
+#include "internal/exceptions.h"
+
+#define LOAD_SYM(symbol)                                                        \
+  do {                                                                          \
+    void **fptr = (void**)(&nvmlFnTable.pfn_##symbol);                          \
+    void *sym = dlsym(nvml_handle, #symbol);                                    \
+    *fptr = sym;                                                                \
+    if (!sym) {                                                                 \
+      printf("%s failed to load\n", #symbol);                                   \
+    }; \
+  } while(false)
+
+namespace cudecomp {
+
+nvmlFunctionTable nvmlFnTable; // global table of required NVML functions
+
+void initNvmlFunctionTable() {
+  void *nvml_handle = dlopen("libnvidia-ml.so.1", RTLD_NOW);
+  if (!nvml_handle) {
+    THROW_INVALID_USAGE("Could not dlopen libnvidia-ml.so.1");
+  }
+  LOAD_SYM(nvmlInit);
+  LOAD_SYM(nvmlShutdown);
+  LOAD_SYM(nvmlErrorString);
+  LOAD_SYM(nvmlDeviceGetHandleByPciBusId);
+#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12030
+  LOAD_SYM(nvmlDeviceGetGpuFabricInfoV);
+#endif
+}
+
+bool nvmlHasFabricSupport() {
+#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12030
+  return (nvmlFnTable.pfn_nvmlDeviceGetGpuFabricInfoV != nullptr);
+#else
+  return false;
+#endif
+}
+
+} // namespace cudecomp
+
+#undef LOAD_SYM


### PR DESCRIPTION
On systems with multi-node NVLink (MNNVL) capabilities, fast communication can occur via NVLink between GPUs that are on separate nodes. The existing pipelined all-to-all communication ordering in cuDecomp makes an attempt to hide faster P2P transfers over NVLink behind slower transfers over IB, but the existing logic was designed with the assumption that NVLink connections only exist with intra-node peers.

This PR generalizes the communication scheduling logic to treat MNNVL "cliques" (i.e. a group of GPUs connected with NVLink) as a logical "node". This enables cuDecomp to pair up "inter-clique" NVLink communications with "inter-clique" IB communication to generalize the communication hiding optimization to MNNVL systems. To detect MNNVL support and clique assignments, bindings to the NVIDIA management library (NVML) have been added in this PR. 