### PR TITLE
Silence messages about NVML symbols failing to load.

### DIFF
--- a/src/nvml_wrap.cc
+++ b/src/nvml_wrap.cc
@@ -40,9 +40,6 @@
     void **fptr = (void**)(&nvmlFnTable.pfn_##symbol);                          \
     void *sym = dlsym(nvml_handle, #symbol);                                    \
     *fptr = sym;                                                                \
-    if (!sym) {                                                                 \
-      printf("%s failed to load\n", #symbol);                                   \
-    }; \
   } while(false)
 
 namespace cudecomp {


### PR DESCRIPTION
The current NVML wrapper verbosely prints a message if a symbol fails to load, even if this is not a fatal issue. This PR removes the print.