### PR TITLE
Fix CUDART_VERSION guard for nvmlDeviceGetGpuFabricInfoV to restrict usage to CUDA >= 12.4.

### DIFF
--- a/include/internal/nvml_wrap.h
+++ b/include/internal/nvml_wrap.h
@@ -41,7 +41,7 @@ struct nvmlFunctionTable {
   nvmlReturn_t (*pfn_nvmlShutdown)(void) = nullptr;
   const char* (*pfn_nvmlErrorString)(nvmlReturn_t result) = nullptr;
   nvmlReturn_t (*pfn_nvmlDeviceGetHandleByPciBusId)(const char* pciBusId, nvmlDevice_t* device) = nullptr;
-#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12030
+#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12040
   nvmlReturn_t (*pfn_nvmlDeviceGetGpuFabricInfoV)(nvmlDevice_t device, nvmlGpuFabricInfoV_t* gpuFabricInfo) = nullptr;
 #endif
 };

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -210,7 +210,7 @@ static void gatherGlobalMPIInfo(cudecompHandle_t& handle) {
   CHECK_CUDA(cudaDeviceGetPCIBusId(pciBusId, sizeof(pciBusId), dev));
   nvmlDevice_t nvml_dev;
   CHECK_NVML(nvmlDeviceGetHandleByPciBusId(pciBusId, &nvml_dev));
-#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12030
+#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12040
   nvmlGpuFabricInfoV_t fabricInfo ={ .version = nvmlGpuFabricInfo_v2 };
   if (nvmlHasFabricSupport()) {
     handle->rank_to_mnnvl_info.resize(handle->nranks);
@@ -237,7 +237,7 @@ static void gatherGlobalMPIInfo(cudecompHandle_t& handle) {
       if (std::memcmp(clusterUuids[i].data(), zeros, NVML_GPU_FABRIC_UUID_LEN) == 0) {
         // If any rank has a zero cluster UUID, disable MNNVL.
         handle->rank_to_mnnvl_info.resize(0);
-	break;
+        break;
       }
       handle->rank_to_mnnvl_info[i].first = clusterUuids[i];
       handle->rank_to_mnnvl_info[i].second = cliqueIds[i];

--- a/src/nvml_wrap.cc
+++ b/src/nvml_wrap.cc
@@ -58,13 +58,13 @@ void initNvmlFunctionTable() {
   LOAD_SYM(nvmlShutdown);
   LOAD_SYM(nvmlErrorString);
   LOAD_SYM(nvmlDeviceGetHandleByPciBusId);
-#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12030
+#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12040
   LOAD_SYM(nvmlDeviceGetGpuFabricInfoV);
 #endif
 }
 
 bool nvmlHasFabricSupport() {
-#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12030
+#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12040
   return (nvmlFnTable.pfn_nvmlDeviceGetGpuFabricInfoV != nullptr);
 #else
   return false;


### PR DESCRIPTION
This PR is a follow up to #56. It turns out that while fabric allocations are available since CUDA 12.3, the versioned `nvmlDeviceGetGpuFabricInfoV` and `nvmlGpuFabricInfoV_t` are not available until CUDA 12.4. Updating the preprocessor macros to enforce this correctly.