### PR TITLE
Improve tests

### DIFF
--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -42,6 +42,7 @@ foreach(tgt ${transpose_test_targets_cc} ${halo_test_targets_cc})
   target_link_libraries(${tgt} PRIVATE MPI::MPI_CXX)
   target_link_libraries(${tgt} PRIVATE NVHPC::CUDART)
   target_link_libraries(${tgt} PUBLIC cudecomp)
+  target_compile_options(${tgt} PRIVATE -O3)
 endforeach()
 
 target_compile_definitions(transpose_test_R32_cc PRIVATE R32)

--- a/tests/cc/halo_test.cc
+++ b/tests/cc/halo_test.cc
@@ -212,12 +212,8 @@ static void usage(const char* pname) {
           "\t\tY-dimension axis-contiguous pencils setting. (default: 0) \n"
           "\t--acz\n"
           "\t\tZ-dimension axis-contiguous pencils setting. (default: 0) \n"
-          "\t--gdx\n"
-          "\t\tX-dimension gdim_dist setting, set to gx - gdx. (default: 0) \n"
-          "\t--gdy\n"
-          "\t\tY-dimension gdim_dist setting, set to gy - gdy. (default: 0) \n"
-          "\t--gdz\n"
-          "\t\tZ-dimension gdim_dist setting, set to gz - gdz. (default: 0) \n"
+          "\t--gd\n"
+          "\t\t gdim_dist setting, set to g[i] - gd[i]. (default: 0 0 0) \n"
           "\t--hex\n"
           "\t\tX-dimension halo_extents setting. (default: 0) \n"
           "\t--hey\n"
@@ -271,8 +267,7 @@ static haloTestArgs parse_arguments(const std::string& arguments) {
         {"gz", required_argument, 0, 'z'},  {"backend", required_argument, 0, 'b'},
         {"pr", required_argument, 0, 'r'},  {"pc", required_argument, 0, 'c'},
         {"acx", required_argument, 0, '1'}, {"acy", required_argument, 0, '2'},
-        {"acz", required_argument, 0, '3'}, {"gdx", required_argument, 0, '4'},
-        {"gdy", required_argument, 0, '5'}, {"gdz", required_argument, 0, '6'},
+        {"acz", required_argument, 0, '3'}, {"gd", required_argument, 0, '4'},
         {"hex", required_argument, 0, '7'}, {"hey", required_argument, 0, '8'},
         {"hez", required_argument, 0, '9'}, {"hpx", required_argument, 0, 'e'},
         {"hpy", required_argument, 0, 'f'}, {"hpz", required_argument, 0, 'g'},
@@ -281,7 +276,7 @@ static haloTestArgs parse_arguments(const std::string& arguments) {
         {"help", no_argument, 0, 'h'},      {0, 0, 0, 0}};
 
     int option_index = 0;
-    int ch = getopt_long(argc, argv, "x:y:z:b:r:c:1:2:3:4:5:6:7:8:9:e:f:g:a:q:mh", long_options, &option_index);
+    int ch = getopt_long(argc, argv, "x:y:z:b:r:c:1:2:3:4:7:8:9:e:f:g:a:q:mh", long_options, &option_index);
     if (ch == -1) break;
 
     switch (ch) {
@@ -295,9 +290,13 @@ static haloTestArgs parse_arguments(const std::string& arguments) {
     case '1': args.axis_contiguous[0] = atoi(optarg); break;
     case '2': args.axis_contiguous[1] = atoi(optarg); break;
     case '3': args.axis_contiguous[2] = atoi(optarg); break;
-    case '4': args.gdims_dist[0] = atoi(optarg); break;
-    case '5': args.gdims_dist[1] = atoi(optarg); break;
-    case '6': args.gdims_dist[2] = atoi(optarg); break;
+    case '4':
+      optind--;
+      for (int i = 0; i < 3; ++i) {
+        args.gdims_dist[i] = atoi(argv[optind]);
+        optind++;
+      }
+      break;
     case '7': args.halo_extents[0] = atoi(optarg); break;
     case '8': args.halo_extents[1] = atoi(optarg); break;
     case '9': args.halo_extents[2] = atoi(optarg); break;

--- a/tests/cc/halo_test.cc
+++ b/tests/cc/halo_test.cc
@@ -116,7 +116,7 @@ static bool compare_pencils(const std::vector<real_t>& ref, const std::vector<re
                             const cudecompPencilInfo_t& pinfo) {
   for (int64_t i = 0; i < ref.size(); ++i) {
     if (ref[i] != real_t(-1)) {
-      if (std::abs(ref[i] - res[i]) > 1e-6) return false;
+      if (ref[i] != res[i]) return false;
     }
   }
   return true;

--- a/tests/cc/halo_test.cc
+++ b/tests/cc/halo_test.cc
@@ -30,8 +30,13 @@
 
 #include <array>
 #include <complex>
+#include <cstring>
 #include <cstdio>
+#include <fstream>
 #include <numeric>
+#include <sstream>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <getopt.h>
@@ -59,6 +64,53 @@ static cudecompDataType_t get_cudecomp_datatype(std::complex<double>) { return C
 using real_t = float;
 static cudecompDataType_t get_cudecomp_datatype(float) { return CUDECOMP_FLOAT; }
 #endif
+
+// Helper function to convert string into equivalent argc/argv input
+static void string_to_argcv(const std::string& input, int& argc, char**& argv) {
+  std::istringstream stream(input);
+  std::vector<std::string> tokens;
+  std::string token;
+
+  // Set argv[0] to dummy value
+  tokens.push_back("");
+
+  while (stream >> token) {
+    tokens.push_back(token);
+  }
+
+  argc = tokens.size();
+  argv = new char*[argc];
+
+  for (int i = 0; i < argc; ++i) {
+    argv[i] = new char[tokens[i].size() + 1];
+    std::strcpy(argv[i], tokens[i].c_str());
+  }
+}
+
+static void free_argcv(int argc, char** argv) {
+  for (int i = 0; i < argc; ++i) {
+    delete[] argv[i];
+  }
+  delete[] argv;
+}
+
+static std::vector<std::string> read_testfile(const std::string& filename) {
+  std::vector<std::string> cases;
+  std::ifstream file(filename);
+  std::string line;
+
+  if (file.is_open()) {
+    while (std::getline(file, line)) {
+      cases.push_back(line);
+    }
+    file.close();
+  } else {
+    fprintf(stderr, "unable to open test file: %s\n", filename.c_str());
+    exit(EXIT_FAILURE);
+  }
+
+  return cases;
+}
 
 static bool compare_pencils(const std::vector<real_t>& ref, const std::vector<real_t>& res,
                             const cudecompPencilInfo_t& pinfo) {
@@ -188,19 +240,7 @@ static void usage(const char* pname) {
   exit(EXIT_SUCCESS);
 }
 
-int main(int argc, char** argv) {
-  CHECK_MPI_EXIT(MPI_Init(nullptr, nullptr));
-  int rank, nranks;
-  CHECK_MPI_EXIT(MPI_Comm_rank(MPI_COMM_WORLD, &rank));
-  CHECK_MPI_EXIT(MPI_Comm_size(MPI_COMM_WORLD, &nranks));
-
-  MPI_Comm local_comm;
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &local_comm);
-  int local_rank;
-  MPI_Comm_rank(local_comm, &local_rank);
-  CHECK_CUDA_EXIT(cudaSetDevice(local_rank));
-
-  // Parse command-line arguments
+struct haloTestArgs {
   int gx = 256;
   int gy = 256;
   int gz = 256;
@@ -214,7 +254,17 @@ int main(int argc, char** argv) {
   int axis = 0;
   bool use_managed_memory = false;
   std::array<int, 9> mem_order{-1, -1, -1, -1, -1, -1, -1, -1, -1};
+};
 
+static haloTestArgs parse_arguments(const std::string& arguments) {
+  haloTestArgs args;
+
+  int argc;
+  char** argv;
+  string_to_argcv(arguments, argc, argv);
+
+  // Parse command-line arguments
+  optind = 0;
   while (1) {
     static struct option long_options[] = {
         {"gx", required_argument, 0, 'x'},  {"gy", required_argument, 0, 'y'},
@@ -236,30 +286,30 @@ int main(int argc, char** argv) {
 
     switch (ch) {
     case 0: break;
-    case 'x': gx = atoi(optarg); break;
-    case 'y': gy = atoi(optarg); break;
-    case 'z': gz = atoi(optarg); break;
-    case 'b': comm_backend = static_cast<cudecompHaloCommBackend_t>(atoi(optarg)); break;
-    case 'r': pr = atoi(optarg); break;
-    case 'c': pc = atoi(optarg); break;
-    case '1': axis_contiguous[0] = atoi(optarg); break;
-    case '2': axis_contiguous[1] = atoi(optarg); break;
-    case '3': axis_contiguous[2] = atoi(optarg); break;
-    case '4': gdims_dist[0] = atoi(optarg); break;
-    case '5': gdims_dist[1] = atoi(optarg); break;
-    case '6': gdims_dist[2] = atoi(optarg); break;
-    case '7': halo_extents[0] = atoi(optarg); break;
-    case '8': halo_extents[1] = atoi(optarg); break;
-    case '9': halo_extents[2] = atoi(optarg); break;
-    case 'e': halo_periods[0] = atoi(optarg); break;
-    case 'f': halo_periods[1] = atoi(optarg); break;
-    case 'g': halo_periods[2] = atoi(optarg); break;
-    case 'a': axis = atoi(optarg); break;
-    case 'm': use_managed_memory = true; break;
+    case 'x': args.gx = atoi(optarg); break;
+    case 'y': args.gy = atoi(optarg); break;
+    case 'z': args.gz = atoi(optarg); break;
+    case 'b': args.comm_backend = static_cast<cudecompHaloCommBackend_t>(atoi(optarg)); break;
+    case 'r': args.pr = atoi(optarg); break;
+    case 'c': args.pc = atoi(optarg); break;
+    case '1': args.axis_contiguous[0] = atoi(optarg); break;
+    case '2': args.axis_contiguous[1] = atoi(optarg); break;
+    case '3': args.axis_contiguous[2] = atoi(optarg); break;
+    case '4': args.gdims_dist[0] = atoi(optarg); break;
+    case '5': args.gdims_dist[1] = atoi(optarg); break;
+    case '6': args.gdims_dist[2] = atoi(optarg); break;
+    case '7': args.halo_extents[0] = atoi(optarg); break;
+    case '8': args.halo_extents[1] = atoi(optarg); break;
+    case '9': args.halo_extents[2] = atoi(optarg); break;
+    case 'e': args.halo_periods[0] = atoi(optarg); break;
+    case 'f': args.halo_periods[1] = atoi(optarg); break;
+    case 'g': args.halo_periods[2] = atoi(optarg); break;
+    case 'a': args.axis = atoi(optarg); break;
+    case 'm': args.use_managed_memory = true; break;
     case 'q':
       optind--;
       for (int i = 0; i < 9; ++i) {
-        mem_order[i] = atoi(argv[optind]);
+        args.mem_order[i] = atoi(argv[optind]);
         optind++;
       }
       break;
@@ -270,133 +320,236 @@ int main(int argc, char** argv) {
   }
 
   // Finish setting up gdim_dist
-  gdims_dist[0] = gx - gdims_dist[0];
-  gdims_dist[1] = gy - gdims_dist[1];
-  gdims_dist[2] = gz - gdims_dist[2];
+  args.gdims_dist[0] = args.gx - args.gdims_dist[0];
+  args.gdims_dist[1] = args.gy - args.gdims_dist[1];
+  args.gdims_dist[2] = args.gz - args.gdims_dist[2];
 
-  // Check for custom process grid
-  std::array<int, 2> pdims;
-  pdims[0] = pr;
-  pdims[1] = pc;
+  free_argcv(argc, argv);
 
-  if (rank == 0) printf("running on %d x %d x %d spatial grid...\n", gx, gy, gz);
+  return args;
+}
+
+int rank, nranks;
+cudecompHandle_t handle;
+std::unordered_map<cudecompHaloCommBackend_t, cudecompGridDesc_t> grid_desc_cache;
+
+// Cache a single grid descriptor per backend type. This keeps NCCL/NVSHMEM initialized between tests for
+// better throughput.
+static void cache_grid_desc(const cudecompGridDesc_t& grid_desc, cudecompHaloCommBackend_t backend) {
+  if (grid_desc_cache.count(backend) != 0) {
+    CHECK_CUDECOMP(cudecompGridDescDestroy(handle, grid_desc_cache[backend]));
+  }
+  grid_desc_cache[backend] = grid_desc;
+}
+
+static int run_test(const std::string& arguments, bool silent) {
+  try {
+    haloTestArgs args = parse_arguments(arguments);
+
+    std::array<int, 2> pdims;
+    pdims[0] = args.pr;
+    pdims[1] = args.pc;
+
+    if (!silent && rank == 0) printf("running on %d x %d x %d spatial grid...\n", args.gx, args.gy, args.gz);
+
+    // Setup grid descriptor
+    std::array<int32_t, 3> gdims{args.gx, args.gy, args.gz};
+    cudecompGridDesc_t grid_desc;
+    cudecompGridDescConfig_t config;
+    CHECK_CUDECOMP(cudecompGridDescConfigSetDefaults(&config));
+    config.pdims[0] = pdims[0];
+    config.pdims[1] = pdims[1];
+    config.gdims[0] = gdims[0];
+    config.gdims[1] = gdims[1];
+    config.gdims[2] = gdims[2];
+    config.gdims_dist[0] = args.gdims_dist[0];
+    config.gdims_dist[1] = args.gdims_dist[1];
+    config.gdims_dist[2] = args.gdims_dist[2];
+    config.transpose_axis_contiguous[0] = args.axis_contiguous[0];
+    config.transpose_axis_contiguous[1] = args.axis_contiguous[1];
+    config.transpose_axis_contiguous[2] = args.axis_contiguous[2];
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        config.transpose_mem_order[i][j] = args.mem_order[i * 3 + j];
+      }
+    }
+
+    cudecompGridDescAutotuneOptions_t options;
+    CHECK_CUDECOMP(cudecompGridDescAutotuneOptionsSetDefaults(&options));
+    options.halo_extents[0] = args.halo_extents[0];
+    options.halo_extents[1] = args.halo_extents[1];
+    options.halo_extents[2] = args.halo_extents[2];
+    options.halo_periods[0] = args.halo_periods[0];
+    options.halo_periods[1] = args.halo_periods[1];
+    options.halo_periods[2] = args.halo_periods[2];
+    options.halo_axis = args.axis;
+    options.dtype = get_cudecomp_datatype(real_t(0));
+    options.grid_mode = CUDECOMP_AUTOTUNE_GRID_HALO;
+
+    if (args.comm_backend != 0) {
+      config.halo_comm_backend = args.comm_backend;
+    } else {
+      options.autotune_halo_backend = true;
+    }
+
+    CHECK_CUDECOMP(cudecompGridDescCreate(handle, &grid_desc, &config, &options));
+    cache_grid_desc(grid_desc, config.halo_comm_backend);
+
+    if (!silent && rank == 0) {
+      printf("running on %d x %d process grid...\n", config.pdims[0], config.pdims[1]);
+      printf("running using %s halo backend...\n", cudecompHaloCommBackendToString(config.halo_comm_backend));
+    }
+
+    // Get pencil information
+    cudecompPencilInfo_t pinfo;
+    CHECK_CUDECOMP(cudecompGetPencilInfo(handle, grid_desc, &pinfo, args.axis, args.halo_extents.data()));
+
+    // Get workspace size
+    int64_t workspace_num_elements;
+    CHECK_CUDECOMP(
+        cudecompGetHaloWorkspaceSize(handle, grid_desc, args.axis, args.halo_extents.data(), &workspace_num_elements));
+
+    // Allocate data arrays
+    int64_t data_num_elements = pinfo.size;
+
+    std::vector<real_t> data(data_num_elements);
+
+    // Create reference data
+    std::vector<real_t> init(pinfo.size);
+    std::vector<real_t> ref(pinfo.size);
+
+    initialize_pencil(init, pinfo, gdims);
+    initialize_reference(ref, pinfo, gdims, args.halo_periods);
+
+    real_t *data_d, *work_d;
+    if (args.use_managed_memory) {
+      CHECK_CUDA(cudaMallocManaged(&data_d, data.size() * sizeof(*data_d)));
+    } else {
+      CHECK_CUDA(cudaMalloc(&data_d, data.size() * sizeof(*data_d)));
+    }
+    int64_t dtype_size;
+    CHECK_CUDECOMP(cudecompGetDataTypeSize(get_cudecomp_datatype(real_t(0)), &dtype_size));
+    CHECK_CUDECOMP(
+        cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work_d), workspace_num_elements * dtype_size));
+
+    // Running correctness tests
+    if (!silent && rank == 0) printf("running correctness tests...\n");
+    // Initialize data to initial pencil data
+    CHECK_CUDA(cudaMemcpy(data_d, init.data(), init.size() * sizeof(*data_d), cudaMemcpyHostToDevice));
+
+    real_t* input = data_d;
+    for (int i = 0; i < 3; ++i) {
+      switch (args.axis) {
+      case 0:
+        CHECK_CUDECOMP(cudecompUpdateHalosX(handle, grid_desc, input, work_d, get_cudecomp_datatype(real_t(0)),
+                                                 pinfo.halo_extents, args.halo_periods.data(), i, 0));
+        break;
+      case 1:
+        CHECK_CUDECOMP(cudecompUpdateHalosY(handle, grid_desc, input, work_d, get_cudecomp_datatype(real_t(0)),
+                                                 pinfo.halo_extents, args.halo_periods.data(), i, 0));
+        break;
+      case 2:
+        CHECK_CUDECOMP(cudecompUpdateHalosZ(handle, grid_desc, input, work_d, get_cudecomp_datatype(real_t(0)),
+                                                 pinfo.halo_extents, args.halo_periods.data(), i, 0));
+        break;
+      }
+    }
+
+    CHECK_CUDA(cudaMemcpy(data.data(), data_d, data.size() * sizeof(*data_d), cudaMemcpyDeviceToHost));
+    if (!compare_pencils(ref, data, pinfo)) {
+      fprintf(stderr, "FAILED cudecompUpdateHalos\n");
+      return 1;
+    }
+
+    CHECK_CUDA(cudaFree(data_d));
+    CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work_d));
+  } catch (const std::exception& e) {
+    return 1;
+  }
+
+  return 0;
+}
+
+int main(int argc, char** argv) {
+  CHECK_MPI_EXIT(MPI_Init(nullptr, nullptr));
+  CHECK_MPI_EXIT(MPI_Comm_rank(MPI_COMM_WORLD, &rank));
+  CHECK_MPI_EXIT(MPI_Comm_size(MPI_COMM_WORLD, &nranks));
+
+  MPI_Comm local_comm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &local_comm);
+  int local_rank;
+  MPI_Comm_rank(local_comm, &local_rank);
+  CHECK_CUDA_EXIT(cudaSetDevice(local_rank));
+
+  // Check if test file was provided
+  std::string testfile;
+  bool using_testfile = false;
+  for (int i = 0; i < argc; ++i) {
+    if (strcmp(argv[i], "-f") == 0 || strcmp(argv[i], "--testfile") == 0) {
+      testfile = std::string(argv[i+1]);
+      using_testfile = true;
+      break;
+    }
+  }
 
   // Initialize cuDecomp
-  cudecompHandle_t handle;
   CHECK_CUDECOMP_EXIT(cudecompInit(&handle, MPI_COMM_WORLD));
 
-  // Setup grid descriptor
-  std::array<int32_t, 3> gdims{gx, gy, gz};
-  cudecompGridDesc_t grid_desc;
-  cudecompGridDescConfig_t config;
-  CHECK_CUDECOMP_EXIT(cudecompGridDescConfigSetDefaults(&config));
-  config.pdims[0] = pdims[0];
-  config.pdims[1] = pdims[1];
-  config.gdims[0] = gdims[0];
-  config.gdims[1] = gdims[1];
-  config.gdims[2] = gdims[2];
-  config.gdims_dist[0] = gdims_dist[0];
-  config.gdims_dist[1] = gdims_dist[1];
-  config.gdims_dist[2] = gdims_dist[2];
-  config.transpose_axis_contiguous[0] = axis_contiguous[0];
-  config.transpose_axis_contiguous[1] = axis_contiguous[1];
-  config.transpose_axis_contiguous[2] = axis_contiguous[2];
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      config.transpose_mem_order[i][j] = mem_order[i * 3 + j];
+  std::vector<std::string> testcases;
+  if (!using_testfile) {
+    std::string arguments;
+    for (int i = 1;  i < argc; ++i) {
+      arguments += argv[i];
+      if (i < argc - 1) {
+        arguments += " ";
+      }
+    }
+    testcases.push_back(arguments);
+  } else {
+    testcases = read_testfile(testfile);
+  }
+
+  std::vector<std::string> failed_cases;
+  double t0 = MPI_Wtime();
+  if (using_testfile && rank == 0) printf("Running %d tests...\n", static_cast<int>(testcases.size()));
+  for (int i = 0; i < testcases.size(); ++i) {
+    if (using_testfile && rank == 0) printf("command: %s %s\n", argv[0], testcases[i].c_str());
+    int res = run_test(testcases[i], using_testfile);
+    CHECK_MPI_EXIT(MPI_Reduce((rank == 0) ? MPI_IN_PLACE: &res, &res, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD));
+    if (using_testfile && rank == 0) {
+      if (res != 0) {
+        printf(" FAILED\n");
+        failed_cases.push_back(testcases[i]);
+      } else {
+        printf(" PASSED\n");
+      }
+    }
+    CHECK_MPI_EXIT(MPI_Barrier(MPI_COMM_WORLD));
+    if (using_testfile && (i + 1) % 10 == 0) {
+      if (rank == 0) printf("Completed %d/%d tests, running time %f s\n", i + 1, static_cast<int>(testcases.size()), MPI_Wtime() - t0);
     }
   }
 
-  cudecompGridDescAutotuneOptions_t options;
-  CHECK_CUDECOMP_EXIT(cudecompGridDescAutotuneOptionsSetDefaults(&options));
-  options.halo_extents[0] = halo_extents[0];
-  options.halo_extents[1] = halo_extents[1];
-  options.halo_extents[2] = halo_extents[2];
-  options.halo_periods[0] = halo_periods[0];
-  options.halo_periods[1] = halo_periods[1];
-  options.halo_periods[2] = halo_periods[2];
-  options.halo_axis = axis;
-  options.dtype = get_cudecomp_datatype(real_t(0));
-  options.grid_mode = CUDECOMP_AUTOTUNE_GRID_HALO;
-
-  if (comm_backend != 0) {
-    config.halo_comm_backend = comm_backend;
-  } else {
-    options.autotune_halo_backend = true;
-  }
-
-  CHECK_CUDECOMP_EXIT(cudecompGridDescCreate(handle, &grid_desc, &config, &options));
-
-  if (rank == 0) {
-    printf("running on %d x %d process grid...\n", config.pdims[0], config.pdims[1]);
-    printf("running using %s halo backend...\n", cudecompHaloCommBackendToString(config.halo_comm_backend));
-  }
-
-  // Get pencil information
-  cudecompPencilInfo_t pinfo;
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, &pinfo, axis, halo_extents.data()));
-
-  // Get workspace size
-  int64_t workspace_num_elements;
-  CHECK_CUDECOMP_EXIT(
-      cudecompGetHaloWorkspaceSize(handle, grid_desc, axis, halo_extents.data(), &workspace_num_elements));
-
-  // Allocate data arrays
-  int64_t data_num_elements = pinfo.size;
-
-  std::vector<real_t> data(data_num_elements);
-
-  // Create reference data
-  std::vector<real_t> init(pinfo.size);
-  std::vector<real_t> ref(pinfo.size);
-
-  initialize_pencil(init, pinfo, gdims);
-  initialize_reference(ref, pinfo, gdims, halo_periods);
-
-  real_t *data_d, *work_d;
-  if (use_managed_memory) {
-    CHECK_CUDA_EXIT(cudaMallocManaged(&data_d, data.size() * sizeof(*data_d)));
-  } else {
-    CHECK_CUDA_EXIT(cudaMalloc(&data_d, data.size() * sizeof(*data_d)));
-  }
-  int64_t dtype_size;
-  CHECK_CUDECOMP_EXIT(cudecompGetDataTypeSize(get_cudecomp_datatype(real_t(0)), &dtype_size));
-  CHECK_CUDECOMP_EXIT(
-      cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work_d), workspace_num_elements * dtype_size));
-
-  // Running correctness tests
-  if (rank == 0) printf("running correctness tests...\n");
-  // Initialize data to initial pencil data
-  CHECK_CUDA_EXIT(cudaMemcpy(data_d, init.data(), init.size() * sizeof(*data_d), cudaMemcpyHostToDevice));
-
-  real_t* input = data_d;
-  for (int i = 0; i < 3; ++i) {
-    switch (axis) {
-    case 0:
-      CHECK_CUDECOMP_EXIT(cudecompUpdateHalosX(handle, grid_desc, input, work_d, get_cudecomp_datatype(real_t(0)),
-                                               pinfo.halo_extents, halo_periods.data(), i, 0));
-      break;
-    case 1:
-      CHECK_CUDECOMP_EXIT(cudecompUpdateHalosY(handle, grid_desc, input, work_d, get_cudecomp_datatype(real_t(0)),
-                                               pinfo.halo_extents, halo_periods.data(), i, 0));
-      break;
-    case 2:
-      CHECK_CUDECOMP_EXIT(cudecompUpdateHalosZ(handle, grid_desc, input, work_d, get_cudecomp_datatype(real_t(0)),
-                                               pinfo.halo_extents, halo_periods.data(), i, 0));
-      break;
+  int retcode = 0;
+  if (using_testfile) {
+    if (rank == 0) {
+      printf("Completed all tests, running time %f s,\n", MPI_Wtime() - t0);
+      if (failed_cases.size() == 0) {
+        printf("Passed all tests.\n");
+      } else {
+        printf("Failed %d/%d tests. Failing cases:\n", static_cast<int>(failed_cases.size()), static_cast<int>(testcases.size()));
+        for (int i = 0; i < failed_cases.size(); ++i) {
+          printf(" %s %s\n", argv[0], failed_cases[i].c_str());
+        }
+      }
     }
+    if (failed_cases.size() != 0) retcode = 1;
   }
 
-  CHECK_CUDA_EXIT(cudaMemcpy(data.data(), data_d, data.size() * sizeof(*data_d), cudaMemcpyDeviceToHost));
-  if (!compare_pencils(ref, data, pinfo)) {
-    printf("FAILED cudecompUpdateHalos\n");
-    exit(EXIT_FAILURE);
-  }
-
-  CHECK_CUDA_EXIT(cudaFree(data_d));
-  CHECK_CUDECOMP_EXIT(cudecompFree(handle, grid_desc, work_d));
-  CHECK_CUDECOMP_EXIT(cudecompGridDescDestroy(handle, grid_desc));
+  // Finalize
   CHECK_CUDECOMP_EXIT(cudecompFinalize(handle));
-
   CHECK_MPI_EXIT(MPI_Finalize());
+
+  return retcode;
+
 }

--- a/tests/cc/transpose_test.cc
+++ b/tests/cc/transpose_test.cc
@@ -336,7 +336,6 @@ static void cache_grid_desc(const cudecompGridDesc_t& grid_desc, cudecompTranspo
 }
 
 static int run_test(const std::string& arguments, bool silent) {
-
   try {
     transposeTestArgs args = parse_arguments(arguments);
 

--- a/tests/cc/transpose_test.cc
+++ b/tests/cc/transpose_test.cc
@@ -116,16 +116,18 @@ static bool compare_pencils(const std::vector<real_t>& ref, const std::vector<re
                             const cudecompPencilInfo_t& pinfo) {
   int64_t lx[3];
   for (int64_t i = 0; i < pinfo.size; ++i) {
-    // Compute pencil local coordinate
-    lx[0] = i % pinfo.shape[0];
-    lx[1] = i / pinfo.shape[0] % pinfo.shape[1];
-    lx[2] = i / (pinfo.shape[0] * pinfo.shape[1]);
+    if (ref[i] != res[i]) {
+      // Compute pencil local coordinate
+      lx[0] = i % pinfo.shape[0];
+      lx[1] = i / pinfo.shape[0] % pinfo.shape[1];
+      lx[2] = i / (pinfo.shape[0] * pinfo.shape[1]);
 
-    // Only compare values inside internal region
-    if (lx[0] >= pinfo.halo_extents[pinfo.order[0]] && lx[0] < (pinfo.shape[0] - pinfo.halo_extents[pinfo.order[0]]) &&
-        lx[1] >= pinfo.halo_extents[pinfo.order[1]] && lx[1] < (pinfo.shape[1] - pinfo.halo_extents[pinfo.order[1]]) &&
-        lx[2] >= pinfo.halo_extents[pinfo.order[2]] && lx[2] < (pinfo.shape[2] - pinfo.halo_extents[pinfo.order[2]])) {
-      if (std::abs(ref[i] - res[i]) != 0) return false;
+      // Only compare values inside internal region
+      if (lx[0] >= pinfo.halo_extents[pinfo.order[0]] && lx[0] < (pinfo.shape[0] - pinfo.halo_extents[pinfo.order[0]]) &&
+          lx[1] >= pinfo.halo_extents[pinfo.order[1]] && lx[1] < (pinfo.shape[1] - pinfo.halo_extents[pinfo.order[1]]) &&
+          lx[2] >= pinfo.halo_extents[pinfo.order[2]] && lx[2] < (pinfo.shape[2] - pinfo.halo_extents[pinfo.order[2]])) {
+        return false;
+      }
     }
   }
   return true;

--- a/tests/cc/transpose_test.cc
+++ b/tests/cc/transpose_test.cc
@@ -190,12 +190,8 @@ static void usage(const char* pname) {
           "\t\tY-dimension axis-contiguous pencils setting. (default: 0) \n"
           "\t--acz\n"
           "\t\tZ-dimension axis-contiguous pencils setting. (default: 0) \n"
-          "\t--gdx\n"
-          "\t\tX-dimension gdim_dist setting, set to gx - gdx. (default: 0) \n"
-          "\t--gdy\n"
-          "\t\tY-dimension gdim_dist setting, set to gy - gdy. (default: 0) \n"
-          "\t--gdz\n"
-          "\t\tZ-dimension gdim_dist setting, set to gz - gdz. (default: 0) \n"
+          "\t--gd\n"
+          "\t\t gdim_dist setting, set to g[i] - gd[i]. (default: 0 0 0) \n"
           "\t--hex\n"
           "\t\tX-pencil halo_extents setting. (default: 0 0 0) \n"
           "\t--hey\n"
@@ -248,9 +244,7 @@ static transposeTestArgs parse_arguments(const std::string& arguments) {
                                            {"acx", required_argument, 0, '1'},
                                            {"acy", required_argument, 0, '2'},
                                            {"acz", required_argument, 0, '3'},
-                                           {"gdx", required_argument, 0, '4'},
-                                           {"gdy", required_argument, 0, '5'},
-                                           {"gdz", required_argument, 0, '6'},
+                                           {"gd", required_argument, 0, '4'},
                                            {"hex", required_argument, 0, '7'},
                                            {"hey", required_argument, 0, '8'},
                                            {"hez", required_argument, 0, '9'},
@@ -261,7 +255,7 @@ static transposeTestArgs parse_arguments(const std::string& arguments) {
                                            {0, 0, 0, 0}};
 
     int option_index = 0;
-    int ch = getopt_long(argc, argv, "x:y:z:b:r:c:1:2:3:4:5:6:7:8:9:q:omh", long_options, &option_index);
+    int ch = getopt_long(argc, argv, "x:y:z:b:r:c:1:2:3:4:7:8:9:q:omh", long_options, &option_index);
     if (ch == -1) break;
 
     switch (ch) {
@@ -275,9 +269,13 @@ static transposeTestArgs parse_arguments(const std::string& arguments) {
     case '1': args.axis_contiguous[0] = atoi(optarg); break;
     case '2': args.axis_contiguous[1] = atoi(optarg); break;
     case '3': args.axis_contiguous[2] = atoi(optarg); break;
-    case '4': args.gdims_dist[0] = atoi(optarg); break;
-    case '5': args.gdims_dist[1] = atoi(optarg); break;
-    case '6': args.gdims_dist[2] = atoi(optarg); break;
+    case '4':
+      optind--;
+      for (int i = 0; i < 3; ++i) {
+        args.gdims_dist[i] = atoi(argv[optind]);
+        optind++;
+      }
+      break;
     case '7':
       optind--;
       for (int i = 0; i < 3; ++i) {

--- a/tests/fortran/CMakeLists.txt
+++ b/tests/fortran/CMakeLists.txt
@@ -41,6 +41,7 @@ foreach(tgt ${transpose_test_targets_f} ${halo_test_targets_f})
   target_link_libraries(${tgt} PUBLIC cudecomp_fort)
   target_compile_options(${tgt} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-cpp -cuda -gpu=${CUF_GPU_ARG}>)
   target_link_options(${tgt} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-cpp -cuda -gpu=${CUF_GPU_ARG}>)
+  target_compile_options(${tgt} PRIVATE -O3)
 endforeach()
 
 target_compile_definitions(transpose_test_R32_f PUBLIC R32)

--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -333,18 +333,15 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
           read(arg, *) iarg
           axis_contiguous(3) = iarg
           skip_count = 1
-        case('--gdx')
+        case('--gd')
           read(args(i+1), *) arg
           read(arg, *) gdims_dist(1)
           skip_count = 1
-        case('--gdy')
-          read(args(i+1), *) arg
-          read(arg, *) gdims_dist(2)
-          skip_count = 1
-        case('--gdz')
-          read(args(i+1), *) arg
-          read(arg, *) gdims_dist(3)
-          skip_count = 1
+          do j = 1, 3
+            read(args(i+j), *) arg
+            read(arg, *) gdims_dist(j)
+          enddo
+          skip_count = 3
         case('--hex')
           read(args(i+1), *) arg
           read(arg, *) halo_extents(1)

--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -27,7 +27,9 @@
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define CHECK_CUDECOMP_EXIT(f) if (f /= CUDECOMP_RESULT_SUCCESS) call exit(1)
+#define CHECK_CUDECOMP(f) if (f /= CUDECOMP_RESULT_SUCCESS) then; res = 1; return; endif
 #define CHECK_CUDA_EXIT(f) if (f /= cudaSuccess) call exit(1)
+#define CHECK_CUDA(f) if (f /= cudaSuccess) thenl res = 1; return; endif
 
 #ifdef R32
 #define ARRTYPE real(real32)
@@ -54,6 +56,15 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
 #endif
 
   use, intrinsic :: iso_fortran_env, only: real32, real64
+  use cudafor
+  use cudecomp
+  use mpi
+
+  type(cudecompHandle) :: handle
+  integer :: rank, nranks
+  type(cudecompGridDesc) :: grid_desc_cache(5)
+  logical :: grid_desc_cache_set(5) = .false.
+
   contains
   function compare_pencils(ref, res, pinfo) result(mismatch)
     use cudecomp
@@ -165,12 +176,336 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
     dst(1:count) = src(1:count)
 
   end subroutine flat_copy
+
+  subroutine read_testfile(filename, testcases)
+    implicit none
+    integer :: i, stat, ncases
+    character(len=*) :: filename
+    character(len=256), allocatable:: testcases(:)
+
+    ! Count number of cases in file
+    ncases = 0
+    open(42, file=trim(filename), status='old')
+    do while (1)
+      read(42, '(A)', iostat=stat)
+      if (stat < 0) exit
+      ncases = ncases + 1
+    enddo
+    close(42)
+
+    allocate(testcases(ncases))
+    open(42, file=trim(filename), status='old')
+    do i = 1, ncases
+      read(42, '(A)') testcases(i)(:)
+    enddo
+    close(42)
+
+  end subroutine read_testfile
+
+  subroutine cache_grid_desc(grid_desc, backend)
+    implicit none
+    type(cudecompGridDesc) :: grid_desc
+    integer :: backend
+
+    if (grid_desc_cache_set(backend)) then
+      CHECK_CUDECOMP_EXIT(cudecompGridDescDestroy(handle, grid_desc_cache(backend)))
+    endif
+
+    grid_desc_cache(backend) = grid_desc
+    grid_desc_cache_set(backend) = .true.
+  end subroutine cache_grid_desc
+
+  function run_test(arguments, silent) result(res)
+    implicit none
+
+    character(len=*) :: arguments
+    logical :: silent
+    integer :: res
+
+    ! Command line arguments
+    integer :: gx, gy, gz
+    integer :: comm_backend
+    logical :: axis_contiguous(3)
+    integer :: gdims_dist(3)
+    integer :: halo_extents(3)
+    logical :: halo_periods(3)
+    integer :: mem_order(3, 3)
+    logical :: use_managed_memory
+    integer :: pr, pc
+    integer :: axis
+
+    ! MPI
+    integer :: local_rank, ierr
+    integer :: local_comm
+
+    ! cudecomp
+    type(cudecompGridDescConfig) :: config
+    type(cudecompGridDescAutotuneOptions) :: options
+    type(cudecompGridDesc) :: grid_desc
+    type(cudecompPencilInfo) :: pinfo
+
+    integer :: pdims(2)
+    integer :: gdims(3)
+    integer(8) :: data_num_elements, workspace_num_elements
+
+    ! data
+    ARRTYPE, allocatable :: ref(:, :, :), init(:, :, :), data(:)
+    ARRTYPE, allocatable, device, target:: data_d(:)
+    ARRTYPE, allocatable, managed, target:: data_m(:)
+    ARRTYPE, pointer, device, contiguous :: work_d(:)
+    ARRTYPE, pointer, device:: input(:)
+    integer :: dtype = DTYPE
+
+    integer :: i, j, k, l, idt, iarg
+    integer :: skip_count, nspaces
+    character(len=16) :: arg
+    character(len=16), allocatable :: args(:)
+
+    res = 0
+
+    ! Split arguments string into list
+    nspaces = 0
+    do i = 1, len_trim(arguments)
+      if (arguments(i:i) == ' ') nspaces = nspaces + 1
+    enddo
+    allocate(args(nspaces + 1))
+    read(arguments, *) args(:)
+
+    ! Parse command-line arguments
+    gx = 256
+    gy = 256
+    gz = 256
+    pr = 0
+    pc = 0
+    comm_backend = 0
+    axis_contiguous(:) = .false.
+    gdims_dist(:) = 0
+    halo_extents(:) = 1
+    halo_periods(:) = .true.
+    axis = 1
+    use_managed_memory = .false.
+
+    skip_count = 0
+    do i = 1, size(args)
+      if (skip_count > 0) then
+        skip_count = skip_count - 1
+        cycle
+      end if
+      read(args(i), *) arg
+      select case(arg)
+        case('--gx')
+          read(args(i+1), *) arg
+          read(arg, *) gx
+          skip_count = 1
+        case('--gy')
+          read(args(i+1), *) arg
+          read(arg, *) gy
+          skip_count = 1
+        case('--gz')
+          read(args(i+1), *) arg
+          read(arg, *) gz
+          skip_count = 1
+        case('--backend')
+          read(args(i+1), *) arg
+          read(arg, *) comm_backend
+          skip_count = 1
+        case('--pr')
+          read(args(i+1), *) arg
+          read(arg, *) pr
+          skip_count = 1
+        case('--pc')
+          read(args(i+1), *) arg
+          read(arg, *) pc
+          skip_count = 1
+        case('--acx')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          axis_contiguous(1) = iarg
+          skip_count = 1
+        case('--acy')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          axis_contiguous(2) = iarg
+          skip_count = 1
+        case('--acz')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          axis_contiguous(3) = iarg
+          skip_count = 1
+        case('--gdx')
+          read(args(i+1), *) arg
+          read(arg, *) gdims_dist(1)
+          skip_count = 1
+        case('--gdy')
+          read(args(i+1), *) arg
+          read(arg, *) gdims_dist(2)
+          skip_count = 1
+        case('--gdz')
+          read(args(i+1), *) arg
+          read(arg, *) gdims_dist(3)
+          skip_count = 1
+        case('--hex')
+          read(args(i+1), *) arg
+          read(arg, *) halo_extents(1)
+          skip_count = 1
+        case('--hey')
+          read(args(i+1), *) arg
+          read(arg, *) halo_extents(2)
+          skip_count = 1
+        case('--hez')
+          read(args(i+1), *) arg
+          read(arg, *) halo_extents(3)
+          skip_count = 1
+        case('--hpx')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          halo_periods(1) = iarg
+          skip_count = 1
+        case('--hpy')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          halo_periods(2) = iarg
+          skip_count = 1
+        case('--hpz')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          halo_periods(3) = iarg
+          skip_count = 1
+        case('--ax')
+          read(args(i+1), *) arg
+          read(arg, *) axis
+          skip_count = 1
+        case('--mem_order')
+          l = 1
+          do j = 1, 3
+            do k = 1, 3
+              read(args(i+l), *) arg
+              read(arg, *) mem_order(k, j)
+              l = l + 1
+            enddo
+          enddo
+          skip_count = 9
+        case('-m')
+          use_managed_memory = .true.
+        case(' ')
+          skip_count = 1
+        case default
+          print*, "Unknown argument."
+          call exit(1)
+      end select
+    end do
+
+    ! Finish setting up gdim_dist
+    gdims_dist(1) = gx - gdims_dist(1)
+    gdims_dist(2) = gy - gdims_dist(2)
+    gdims_dist(3) = gz - gdims_dist(3)
+
+    pdims(1) = pr
+    pdims(2) = pc
+
+    if (.not. silent .and. rank == 0) then
+       write(*,"('Running on ', i0, ' x ', i0, ' x ', i0, ' spatial grid ...')") gx, gy, gz
+    end if
+
+    ! Setup grid descriptor
+    CHECK_CUDECOMP(cudecompGridDescConfigSetDefaults(config))
+    config%pdims = pdims
+    gdims = [gx, gy, gz]
+    config%gdims = gdims
+    config%gdims_dist = gdims_dist
+    config%transpose_axis_contiguous = axis_contiguous
+    config%transpose_mem_order = mem_order
+
+    CHECK_CUDECOMP(cudecompGridDescAutotuneOptionsSetDefaults(options))
+    options%halo_extents = halo_extents
+    options%halo_periods = halo_periods
+    options%halo_axis = axis
+    options%dtype = dtype
+    options%grid_mode = CUDECOMP_AUTOTUNE_GRID_HALO
+
+    if (comm_backend /= 0) then
+      config%halo_comm_backend = comm_backend
+    else
+      options%autotune_halo_backend = .true.
+    endif
+
+    CHECK_CUDECOMP(cudecompGridDescCreate(handle, grid_desc, config, options))
+    call cache_grid_desc(grid_desc, config%halo_comm_backend)
+
+    if (.not. silent .and. rank == 0) then
+       write(*,"('running on ', i0, ' x ', i0, ' process grid ...')") config%pdims(1), config%pdims(2)
+       write(*,"('running using ', a, ' halo backend ...')") &
+                 cudecompHaloCommBackendToString(config%halo_comm_backend)
+    endif
+
+    ! Get pencil information
+    CHECK_CUDECOMP(cudecompGetPencilInfo(handle, grid_desc, pinfo, axis, halo_extents))
+
+    ! Get workspace size
+    CHECK_CUDECOMP(cudecompGetHaloWorkspaceSize(handle, grid_desc, axis, halo_extents, workspace_num_elements))
+
+    ! Allocate data arrays
+    data_num_elements = pinfo%size
+    allocate(data(data_num_elements))
+
+    ! Create reference data
+    call initialize_pencil(init, pinfo, gdims)
+    call initialize_reference(ref, pinfo, gdims, halo_periods)
+
+    if (use_managed_memory) then
+      allocate(data_m(data_num_elements))
+    else
+      allocate(data_d(data_num_elements))
+    endif
+    CHECK_CUDECOMP(cudecompMalloc(handle, grid_desc, work_d, workspace_num_elements))
+
+    ! Running correctness tests
+    if (.not. silent .and. rank == 0) write(*,"('Running correctness tests using ', a, ' backend ...')") &
+                           cudecompHaloCommBackendToString(config%halo_comm_backend)
+
+    ! Initialize data to initial pencil data
+    if (use_managed_memory) then
+      call flat_copy(init, data_m, pinfo%size)
+    else
+      call flat_copy(init, data_d, pinfo%size)
+    endif
+
+    if (use_managed_memory) then
+      input => data_m
+    else
+      input => data_d
+    endif
+
+    do i = 1, 3
+      select case(axis)
+        case(1)
+          CHECK_CUDECOMP(cudecompUpdateHalosX(handle, grid_desc, input, work_d, dtype, pinfo%halo_extents, halo_periods, i))
+        case(2)
+          CHECK_CUDECOMP(cudecompUpdateHalosY(handle, grid_desc, input, work_d, dtype, pinfo%halo_extents, halo_periods, i))
+        case(3)
+          CHECK_CUDECOMP(cudecompUpdateHalosZ(handle, grid_desc, input, work_d, dtype, pinfo%halo_extents, halo_periods, i))
+      end select
+    end do
+
+    data = input
+    if (compare_pencils(ref, data, pinfo)) then
+      print*, "FAILED cudecompUpdateHalos"
+      res = 1
+      return
+    endif
+
+    if (use_managed_memory) then
+      deallocate(data_m)
+    else
+      deallocate(data_d)
+    endif
+
+    CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work_d))
+
+  end function
 end module
 
 program main
-  use cudafor
-  use mpi
-  use cudecomp
   use, intrinsic :: iso_fortran_env, only: real32, real64
 
 #ifdef R32
@@ -191,44 +526,18 @@ program main
 
   implicit none
 
-  ! Command line arguments
-  integer :: gx, gy, gz
-  integer :: comm_backend
-  logical :: axis_contiguous(3)
-  integer :: gdims_dist(3)
-  integer :: halo_extents(3)
-  logical :: halo_periods(3)
-  integer :: mem_order(3, 3)
-  logical :: use_managed_memory
-  integer :: pr, pc
-  integer :: axis
-
-  ! MPI
-  integer :: rank, local_rank, nranks, ierr
+  integer :: i, idx
+  real(real64) :: t0
+  integer :: local_rank, ierr
   integer :: local_comm
-
-  ! cudecomp
-  type(cudecompHandle) :: handle
-  type(cudecompGridDescConfig) :: config
-  type(cudecompGridDescAutotuneOptions) :: options
-  type(cudecompGridDesc) :: grid_desc
-  type(cudecompPencilInfo) :: pinfo
-
-  integer :: pdims(2)
-  integer :: gdims(3)
-  integer(8) :: data_num_elements, workspace_num_elements
-
-  ! data
-  ARRTYPE, allocatable :: ref(:, :, :), init(:, :, :), data(:)
-  ARRTYPE, allocatable, device, target:: data_d(:)
-  ARRTYPE, allocatable, managed, target:: data_m(:)
-  ARRTYPE, pointer, device, contiguous :: work_d(:)
-  ARRTYPE, pointer, device:: input(:)
-  integer :: dtype = DTYPE
-
-  integer :: i, j, k, l, idt, iarg
-  integer :: skip_count
+  integer :: res, retcode
+  logical :: using_testfile
   character(len=16) :: arg
+  character(len=32) :: binname
+  character(len=256) :: testfile
+  character(len=256), allocatable:: testcases(:)
+  integer :: nfailed
+  character(len=256), allocatable:: failed_cases(:)
 
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
@@ -238,239 +547,83 @@ program main
   call MPI_Comm_rank(local_comm, local_rank, ierr)
   CHECK_CUDA_EXIT(cudaSetDevice(local_rank))
 
-  ! Parse command-line arguments
-  gx = 256
-  gy = 256
-  gz = 256
-  pr = 0
-  pc = 0
-  comm_backend = 0
-  axis_contiguous(:) = .false.
-  gdims_dist(:) = 0
-  halo_extents(:) = 1
-  halo_periods(:) = .true.
-  axis = 1
-  use_managed_memory = .false.
-
-  skip_count = 0
+  using_testfile = .false.
   do i = 1, command_argument_count()
-    if (skip_count > 0) then
-      skip_count = skip_count - 1
-      cycle
-    end if
     call get_command_argument(i, arg)
-    select case(arg)
-      case('--gx')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gx
-        skip_count = 1
-      case('--gy')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gy
-        skip_count = 1
-      case('--gz')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gz
-        skip_count = 1
-      case('--backend')
-        call get_command_argument(i+1, arg)
-        read(arg, *) comm_backend
-        skip_count = 1
-      case('--pr')
-        call get_command_argument(i+1, arg)
-        read(arg, *) pr
-        skip_count = 1
-      case('--pc')
-        call get_command_argument(i+1, arg)
-        read(arg, *) pc
-        skip_count = 1
-      case('--acx')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        axis_contiguous(1) = iarg
-        skip_count = 1
-      case('--acy')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        axis_contiguous(2) = iarg
-        skip_count = 1
-      case('--acz')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        axis_contiguous(3) = iarg
-        skip_count = 1
-      case('--gdx')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gdims_dist(1)
-        skip_count = 1
-      case('--gdy')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gdims_dist(2)
-        skip_count = 1
-      case('--gdz')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gdims_dist(3)
-        skip_count = 1
-      case('--hex')
-        call get_command_argument(i+1, arg)
-        read(arg, *) halo_extents(1)
-        skip_count = 1
-      case('--hey')
-        call get_command_argument(i+1, arg)
-        read(arg, *) halo_extents(2)
-        skip_count = 1
-      case('--hez')
-        call get_command_argument(i+1, arg)
-        read(arg, *) halo_extents(3)
-        skip_count = 1
-      case('--hpx')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        halo_periods(1) = iarg
-        skip_count = 1
-      case('--hpy')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        halo_periods(2) = iarg
-        skip_count = 1
-      case('--hpz')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        halo_periods(3) = iarg
-        skip_count = 1
-      case('--ax')
-        call get_command_argument(i+1, arg)
-        read(arg, *) axis
-        skip_count = 1
-      case('--mem_order')
-        l = 1
-        do j = 1, 3
-          do k = 1, 3
-            call get_command_argument(i+l, arg)
-            read(arg, *) mem_order(k, j)
-            l = l + 1
-          enddo
-        enddo
-        skip_count = 9
-      case('-m')
-        use_managed_memory = .true.
-      case(' ')
-        skip_count = 1
-      case default
-        print*, "Unknown argument."
-        call exit(1)
-    end select
-  end do
-
-  ! Finish setting up gdim_dist
-  gdims_dist(1) = gx - gdims_dist(1)
-  gdims_dist(2) = gy - gdims_dist(2)
-  gdims_dist(3) = gz - gdims_dist(3)
-
-  pdims(1) = pr
-  pdims(2) = pc
-
-  if (rank == 0) then
-     write(*,"('Running on ', i0, ' x ', i0, ' x ', i0, ' spatial grid ...')") gx, gy, gz
-  end if
+    if (arg == "--testfile") then
+      call get_command_argument(i+1, testfile)
+      using_testfile = .true.
+      exit
+    endif
+  enddo
 
   ! Initialize cuDecomp
   CHECK_CUDECOMP_EXIT(cudecompInit(handle, MPI_COMM_WORLD))
 
-  ! Setup grid descriptor
-  CHECK_CUDECOMP_EXIT(cudecompGridDescConfigSetDefaults(config))
-  config%pdims = pdims
-  gdims = [gx, gy, gz]
-  config%gdims = gdims
-  config%gdims_dist = gdims_dist
-  config%transpose_axis_contiguous = axis_contiguous
-  config%transpose_mem_order = mem_order
-
-  CHECK_CUDECOMP_EXIT(cudecompGridDescAutotuneOptionsSetDefaults(options))
-  options%halo_extents = halo_extents
-  options%halo_periods = halo_periods
-  options%halo_axis = axis
-  options%dtype = dtype
-  options%grid_mode = CUDECOMP_AUTOTUNE_GRID_HALO
-
-  if (comm_backend /= 0) then
-    config%halo_comm_backend = comm_backend
+  if (.not. using_testfile) then
+    allocate(testcases(1))
+    testcases(1)(:) = ' '
+    idx = 1
+    do i = 1, command_argument_count()
+      call get_command_argument(i, arg)
+      testcases(1)(idx:idx+len_trim(arg)) = trim(arg)
+      idx = idx + len_trim(arg) + 1
+    enddo
   else
-    options%autotune_halo_backend = .true.
+    call read_testfile(testfile, testcases)
   endif
 
-  CHECK_CUDECOMP_EXIT(cudecompGridDescCreate(handle, grid_desc, config, options))
 
-  if (rank == 0) then
-     write(*,"('running on ', i0, ' x ', i0, ' process grid ...')") config%pdims(1), config%pdims(2)
-     write(*,"('running using ', a, ' halo backend ...')") &
-               cudecompHaloCommBackendToString(config%halo_comm_backend)
+  nfailed = 0
+  allocate(failed_cases(size(testcases)))
+
+  t0 = MPI_Wtime()
+  if (using_testfile .and. rank == 0) write(*,"('Running ', i0, ' tests...')"), size(testcases)
+  call get_command_argument(0, binname)
+  do i = 1, size(testcases)
+    if (using_testfile .and. rank == 0) write(*, "('command: ', A, ' ', A)"), trim(binname), trim(testcases(i))
+
+    res = run_test(testcases(i), using_testfile)
+    if (rank == 0) then
+      call MPI_Reduce(MPI_IN_PLACE, res, 1, MPI_INTEGER, MPI_MAX, 0, MPI_COMM_WORLD, ierr)
+    else
+      call MPI_Reduce(res, res, 1, MPI_INTEGER, MPI_MAX, 0, MPI_COMM_WORLD, ierr)
+    endif
+    if (using_testfile .and. rank == 0) then
+      if (res /= 0) then
+        print*, "FAILED"
+        nfailed = nfailed + 1
+        failed_cases(nfailed)(:) = testcases(i)(:)
+      else
+        print*, "PASSED"
+      endif
+    endif
+    call MPI_Barrier(MPI_COMM_WORLD, ierr)
+    if (using_testfile .and. mod(i, 10) == 0) then
+      if (rank == 0) then
+        write(*, "('Completed ', i0, '/', i0, ' tests, running time ', f0.8, 's')"), i, size(testcases), MPI_Wtime() - t0
+      endif
+    endif
+  enddo
+
+  retcode = 0
+  if (using_testfile) then
+    if (rank == 0) then
+      write(*, "('Completed all tests, running time ', f0.8, ' s')"), MPI_Wtime() - t0
+      if (nfailed == 0) then
+        write(*, "(A)"), "Passed all tests."
+      else
+        write(*, "('Failed ', i0, '/', i0, ' tests. Failing cases:')"), nfailed, size(testcases)
+        do i = 1, nfailed
+          write(*, "(A, ' ', A)"), trim(binname), trim(failed_cases(i))
+        enddo
+      endif
+    endif
+    if (nfailed /= 0) retcode = 1;
   endif
 
-  ! Get pencil information
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo, axis, halo_extents))
-
-  ! Get workspace size
-  CHECK_CUDECOMP_EXIT(cudecompGetHaloWorkspaceSize(handle, grid_desc, axis, halo_extents, workspace_num_elements))
-
-  ! Allocate data arrays
-  data_num_elements = pinfo%size
-  allocate(data(data_num_elements))
-
-  ! Create reference data
-  call initialize_pencil(init, pinfo, gdims)
-  call initialize_reference(ref, pinfo, gdims, halo_periods)
-
-  if (use_managed_memory) then
-    allocate(data_m(data_num_elements))
-  else
-    allocate(data_d(data_num_elements))
-  endif
-  CHECK_CUDECOMP_EXIT(cudecompMalloc(handle, grid_desc, work_d, workspace_num_elements))
-
-  ! Running correctness tests
-  if (rank == 0) write(*,"('Running correctness tests using ', a, ' backend ...')") &
-                         cudecompHaloCommBackendToString(config%halo_comm_backend)
-
-  ! Initialize data to initial pencil data
-  if (use_managed_memory) then
-    call flat_copy(init, data_m, pinfo%size)
-  else
-    call flat_copy(init, data_d, pinfo%size)
-  endif
-
-  if (use_managed_memory) then
-    input => data_m
-  else
-    input => data_d
-  endif
-
-  do i = 1, 3
-    select case(axis)
-      case(1)
-        CHECK_CUDECOMP_EXIT(cudecompUpdateHalosX(handle, grid_desc, input, work_d, dtype, pinfo%halo_extents, halo_periods, i))
-      case(2)
-        CHECK_CUDECOMP_EXIT(cudecompUpdateHalosY(handle, grid_desc, input, work_d, dtype, pinfo%halo_extents, halo_periods, i))
-      case(3)
-        CHECK_CUDECOMP_EXIT(cudecompUpdateHalosZ(handle, grid_desc, input, work_d, dtype, pinfo%halo_extents, halo_periods, i))
-    end select
-  end do
-
-  data = input
-  if (compare_pencils(ref, data, pinfo)) then
-    print*, "FAILED cudecompUpdateHalos"
-    call exit(1)
-  endif
-
-  if (use_managed_memory) then
-    deallocate(data_m)
-  else
-    deallocate(data_d)
-  endif
-  CHECK_CUDECOMP_EXIT(cudecompFree(handle, grid_desc, work_d))
-  CHECK_CUDECOMP_EXIT(cudecompGridDescDestroy(handle, grid_desc))
   CHECK_CUDECOMP_EXIT(cudecompFinalize(handle))
-
   call MPI_Finalize(ierr)
 
+  call exit(retcode)
 end program main

--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -531,7 +531,7 @@ program main
   integer :: res, retcode
   logical :: using_testfile
   character(len=16) :: arg
-  character(len=32) :: binname
+  character(len=256) :: binname
   character(len=256) :: testfile
   character(len=256), allocatable:: testcases(:)
   integer :: nfailed

--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -282,6 +282,7 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
     gdims_dist(:) = 0
     halo_extents(:) = 1
     halo_periods(:) = .true.
+    mem_order(:, :) = -1
     axis = 1
     use_managed_memory = .false.
 

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -213,8 +213,12 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
     do i = 1, len_trim(arguments)
       if (arguments(i:i) == ' ') nspaces = nspaces + 1
     enddo
-    allocate(args(nspaces + 1))
-    read(arguments, *) args(:)
+    if (nspaces >= 1) then
+      allocate(args(nspaces + 1))
+      read(arguments, *) args(:)
+    else
+      allocate(args(0))
+    endif
 
     ! Parse command-line arguments
     gx = 256
@@ -279,18 +283,12 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
           read(arg, *) iarg
           axis_contiguous(3) = iarg
           skip_count = 1
-        case('--gdx')
-          read(args(i+1), *) arg
-          read(arg, *) gdims_dist(1)
-          skip_count = 1
-        case('--gdy')
-          read(args(i+1), *) arg
-          read(arg, *) gdims_dist(2)
-          skip_count = 1
-        case('--gdz')
-          read(args(i+1), *) arg
-          read(arg, *) gdims_dist(3)
-          skip_count = 1
+        case('--gd')
+          do j = 1, 3
+            read(args(i+j), *) arg
+            read(arg, *) gdims_dist(j)
+          enddo
+          skip_count = 3
         case('--hex')
           do j = 1, 3
             read(args(i+j), *) arg

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -27,7 +27,9 @@
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define CHECK_CUDECOMP_EXIT(f) if (f /= CUDECOMP_RESULT_SUCCESS) call exit(1)
+#define CHECK_CUDECOMP(f) if (f /= CUDECOMP_RESULT_SUCCESS) then; res = 1; return; endif
 #define CHECK_CUDA_EXIT(f) if (f /= cudaSuccess) call exit(1)
+#define CHECK_CUDA(f) if (f /= cudaSuccess) thenl res = 1; return; endif
 
 #ifdef R32
 #define ARRTYPE real(real32)
@@ -54,9 +56,17 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
 #endif
 
   use, intrinsic :: iso_fortran_env, only: real32, real64
+  use cudafor
+  use cudecomp
+  use mpi
+
+  type(cudecompHandle) :: handle
+  integer :: rank, nranks
+  type(cudecompGridDesc) :: grid_desc_cache(7)
+  logical :: grid_desc_cache_set(7) = .false.
+
   contains
   function compare_pencils(ref, res, pinfo) result(mismatch)
-    use cudecomp
     implicit none
     type(cudecompPencilInfo) :: pinfo
     ARRTYPE :: ref(pinfo%lo(1) - pinfo%halo_extents(pinfo%order(1)): pinfo%hi(1) + pinfo%halo_extents(pinfo%order(1)), &
@@ -72,7 +82,6 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
   end function compare_pencils
 
   subroutine initialize_pencil(ref, pinfo, gdims)
-    use cudecomp
     implicit none
     ARRTYPE, allocatable :: ref(:,:,:)
 
@@ -100,9 +109,9 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
           ! Set reference to global linear index
           ref(i,j,k) = gx(1) + gdims(1) * ((gx(2) - 1) + (gx(3) - 1) * gdims(2))
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
   end subroutine initialize_pencil
 
   subroutine flat_copy(src, dst, count)
@@ -114,12 +123,390 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
     dst(1:count) = src(1:count)
 
   end subroutine flat_copy
+
+  subroutine read_testfile(filename, testcases)
+    implicit none
+    integer :: i, stat, ncases
+    character(len=*) :: filename
+    character(len=256), allocatable:: testcases(:)
+
+    ! Count number of cases in file
+    ncases = 0
+    open(42, file=trim(filename), status='old')
+    do while (1)
+      read(42, '(A)', iostat=stat)
+      if (stat < 0) exit
+      ncases = ncases + 1
+    enddo
+    close(42)
+
+    allocate(testcases(ncases))
+    open(42, file=trim(filename), status='old')
+    do i = 1, ncases
+      read(42, '(A)') testcases(i)(:)
+    enddo
+    close(42)
+
+  end subroutine read_testfile
+
+  subroutine cache_grid_desc(grid_desc, backend)
+    implicit none
+    type(cudecompGridDesc) :: grid_desc
+    integer :: backend
+
+    if (grid_desc_cache_set(backend)) then
+      CHECK_CUDECOMP_EXIT(cudecompGridDescDestroy(handle, grid_desc_cache(backend)))
+    endif
+
+    grid_desc_cache(backend) = grid_desc
+    grid_desc_cache_set(backend) = .true.
+  end subroutine cache_grid_desc
+
+  function run_test(arguments, silent) result(res)
+    implicit none
+
+    character(len=*) :: arguments
+    logical :: silent
+    integer :: res
+
+    ! Command line arguments
+    integer :: gx, gy, gz
+    integer :: comm_backend
+    logical :: axis_contiguous(3)
+    integer :: gdims_dist(3)
+    integer :: halo_extents_x(3), halo_extents_y(3), halo_extents_z(3)
+    integer :: mem_order(3, 3)
+    logical :: out_of_place, use_managed_memory
+    integer :: pr, pc
+
+    ! MPI
+    integer :: local_rank, nranks, ierr
+    integer :: local_comm
+
+    ! cudecomp
+    type(cudecompGridDescConfig) :: config
+    type(cudecompGridDescAutotuneOptions) :: options
+    type(cudecompGridDesc) :: grid_desc
+    type(cudecompPencilInfo) :: pinfo_x, pinfo_y, pinfo_z
+
+    integer :: pdims(2)
+    integer :: gdims(3)
+    integer(8) :: data_num_elements, workspace_num_elements
+
+    ! data
+    ARRTYPE, allocatable :: xref(:, :, :), yref(:, :, :), zref(:, :, :), data(:)
+    ARRTYPE, allocatable, device, target:: data_d(:), data_2_d(:)
+    ARRTYPE, allocatable, managed, target:: data_m(:), data_2_m(:)
+    ARRTYPE, pointer, device, contiguous :: work_d(:)
+    ARRTYPE, pointer, device:: input(:), output(:)
+    integer :: dtype = DTYPE
+
+    integer :: i, j, k, l, idt, iarg
+    integer :: skip_count, nspaces
+    character(len=16) :: arg
+    character(len=16), allocatable :: args(:)
+
+    real(8) :: t0
+
+    res = 0
+
+    ! Split arguments string into list
+    nspaces = 0
+    do i = 1, len_trim(arguments)
+      if (arguments(i:i) == ' ') nspaces = nspaces + 1
+    enddo
+    allocate(args(nspaces + 1))
+    read(arguments, *) args(:)
+
+    ! Parse command-line arguments
+    gx = 256
+    gy = 256
+    gz = 256
+    pr = 0
+    pc = 0
+    comm_backend = 0
+    axis_contiguous(:) = .false.
+    gdims_dist(:) = 0
+    halo_extents_x(:) = 0
+    halo_extents_y(:) = 0
+    halo_extents_z(:) = 0
+    mem_order(:,:) = -1
+    out_of_place = .false.
+    use_managed_memory = .false.
+
+    skip_count = 0
+    do i = 1, size(args)
+      if (skip_count > 0) then
+        skip_count = skip_count - 1
+        cycle
+      endif
+      read(args(i), *) arg
+      select case(arg)
+        case('--gx')
+          read(args(i+1), *) arg
+          read(arg, *) gx
+          skip_count = 1
+        case('--gy')
+          read(args(i+1), *) arg
+          read(arg, *) gy
+          skip_count = 1
+        case('--gz')
+          read(args(i+1), *) arg
+          read(arg, *) gz
+          skip_count = 1
+        case('--backend')
+          read(args(i+1), *) arg
+          read(arg, *) comm_backend
+          skip_count = 1
+        case('--pr')
+          read(args(i+1), *) arg
+          read(arg, *) pr
+          skip_count = 1
+        case('--pc')
+          read(args(i+1), *) arg
+          read(arg, *) pc
+          skip_count = 1
+        case('--acx')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          axis_contiguous(1) = iarg
+          skip_count = 1
+        case('--acy')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          axis_contiguous(2) = iarg
+          skip_count = 1
+        case('--acz')
+          read(args(i+1), *) arg
+          read(arg, *) iarg
+          axis_contiguous(3) = iarg
+          skip_count = 1
+        case('--gdx')
+          read(args(i+1), *) arg
+          read(arg, *) gdims_dist(1)
+          skip_count = 1
+        case('--gdy')
+          read(args(i+1), *) arg
+          read(arg, *) gdims_dist(2)
+          skip_count = 1
+        case('--gdz')
+          read(args(i+1), *) arg
+          read(arg, *) gdims_dist(3)
+          skip_count = 1
+        case('--hex')
+          do j = 1, 3
+            read(args(i+j), *) arg
+            read(arg, *) halo_extents_x(j)
+          enddo
+          skip_count = 3
+        case('--hey')
+          do j = 1, 3
+            read(args(i+j), *) arg
+            read(arg, *) halo_extents_y(j)
+          enddo
+          skip_count = 3
+        case('--hez')
+          do j = 1, 3
+            read(args(i+j), *) arg
+            read(arg, *) halo_extents_z(j)
+          enddo
+          skip_count = 3
+        case('--mem_order')
+          l = 1
+          do j = 1, 3
+            do k = 1, 3
+              read(args(i+l), *) arg
+              read(arg, *) mem_order(k, j)
+              l = l + 1
+            enddo
+          enddo
+          skip_count = 9
+        case('-o')
+          out_of_place = .true.
+        case('-m')
+          use_managed_memory = .true.
+        case(' ')
+          skip_count = 1
+        case default
+          print*, "Unknown argument."
+          call exit(1)
+      end select
+    enddo
+
+    ! Finish setting up gdim_dist
+    gdims_dist(1) = gx - gdims_dist(1)
+    gdims_dist(2) = gy - gdims_dist(2)
+    gdims_dist(3) = gz - gdims_dist(3)
+
+    pdims(1) = pr
+    pdims(2) = pc
+
+    if (.not. silent .and. rank == 0) then
+       write(*,"('running on ', i0, ' x ', i0, ' x ', i0, ' spatial grid ...')") gx, gy, gz
+    endif
+
+    ! Setup grid descriptor
+    CHECK_CUDECOMP(cudecompGridDescConfigSetDefaults(config))
+    config%pdims = pdims
+    gdims = [gx, gy, gz]
+    config%gdims = gdims
+    config%gdims_dist = gdims_dist
+    config%transpose_axis_contiguous = axis_contiguous
+    config%transpose_mem_order = mem_order
+
+    CHECK_CUDECOMP(cudecompGridDescAutotuneOptionsSetDefaults(options))
+    options%dtype = dtype
+    options%transpose_use_inplace_buffers = .not. out_of_place
+
+    if (comm_backend /= 0) then
+      config%transpose_comm_backend = comm_backend
+    else
+      options%autotune_transpose_backend = .true.
+    endif
+
+    CHECK_CUDECOMP(cudecompGridDescCreate(handle, grid_desc, config, options))
+    call cache_grid_desc(grid_desc, config%transpose_comm_backend)
+
+    if (.not. silent .and. rank == 0) then
+       write(*,"('running on ', i0, ' x ', i0, ' process grid ...')") config%pdims(1), config%pdims(2)
+       write(*,"('running using ', a, ' transpose backend ...')") &
+                 cudecompTransposeCommBackendToString(config%transpose_comm_backend)
+    endif
+
+    ! Get x-pencil information
+    CHECK_CUDECOMP(cudecompGetPencilInfo(handle, grid_desc, pinfo_x, 1, halo_extents_x))
+
+    ! Get y-pencil information
+    CHECK_CUDECOMP(cudecompGetPencilInfo(handle, grid_desc, pinfo_y, 2, halo_extents_y))
+
+    ! Get z-pencil information
+    CHECK_CUDECOMP(cudecompGetPencilInfo(handle, grid_desc, pinfo_z, 3, halo_extents_z))
+
+    ! Get workspace size
+    CHECK_CUDECOMP(cudecompGetTransposeWorkspaceSize(handle, grid_desc, workspace_num_elements))
+
+    ! Allocate data arrays
+    data_num_elements = max(pinfo_x%size, pinfo_y%size, pinfo_z%size)
+    allocate(data(data_num_elements))
+
+    ! Create reference data
+    call initialize_pencil(xref, pinfo_x, gdims)
+    call initialize_pencil(yref, pinfo_y, gdims)
+    call initialize_pencil(zref, pinfo_z, gdims)
+
+    if (use_managed_memory) then
+      allocate(data_m(data_num_elements))
+    else
+      allocate(data_d(data_num_elements))
+    endif
+    CHECK_CUDECOMP(cudecompMalloc(handle, grid_desc, work_d, workspace_num_elements))
+    if (out_of_place) then
+      if (use_managed_memory) then
+        allocate(data_2_m(data_num_elements))
+      else
+        allocate(data_2_d(data_num_elements))
+      endif
+    endif
+
+    ! Running correctness tests
+    if (.not. silent .and. rank == 0) write(*,"('running correctness tests...')")
+
+    ! Initialize data to reference x-pencil data
+    if (use_managed_memory) then
+      call flat_copy(xref, data_m, pinfo_x%size)
+    else
+      call flat_copy(xref, data_d, pinfo_x%size)
+    endif
+
+    if (use_managed_memory) then
+      input => data_m
+      output => data_m
+      if (out_of_place) output => data_2_m
+    else
+      input => data_d
+      output => data_d
+      if (out_of_place) output => data_2_d
+    endif
+
+    work_d = 0
+    CHECK_CUDECOMP(cudecompTransposeXToY(handle, grid_desc, input, output, work_d, dtype, pinfo_x%halo_extents, pinfo_y%halo_extents))
+    data = output
+    if (compare_pencils(yref, data, pinfo_y)) then
+      print*, "FAILED cudecompTranposeXToY"
+      res = 1
+      return
+    endif
+
+    if (out_of_place) then
+      if (use_managed_memory) then
+        output => data_m
+        input => data_2_m
+      else
+        output => data_d
+        input => data_2_d
+      endif
+    endif
+
+    work_d = 0
+    CHECK_CUDECOMP(cudecompTransposeYToZ(handle, grid_desc, input, output, work_d, dtype, pinfo_y%halo_extents, pinfo_z%halo_extents))
+    data = output
+    if (compare_pencils(zref, data, pinfo_z)) then
+      print*, "FAILED cudecompTranposeYToZ"
+      res = 1
+      return
+    endif
+
+    if (out_of_place) then
+      if (use_managed_memory) then
+        output => data_2_m
+        input => data_m
+      else
+        output => data_2_d
+        input => data_d
+      endif
+    endif
+
+    work_d = 0
+    CHECK_CUDECOMP(cudecompTransposeZToY(handle, grid_desc, input, output, work_d, dtype, pinfo_z%halo_extents, pinfo_y%halo_extents))
+    data = output
+    if (compare_pencils(yref, data, pinfo_y)) then
+      print*, "FAILED cudecompTranposeZToY"
+      res = 1
+      return
+    endif
+
+    if (out_of_place) then
+      if (use_managed_memory) then
+        output => data_m
+        input => data_2_m
+      else
+        output => data_d
+        input => data_2_d
+      endif
+    endif
+
+    work_d = 0
+    CHECK_CUDECOMP(cudecompTransposeYToX(handle, grid_desc, input, output, work_d, dtype, pinfo_y%halo_extents, pinfo_x%halo_extents))
+    data = output
+    if (compare_pencils(xref, data, pinfo_x)) then
+      print*, "FAILED cudecompTranposeYToX"
+      res = 1
+      return
+    endif
+
+    if (use_managed_memory) then
+      deallocate(data_m)
+      if (out_of_place) deallocate(data_2_m)
+    else
+      deallocate(data_d)
+      if (out_of_place) deallocate(data_2_d)
+    endif
+    CHECK_CUDECOMP(cudecompFree(handle, grid_desc, work_d))
+
+  end function run_test
 end module
 
 program main
-  use cudafor
-  use mpi
-  use cudecomp
   use, intrinsic :: iso_fortran_env, only: real32, real64
 
 #ifdef R32
@@ -140,42 +527,18 @@ program main
 
   implicit none
 
-  ! Command line arguments
-  integer :: gx, gy, gz
-  integer :: comm_backend
-  logical :: axis_contiguous(3)
-  integer :: gdims_dist(3)
-  integer :: halo_extents_x(3), halo_extents_y(3), halo_extents_z(3)
-  integer :: mem_order(3, 3)
-  logical :: out_of_place, use_managed_memory
-  integer :: pr, pc
-
-  ! MPI
-  integer :: rank, local_rank, nranks, ierr
+  integer :: i, idx
+  real(real64) :: t0
+  integer :: local_rank, ierr
   integer :: local_comm
-
-  ! cudecomp
-  type(cudecompHandle) :: handle
-  type(cudecompGridDescConfig) :: config
-  type(cudecompGridDescAutotuneOptions) :: options
-  type(cudecompGridDesc) :: grid_desc
-  type(cudecompPencilInfo) :: pinfo_x, pinfo_y, pinfo_z
-
-  integer :: pdims(2)
-  integer :: gdims(3)
-  integer(8) :: data_num_elements, workspace_num_elements
-
-  ! data
-  ARRTYPE, allocatable :: xref(:, :, :), yref(:, :, :), zref(:, :, :), data(:)
-  ARRTYPE, allocatable, device, target:: data_d(:), data_2_d(:)
-  ARRTYPE, allocatable, managed, target:: data_m(:), data_2_m(:)
-  ARRTYPE, pointer, device, contiguous :: work_d(:)
-  ARRTYPE, pointer, device:: input(:), output(:)
-  integer :: dtype = DTYPE
-
-  integer :: i, j, k, l, idt, iarg
-  integer :: skip_count
+  integer :: res, retcode
+  logical :: using_testfile
   character(len=16) :: arg
+  character(len=32) :: binname
+  character(len=256) :: testfile
+  character(len=256), allocatable:: testcases(:)
+  integer :: nfailed
+  character(len=256), allocatable:: failed_cases(:)
 
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
@@ -185,291 +548,83 @@ program main
   call MPI_Comm_rank(local_comm, local_rank, ierr)
   CHECK_CUDA_EXIT(cudaSetDevice(local_rank))
 
-  ! Parse command-line arguments
-  gx = 256
-  gy = 256
-  gz = 256
-  pr = 0
-  pc = 0
-  comm_backend = 0
-  axis_contiguous(:) = .false.
-  gdims_dist(:) = 0
-  halo_extents_x(:) = 0
-  halo_extents_y(:) = 0
-  halo_extents_z(:) = 0
-  mem_order(:,:) = -1
-  out_of_place = .false.
-  use_managed_memory = .false.
-
-  skip_count = 0
+  using_testfile = .false.
   do i = 1, command_argument_count()
-    if (skip_count > 0) then
-      skip_count = skip_count - 1
-      cycle
-    end if
     call get_command_argument(i, arg)
-    select case(arg)
-      case('--gx')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gx
-        skip_count = 1
-      case('--gy')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gy
-        skip_count = 1
-      case('--gz')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gz
-        skip_count = 1
-      case('--backend')
-        call get_command_argument(i+1, arg)
-        read(arg, *) comm_backend
-        skip_count = 1
-      case('--pr')
-        call get_command_argument(i+1, arg)
-        read(arg, *) pr
-        skip_count = 1
-      case('--pc')
-        call get_command_argument(i+1, arg)
-        read(arg, *) pc
-        skip_count = 1
-      case('--acx')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        axis_contiguous(1) = iarg
-        skip_count = 1
-      case('--acy')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        axis_contiguous(2) = iarg
-        skip_count = 1
-      case('--acz')
-        call get_command_argument(i+1, arg)
-        read(arg, *) iarg
-        axis_contiguous(3) = iarg
-        skip_count = 1
-      case('--gdx')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gdims_dist(1)
-        skip_count = 1
-      case('--gdy')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gdims_dist(2)
-        skip_count = 1
-      case('--gdz')
-        call get_command_argument(i+1, arg)
-        read(arg, *) gdims_dist(3)
-        skip_count = 1
-      case('--hex')
-        do j = 1, 3
-          call get_command_argument(i+j, arg)
-          read(arg, *) halo_extents_x(j)
-        enddo
-        skip_count = 3
-      case('--hey')
-        do j = 1, 3
-          call get_command_argument(i+j, arg)
-          read(arg, *) halo_extents_y(j)
-        enddo
-        skip_count = 3
-      case('--hez')
-        do j = 1, 3
-          call get_command_argument(i+j, arg)
-          read(arg, *) halo_extents_z(j)
-        enddo
-        skip_count = 3
-      case('--mem_order')
-        l = 1
-        do j = 1, 3
-          do k = 1, 3
-            call get_command_argument(i+l, arg)
-            read(arg, *) mem_order(k, j)
-            l = l + 1
-          enddo
-        enddo
-        skip_count = 9
-      case('-o')
-        out_of_place = .true.
-      case('-m')
-        use_managed_memory = .true.
-      case(' ')
-        skip_count = 1
-      case default
-        print*, "Unknown argument."
-        call exit(1)
-    end select
-  end do
-
-  ! Finish setting up gdim_dist
-  gdims_dist(1) = gx - gdims_dist(1)
-  gdims_dist(2) = gy - gdims_dist(2)
-  gdims_dist(3) = gz - gdims_dist(3)
-
-  pdims(1) = pr
-  pdims(2) = pc
-
-  if (rank == 0) then
-     write(*,"('running on ', i0, ' x ', i0, ' x ', i0, ' spatial grid ...')") gx, gy, gz
-  end if
+    if (arg == "--testfile") then
+      call get_command_argument(i+1, testfile)
+      using_testfile = .true.
+      exit
+    endif
+  enddo
 
   ! Initialize cuDecomp
   CHECK_CUDECOMP_EXIT(cudecompInit(handle, MPI_COMM_WORLD))
 
-  ! Setup grid descriptor
-  CHECK_CUDECOMP_EXIT(cudecompGridDescConfigSetDefaults(config))
-  config%pdims = pdims
-  gdims = [gx, gy, gz]
-  config%gdims = gdims
-  config%gdims_dist = gdims_dist
-  config%transpose_axis_contiguous = axis_contiguous
-  config%transpose_mem_order = mem_order
-
-  CHECK_CUDECOMP_EXIT(cudecompGridDescAutotuneOptionsSetDefaults(options))
-  options%dtype = dtype
-  options%transpose_use_inplace_buffers = .not. out_of_place
-
-  if (comm_backend /= 0) then
-    config%transpose_comm_backend = comm_backend
+  if (.not. using_testfile) then
+    allocate(testcases(1))
+    testcases(1)(:) = ' '
+    idx = 1
+    do i = 1, command_argument_count()
+      call get_command_argument(i, arg)
+      testcases(1)(idx:idx+len_trim(arg)) = trim(arg)
+      idx = idx + len_trim(arg) + 1
+    enddo
   else
-    options%autotune_transpose_backend = .true.
+    call read_testfile(testfile, testcases)
   endif
 
-  CHECK_CUDECOMP_EXIT(cudecompGridDescCreate(handle, grid_desc, config, options))
 
-  if (rank == 0) then
-     write(*,"('running on ', i0, ' x ', i0, ' process grid ...')") config%pdims(1), config%pdims(2)
-     write(*,"('running using ', a, ' transpose backend ...')") &
-               cudecompTransposeCommBackendToString(config%transpose_comm_backend)
-  endif
+  nfailed = 0
+  allocate(failed_cases(size(testcases)))
 
-  ! Get x-pencil information
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_x, 1, halo_extents_x))
+  t0 = MPI_Wtime()
+  if (using_testfile .and. rank == 0) write(*,"('Running ', i0, ' tests...')"), size(testcases)
+  call get_command_argument(0, binname)
+  do i = 1, size(testcases)
+    if (using_testfile .and. rank == 0) write(*, "('command: ', A, ' ', A)"), trim(binname), trim(testcases(i))
 
-  ! Get y-pencil information
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_y, 2, halo_extents_y))
-
-  ! Get z-pencil information
-  CHECK_CUDECOMP_EXIT(cudecompGetPencilInfo(handle, grid_desc, pinfo_z, 3, halo_extents_z))
-
-  ! Get workspace size
-  CHECK_CUDECOMP_EXIT(cudecompGetTransposeWorkspaceSize(handle, grid_desc, workspace_num_elements))
-
-  ! Allocate data arrays
-  data_num_elements = max(pinfo_x%size, pinfo_y%size, pinfo_z%size)
-  allocate(data(data_num_elements))
-
-  ! Create reference data
-  call initialize_pencil(xref, pinfo_x, gdims)
-  call initialize_pencil(yref, pinfo_y, gdims)
-  call initialize_pencil(zref, pinfo_z, gdims)
-
-  if (use_managed_memory) then
-    allocate(data_m(data_num_elements))
-  else
-    allocate(data_d(data_num_elements))
-  endif
-  CHECK_CUDECOMP_EXIT(cudecompMalloc(handle, grid_desc, work_d, workspace_num_elements))
-  if (out_of_place) then
-    if (use_managed_memory) then
-      allocate(data_2_m(data_num_elements))
+    res = run_test(testcases(i), using_testfile)
+    if (rank == 0) then
+      call MPI_Reduce(MPI_IN_PLACE, res, 1, MPI_INTEGER, MPI_MAX, 0, MPI_COMM_WORLD, ierr)
     else
-      allocate(data_2_d(data_num_elements))
+      call MPI_Reduce(res, res, 1, MPI_INTEGER, MPI_MAX, 0, MPI_COMM_WORLD, ierr)
     endif
-  endif
-
-  ! Running correctness tests
-  if (rank == 0) write(*,"('running correctness tests...')")
-
-  ! Initialize data to reference x-pencil data
-  if (use_managed_memory) then
-    call flat_copy(xref, data_m, pinfo_x%size)
-  else
-    call flat_copy(xref, data_d, pinfo_x%size)
-  endif
-
-  if (use_managed_memory) then
-    input => data_m
-    output => data_m
-    if (out_of_place) output => data_2_m
-  else
-    input => data_d
-    output => data_d
-    if (out_of_place) output => data_2_d
-  endif
-
-  work_d = 0
-  CHECK_CUDECOMP_EXIT(cudecompTransposeXToY(handle, grid_desc, input, output, work_d, dtype, pinfo_x%halo_extents, pinfo_y%halo_extents))
-  data = output
-  if (compare_pencils(yref, data, pinfo_y)) then
-    print*, "FAILED cudecompTranposeXToY"
-    call exit(1)
-  endif
-
-  if (out_of_place) then
-    if (use_managed_memory) then
-      output => data_m
-      input => data_2_m
-    else
-      output => data_d
-      input => data_2_d
+    if (using_testfile .and. rank == 0) then
+      if (res /= 0) then
+        print*, "FAILED"
+        nfailed = nfailed + 1
+        failed_cases(nfailed)(:) = testcases(i)(:)
+      else
+        print*, "PASSED"
+      endif
     endif
-  endif
-
-  work_d = 0
-  CHECK_CUDECOMP_EXIT(cudecompTransposeYToZ(handle, grid_desc, input, output, work_d, dtype, pinfo_y%halo_extents, pinfo_z%halo_extents))
-  data = output
-  if (compare_pencils(zref, data, pinfo_z)) then
-    print*, "FAILED cudecompTranposeYToZ"
-    call exit(1)
-  endif
-
-  if (out_of_place) then
-    if (use_managed_memory) then
-      output => data_2_m
-      input => data_m
-    else
-      output => data_2_d
-      input => data_d
+    call MPI_Barrier(MPI_COMM_WORLD, ierr)
+    if (using_testfile .and. mod(i, 10) == 0) then
+      if (rank == 0) then
+        write(*, "('Completed ', i0, '/', i0, ' tests, running time ', f0.8, 's')"), i, size(testcases), MPI_Wtime() - t0
+      endif
     endif
-  endif
+  enddo
 
-  work_d = 0
-  CHECK_CUDECOMP_EXIT(cudecompTransposeZToY(handle, grid_desc, input, output, work_d, dtype, pinfo_z%halo_extents, pinfo_y%halo_extents))
-  data = output
-  if (compare_pencils(yref, data, pinfo_y)) then
-    print*, "FAILED cudecompTranposeZToY"
-    call exit(1)
-  endif
-
-  if (out_of_place) then
-    if (use_managed_memory) then
-      output => data_m
-      input => data_2_m
-    else
-      output => data_d
-      input => data_2_d
+  retcode = 0
+  if (using_testfile) then
+    if (rank == 0) then
+      write(*, "('Completed all tests, running time ', f0.8, ' s')"), MPI_Wtime() - t0
+      if (nfailed == 0) then
+        write(*, "(A)"), "Passed all tests."
+      else
+        write(*, "('Failed ', i0, '/', i0, ' tests. Failing cases:')"), nfailed, size(testcases)
+        do i = 1, nfailed
+          write(*, "(A, ' ', A)"), trim(binname), trim(failed_cases(i))
+        enddo
+      endif
     endif
+    if (nfailed /= 0) retcode = 1;
   endif
 
-  work_d = 0
-  CHECK_CUDECOMP_EXIT(cudecompTransposeYToX(handle, grid_desc, input, output, work_d, dtype, pinfo_y%halo_extents, pinfo_x%halo_extents))
-  data = output
-  if (compare_pencils(xref, data, pinfo_x)) then
-    print*, "FAILED cudecompTranposeYToX"
-    call exit(1)
-  endif
-
-  if (use_managed_memory) then
-    deallocate(data_m)
-    if (out_of_place) deallocate(data_2_m)
-  else
-    deallocate(data_d)
-    if (out_of_place) deallocate(data_2_d)
-  endif
-  CHECK_CUDECOMP_EXIT(cudecompFree(handle, grid_desc, work_d))
-  CHECK_CUDECOMP_EXIT(cudecompGridDescDestroy(handle, grid_desc))
   CHECK_CUDECOMP_EXIT(cudecompFinalize(handle))
-
   call MPI_Finalize(ierr)
 
+  call exit(retcode)
 end program main

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -180,7 +180,7 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
     integer :: pr, pc
 
     ! MPI
-    integer :: local_rank, nranks, ierr
+    integer :: local_rank, ierr
     integer :: local_comm
 
     ! cudecomp
@@ -205,8 +205,6 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
     integer :: skip_count, nspaces
     character(len=16) :: arg
     character(len=16), allocatable :: args(:)
-
-    real(8) :: t0
 
     res = 0
 

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -530,7 +530,7 @@ program main
   integer :: res, retcode
   logical :: using_testfile
   character(len=16) :: arg
-  character(len=32) :: binname
+  character(len=256) :: binname
   character(len=256) :: testfile
   character(len=256), allocatable:: testcases(:)
   integer :: nfailed

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,6 +1,7 @@
 base: &base
   env_vars :
     NVSHMEM_DISABLE_CUDA_VMM: 1
+    NVSHMEM_DISABLE_NCCL: 1
 
   dtypes: ['R32', 'R64', 'C32', 'C64']
 
@@ -11,7 +12,6 @@ transpose_test_base: &transpose_test_base
   # Creating list of args to control order and enable easier overriding of values
   args : ['backend',
           'gx', 'gy', 'gz',
-          'acx', 'acy', 'acz',
           'gdx', 'gdy', 'gdz',
           'hex' ,'hey', 'hez']
 
@@ -20,10 +20,6 @@ transpose_test_base: &transpose_test_base
   gx: [128]
   gy: [124]
   gz: [132]
-
-  acx: [0]
-  acy: [0]
-  acz: [0]
 
   gdx: [0]
   gdy: [0]
@@ -36,132 +32,50 @@ transpose_test_base: &transpose_test_base
   out_of_place: [True, False]
   managed_memory : [True, False]
   run_autotuning : False
-  test_mem_order: False
+  test_mem_order: True
   fortran_indexing: False
 
-transpose_test_acfalse: &transpose_test_acfalse
+transpose_test: &transpose_test
   <<: *transpose_test_base
-  acx: [0]
-  acy: [0]
-  acz: [0]
-
-transpose_test_actrue: &transpose_test_actrue
-  <<: *transpose_test_base
-  acx: [1]
-  acy: [1]
-  acz: [1]
-
-transpose_test_acmix: &transpose_test_acmix
-  <<: *transpose_test_base
-  backend: [1, 2] # Limit this testing to one normal and one pipelined backend
-  dtypes: ['C64'] # Limit to one data type
-  acx: [0, 1]
-  acy: [0, 1]
-  acz: [0, 1]
-
-transpose_test_halo: &transpose_test_halo
-  <<: *transpose_test_base
-  args : ['backend',
-          'gx', 'gy', 'gz',
-          'gdx', 'gdy', 'gdz',
-          'hex' ,'hey', 'hez']
-
-  backend: [1, 2] # Limit this testing to one normal and one pipelined backend
-  dtypes: ['C64'] # Limit to one data type
-  test_mem_order: true
 
   hex: ["0 0 0", "1 1 1"]
-  hey: ["1 1 1"]
+  hey: ["0 0 0", "1 1 1"]
   hez: ["0 0 0", "1 1 1"]
-
-transpose_test_acfalse_gdimdist: &transpose_test_acfalse_gdimdist
-  <<: *transpose_test_base
-  backend: [1, 2] # Limit this testing to one normal and one pipelined backend
-  dtypes: ['C64'] # Limit to one data type
-  acx: [0]
-  acy: [0]
-  acz: [0]
 
   gdx: [0, 16]
   gdy: [0, 16]
   gdz: [0, 16]
 
-transpose_test_actrue_gdimdist: &transpose_test_actrue_gdimdist
-  <<: *transpose_test_acfalse_gdimdist
-  acx: [1]
-  acy: [1]
-  acz: [1]
-
-transpose_test_mem_order: &transpose_test_mem_order
+transpose_test_ac: &transpose_test_ac
   <<: *transpose_test_base
-  backend: [1, 2] # Limit this testing to one normal and one pipelined backend
-  dtypes: ['C64'] # Limit to one data type
-  test_mem_order: true
   args : ['backend',
+          'acx', 'acy', 'acz',
           'gx', 'gy', 'gz',
           'gdx', 'gdy', 'gdz',
           'hex' ,'hey', 'hez']
 
-transpose_test_acfalse_cc:
-  <<: *transpose_test_acfalse
+  backend: [1] # Limit this testing to one backend
+  dtypes: ['R32'] # Limit to one data type
+
+  acx: [0, 1]
+  acy: [0, 1]
+  acz: [0, 1]
+
+transpose_test_cc:
+  <<: *transpose_test
   executable_prefix: 'cc/transpose_test'
 
-transpose_test_actrue_cc:
-  <<: *transpose_test_actrue
+transpose_test_ac_cc:
+  <<: *transpose_test_ac
   executable_prefix: 'cc/transpose_test'
 
-transpose_test_acmix_cc:
-  <<: *transpose_test_acmix
-  executable_prefix: 'cc/transpose_test'
-
-transpose_test_halo_cc:
-  <<: *transpose_test_halo
-  executable_prefix: 'cc/transpose_test'
-
-transpose_test_acfalse_gdimdist_cc:
-  <<: *transpose_test_acfalse_gdimdist
-  executable_prefix: 'cc/transpose_test'
-
-transpose_test_actrue_gdimdist_cc:
-  <<: *transpose_test_actrue_gdimdist
-  executable_prefix: 'cc/transpose_test'
-
-transpose_test_mem_order_cc:
-  <<: *transpose_test_mem_order
-  executable_prefix: 'cc/transpose_test'
-
-transpose_test_acfalse_fortran:
-  <<: *transpose_test_acfalse
+transpose_test_fortran:
+  <<: *transpose_test
   executable_prefix: 'fortran/transpose_test'
   fortran_indexing: true
 
-transpose_test_actrue_fortran:
-  <<: *transpose_test_actrue
-  executable_prefix: 'fortran/transpose_test'
-  fortran_indexing: true
-
-transpose_test_acmix_fortran:
-  <<: *transpose_test_acmix
-  executable_prefix: 'fortran/transpose_test'
-  fortran_indexing: true
-
-transpose_test_halo_fortran:
-  <<: *transpose_test_halo
-  executable_prefix: 'fortran/transpose_test'
-  fortran_indexing: true
-
-transpose_test_acfalse_gdimdist_fortran:
-  <<: *transpose_test_acfalse_gdimdist
-  executable_prefix: 'fortran/transpose_test'
-  fortran_indexing: true
-
-transpose_test_actrue_gdimdist_fortran:
-  <<: *transpose_test_actrue_gdimdist
-  executable_prefix: 'fortran/transpose_test'
-  fortran_indexing: true
-
-transpose_test_mem_order_fortran:
-  <<: *transpose_test_mem_order
+transpose_test_ac_fortran:
+  <<: *transpose_test_ac
   executable_prefix: 'fortran/transpose_test'
   fortran_indexing: true
 
@@ -170,7 +84,6 @@ halo_test_base: &halo_test_base
 
   args : ['backend',
           'gx', 'gy', 'gz',
-          'acx', 'acy', 'acz',
           'gdx', 'gdy', 'gdz',
           'hex' ,'hey', 'hez',
           'hpx', 'hpy', 'hpz',
@@ -181,10 +94,6 @@ halo_test_base: &halo_test_base
   gx: [128]
   gy: [132]
   gz: [124]
-
-  acx: [0]
-  acy: [0]
-  acz: [0]
 
   gdx: [0]
   gdy: [0]
@@ -203,30 +112,12 @@ halo_test_base: &halo_test_base
   managed_memory : [True, False]
   out_of_place : [False]
   run_autotuning : False
-  test_mem_order: False
+  test_mem_order: True
   fortran_indexing: False
 
-halo_test_acfalse: &halo_test_acfalse
+
+halo_test: &halo_test
   <<: *halo_test_base
-  acx: [0]
-  acy: [0]
-  acz: [0]
-
-halo_test_actrue: &halo_test_actrue
-  <<: *halo_test_base
-  acx: [1]
-  acy: [1]
-  acz: [1]
-
-halo_test_acfalse_halomix: &halo_test_acfalse_halomix
-  <<: *halo_test_base
-  backend: [1] # Limit this testing to one backend
-  dtypes: ['C64'] # Limit to one data type
-
-  acx: [0]
-  acy: [0]
-  acz: [0]
-
   hex: [0, 1]
   hey: [0, 1]
   hez: [0, 1]
@@ -235,108 +126,43 @@ halo_test_acfalse_halomix: &halo_test_acfalse_halomix
   hpy: [0, 1]
   hpz: [0, 1]
 
-halo_test_actrue_halomix: &halo_test_actrue_halomix
-  <<: *halo_test_acfalse_halomix
-  acx: [1]
-  acy: [1]
-  acz: [1]
-
-halo_test_acfalse_gdimdist: &halo_test_acfalse_gdimdist
-  <<: *halo_test_base
-  backend: [1] # Limit this testing to one backend
-  dtypes: ['C64'] # Limit to one data type
-
-  acx: [0]
-  acy: [0]
-  acz: [0]
-
   gdx: [0, 16]
   gdy: [0, 16]
   gdz: [0, 16]
 
-halo_test_actrue_gdimdist: &halo_test_actrue_gdimdist
-  <<: *halo_test_acfalse_gdimdist
-  acx: [1]
-  acy: [1]
-  acz: [1]
-
-halo_test_mem_order: &halo_test_mem_order
+halo_test_ac: &halo_test_ac
   <<: *halo_test_base
-  backend: [1] # Limit this testing to one backend
-  dtypes: ['C64'] # Limit to one data type
-  test_mem_order: true
   args : ['backend',
+          'acx', 'acy', 'acz',
           'gx', 'gy', 'gz',
           'gdx', 'gdy', 'gdz',
           'hex' ,'hey', 'hez',
           'hpx', 'hpy', 'hpz',
           'ax']
 
-halo_test_acfalse_cc:
-  <<: *halo_test_acfalse
+  backend: [1] # Limit this testing to one backend
+  dtypes: ['R32'] # Limit to one data type
+
+  acx: [0, 1]
+  acy: [0, 1]
+  acz: [0, 1]
+
+halo_test_cc:
+  <<: *halo_test
   executable_prefix: 'cc/halo_test'
 
-halo_test_actrue_cc:
-  <<: *halo_test_actrue
+halo_test_ac_cc:
+  <<: *halo_test_ac
   executable_prefix: 'cc/halo_test'
 
-halo_test_acfalse_halomix_cc:
-  <<: *halo_test_acfalse_halomix
-  executable_prefix: 'cc/halo_test'
-
-halo_test_actrue_halomix_cc:
-  <<: *halo_test_actrue_halomix
-  executable_prefix: 'cc/halo_test'
-
-halo_test_acfalse_gdimdist_cc:
-  <<: *halo_test_acfalse_gdimdist
-  executable_prefix: 'cc/halo_test'
-
-halo_test_actrue_gdimdist_cc:
-  <<: *halo_test_actrue_gdimdist
-  executable_prefix: 'cc/halo_test'
-
-halo_test_mem_order_cc:
-  <<: *halo_test_mem_order
-  executable_prefix: 'cc/halo_test'
-
-halo_test_acfalse_fortran:
-  <<: *halo_test_acfalse
+halo_test_fortran:
+  <<: *halo_test
   ax: [1, 2, 3]
   executable_prefix: 'fortran/halo_test'
   fortran_indexing: true
 
-halo_test_actrue_fortran:
-  <<: *halo_test_actrue
+halo_test_ac_fortran:
+  <<: *halo_test_ac
   ax: [1, 2, 3]
-  executable_prefix: 'fortran/halo_test'
-  fortran_indexing: true
-
-halo_test_acfalse_halomix_fortran:
-  <<: *halo_test_acfalse_halomix
-  ax: [1, 2, 3]
-  executable_prefix: 'fortran/halo_test'
-  fortran_indexing: true
-
-halo_test_actrue_halomix_fortran:
-  <<: *halo_test_actrue_halomix
-  ax: [1, 2, 3]
-  executable_prefix: 'fortran/halo_test'
-  fortran_indexing: true
-
-halo_test_acfalse_gdimdist_fortran:
-  <<: *halo_test_acfalse_gdimdist
-  ax: [1, 2, 3]
-  executable_prefix: 'fortran/halo_test'
-  fortran_indexing: true
-
-halo_test_actrue_gdimdist_fortran:
-  <<: *halo_test_actrue_gdimdist
-  ax: [1, 2, 3]
-  executable_prefix: 'fortran/halo_test'
-  fortran_indexing: true
-
-halo_test_mem_order_fortran:
-  <<: *halo_test_mem_order
   executable_prefix: 'fortran/halo_test'
   fortran_indexing: true

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -12,7 +12,7 @@ transpose_test_base: &transpose_test_base
   # Creating list of args to control order and enable easier overriding of values
   args : ['backend',
           'gx', 'gy', 'gz',
-          'gdx', 'gdy', 'gdz',
+          'gd',
           'hex' ,'hey', 'hez']
 
   backend: [1, 2, 3, 4, 5, 6, 7]
@@ -21,9 +21,7 @@ transpose_test_base: &transpose_test_base
   gy: [124]
   gz: [132]
 
-  gdx: [0]
-  gdy: [0]
-  gdz: [0]
+  gd: ["0 0 0"]
 
   hex: ["0 0 0"]
   hey: ["0 0 0"]
@@ -42,16 +40,14 @@ transpose_test: &transpose_test
   hey: ["0 0 0", "1 1 1"]
   hez: ["0 0 0", "1 1 1"]
 
-  gdx: [0, 16]
-  gdy: [0, 16]
-  gdz: [0, 16]
+  gd: ["0 0 0", "16 16 16"]
 
 transpose_test_ac: &transpose_test_ac
   <<: *transpose_test_base
   args : ['backend',
           'acx', 'acy', 'acz',
           'gx', 'gy', 'gz',
-          'gdx', 'gdy', 'gdz',
+          'gd',
           'hex' ,'hey', 'hez']
 
   backend: [1] # Limit this testing to one backend
@@ -84,7 +80,7 @@ halo_test_base: &halo_test_base
 
   args : ['backend',
           'gx', 'gy', 'gz',
-          'gdx', 'gdy', 'gdz',
+          'gd',
           'hex' ,'hey', 'hez',
           'hpx', 'hpy', 'hpz',
           'ax']
@@ -95,9 +91,7 @@ halo_test_base: &halo_test_base
   gy: [132]
   gz: [124]
 
-  gdx: [0]
-  gdy: [0]
-  gdz: [0]
+  gd: ["0 0 0"]
 
   hex: [1]
   hey: [1]
@@ -126,16 +120,14 @@ halo_test: &halo_test
   hpy: [0, 1]
   hpz: [0, 1]
 
-  gdx: [0, 16]
-  gdy: [0, 16]
-  gdz: [0, 16]
+  gd: ["0 0 0", "16 16 16"]
 
 halo_test_ac: &halo_test_ac
   <<: *halo_test_base
   args : ['backend',
           'acx', 'acy', 'acz',
           'gx', 'gy', 'gz',
-          'gdx', 'gdy', 'gdz',
+          'gd',
           'hex' ,'hey', 'hez',
           'hpx', 'hpy', 'hpz',
           'ax']

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -127,7 +127,7 @@ def main():
   config = load_yaml_config("test_config.yaml", args.config_name)
 
   cmds = generate_command_lines(config, args)
-  with open("cases.txt", 'w') as f:
+  with open(f"{args.config_name}_cases.txt", 'w') as f:
     for c in cmds:
       f.write(c)
       f.write("\n")
@@ -138,7 +138,7 @@ def main():
   print(f"Running tests for dtypes ({', '.join(config['dtypes'])})...")
   for dtype in config['dtypes']:
     print(f"Running {dtype} tests...")
-    cmd = f"{args.launcher_cmd} {config['executable_prefix']}_{dtype} -f cases.txt"
+    cmd = f"{args.launcher_cmd} {config['executable_prefix']}_{dtype} -f {args.config_name}_cases.txt"
     status = run_test(cmd, args)
 
     if not status:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -138,7 +138,7 @@ def main():
   print(f"Running tests for dtypes ({', '.join(config['dtypes'])})...")
   for dtype in config['dtypes']:
     print(f"Running {dtype} tests...")
-    cmd = f"{args.launcher_cmd} {config['executable_prefix']}_{dtype} -f {args.config_name}_cases.txt"
+    cmd = f"{args.launcher_cmd} {config['executable_prefix']}_{dtype} --testfile {args.config_name}_cases.txt"
     status = run_test(cmd, args)
 
     if not status:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -58,41 +58,36 @@ def generate_command_lines(config, args):
     config['args'].append("mem_order")
     config['mem_order'] = generate_mem_order_args(not config["fortran_indexing"])
 
-  generic_cmd = f"{args.launcher_cmd}"
-  generic_cmd += " {0}"
-
-  generic_cmd += " --pr {1} --pc {2}"
-
   cmds = []
-  for dtype in config['dtypes']:
-    prs = get_factors(args.ngpu)
-    pcs = [args.ngpu // x for x in prs]
-    if config['run_autotuning']:
-      prs = [0] + prs
-      pcs = [0] + pcs
-      if (not 0 in config['backend']):
-        config['backend'].append(0)
-    for pr, pc in zip(prs, pcs):
-      for vals in itertools.product(*[config[x] for x in config['args']]):
-        arg_dict = dict(zip(config['args'], vals))
-        cmd = generic_cmd.format(f"{config['executable_prefix']}_{dtype}", pr, pc)
-        cmd += " "  + " ".join([f"--{x} {y}" for x, y in arg_dict.items()])
+  prs = get_factors(args.ngpu)
+  pcs = [args.ngpu // x for x in prs]
+  if config['run_autotuning']:
+    prs = [0] + prs
+    pcs = [0] + pcs
+    if (not 0 in config['backend']):
+      config['backend'].append(0)
+  for pr, pc in zip(prs, pcs):
+    for vals in itertools.product(*[config[x] for x in config['args']]):
+      arg_dict = dict(zip(config['args'], vals))
+      #cmd = generic_cmd.format(f"{config['executable_prefix']}_{dtype}", pr, pc)
+      cmd = f"--pr {pr} --pc {pc} "
+      cmd += " ".join([f"--{x} {y}" for x, y in arg_dict.items()])
 
-        # Only run full (grid and backend) autotuning cases
-        if (config['run_autotuning']):
-          if ((pr == 0 and pc == 0) and arg_dict["backend"] != 0):
-            continue
-          elif ((pr != 0 and pc != 0) and arg_dict["backend"] == 0):
-            continue
+      # Only run full (grid and backend) autotuning cases
+      if (config['run_autotuning']):
+        if ((pr == 0 and pc == 0) and arg_dict["backend"] != 0):
+          continue
+        elif ((pr != 0 and pc != 0) and arg_dict["backend"] == 0):
+          continue
 
-        # Check additional skip conditions
-        if should_skip_case(arg_dict): continue
+      # Check additional skip conditions
+      if should_skip_case(arg_dict): continue
 
-        extra_flags = []
-        extra_flags.append(['-m' if x else '' for x in config['managed_memory']])
-        extra_flags.append(['-o' if x else '' for x in config['out_of_place']])
-        for extras in itertools.product(*extra_flags):
-          cmds.append(f"{cmd} {' '.join(filter(lambda x: x != '', extras))}")
+      extra_flags = []
+      extra_flags.append(['-m' if x else '' for x in config['managed_memory']])
+      extra_flags.append(['-o' if x else '' for x in config['out_of_place']])
+      for extras in itertools.product(*extra_flags):
+        cmds.append(f"{cmd} {' '.join(filter(lambda x: x != '', extras))}")
 
 
   return cmds
@@ -105,32 +100,19 @@ def setup_env(config, args):
     print(f"Set {var} = {val}")
 
 def run_test(cmd, args):
-  print(f"command: {cmd}", sep="")
   cmd_fields = cmd.split()
-
-  failed = False
   try:
-    status = subprocess.run(cmd_fields, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                            timeout=300, check=True)
-  except subprocess.TimeoutExpired as ex:
-    print(f" FAILED (timeout)")
-    print(f"Failing output:\n{ex.stdout.decode('utf-8')}")
-    failed = True
-  except subprocess.CalledProcessError as ex:
-    print(f" FAILED")
-    print(f"Failing output:\n{ex.stdout.decode('utf-8')}")
-    failed = True
-  else:
-    print(" PASSED")
+    sp = subprocess.Popen(cmd_fields, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-  if failed:
-    if args.exit_on_failure:
-      print("Stopping tests...")
-      sys.exit(1)
+    while sp.poll() is None:
+      line = sp.stdout.readline()
+      print(line.decode('utf-8'), end='')
+
+    if sp.poll() != 0:
+      return False
+
+  except:
     return False
-
-  if args.verbose:
-    print(f"Passing output:\n{status.stdout.decode('utf-8')}")
 
   return True
 
@@ -138,7 +120,6 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--launcher_cmd', type=str, required=True, help='parallel launch command')
   parser.add_argument('--ngpu', type=int, required=True, help='number of gpus')
-  parser.add_argument('--verbose', action='store_true', required=False, help='flag to enable full run output')
   parser.add_argument('--exit_on_failure', action='store_true', required=False, help='flag to control whether script exits on case failure')
   parser.add_argument('config_name', type=str, help='configuration name from test_configs.yaml')
   args = parser.parse_args()
@@ -146,30 +127,35 @@ def main():
   config = load_yaml_config("test_config.yaml", args.config_name)
 
   cmds = generate_command_lines(config, args)
+  with open("cases.txt", 'w') as f:
+    for c in cmds:
+      f.write(c)
+      f.write("\n")
   setup_env(config, args)
 
-  print(f"Running {len(cmds)} tests...")
   t0 = time.time()
-  failed_cmds = []
-  for i,c in enumerate(cmds):
-    status = run_test(c, args)
+  failed_dtypes = []
+  print(f"Running tests for dtypes ({', '.join(config['dtypes'])})...")
+  for dtype in config['dtypes']:
+    print(f"Running {dtype} tests...")
+    cmd = f"{args.launcher_cmd} {config['executable_prefix']}_{dtype} -f cases.txt"
+    status = run_test(cmd, args)
 
     if not status:
-      failed_cmds.append(c)
+      failed_dtypes.append(dtype)
+      print(f"Failed {dtype} tests.")
 
-    if (i+1) % 10 == 0:
-      t1 = time.time()
-      print(f"Completed {i+1}/{len(cmds)} tests, running time {t1-t0} s")
-  print(f"Completed all tests, running time {time.time() - t0} s")
+      if (args.exit_on_failure):
+        print("Stopping tests...")
+        return 1
 
-  if len(failed_cmds) == 0:
-    print("Passed all tests.")
+  if len(failed_dtypes) == 0:
+    print(f"Passed all tests for all dtypes, running time {time.time() - t0} s")
     return 0
   else:
-    print(f"Failed {len(failed_cmds)} / {len(cmds)} tests. Failing commands:")
-    for c in failed_cmds:
-      print(f"\t{c}")
-    return -1
+    print(f"Failed tests for dtypes ({', '.join(failed_dtypes)})., running time {time.time() - t0} s")
+    return 1
+
 
 if __name__ == "__main__":
   main()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -70,7 +70,6 @@ def generate_command_lines(config, args):
   for pr, pc in zip(prs, pcs):
     for vals in itertools.product(*[config[x] for x in config['args']]):
       arg_dict = dict(zip(config['args'], vals))
-      #cmd = generic_cmd.format(f"{config['executable_prefix']}_{dtype}", pr, pc)
       cmd = f"--pr {pr} --pc {pc} "
       cmd += " ".join([f"--{x} {y}" for x, y in arg_dict.items()])
 
@@ -122,14 +121,14 @@ def main():
   parser.add_argument('--launcher_cmd', type=str, required=True, help='parallel launch command')
   parser.add_argument('--ngpu', type=int, required=True, help='number of gpus')
   parser.add_argument('--exit_on_failure', action='store_true', required=False, help='flag to control whether script exits on case failure')
-  parser.add_argument('--config_overrides', type=str, required=False, help='string list of key:value pairs, e.g. backend:[1,2],dtype:["C64"]')
+  parser.add_argument('--config_overrides', type=str, required=False, help="string list of semi-colon separated key:value pairs, e.g. \"backend:[1,2];dtype:['C64']\"")
   parser.add_argument('config_name', type=str, help='configuration name from test_configs.yaml')
   args = parser.parse_args()
 
   config = load_yaml_config("test_config.yaml", args.config_name)
 
   if (args.config_overrides):
-    entries = args.config_overrides.split(',')
+    entries = args.config_overrides.split(';')
     for e in entries:
       fields = e.split(':')
       key = fields[0].strip()


### PR DESCRIPTION
Recent and upcoming PRs (like #49) add features that require significant expansion of test argument coverage (e.g., `transpose_mem_order` produces 216 different possibilities across X, Y and Z vs. the 8 that existing with just the `axis_contiguous` option). With this expansion of testing, it was found that our existing methodology, repeatedly launching a test binary like `transpose_test_C64` to execute one combination of options at a time, was inadequate to get the coverage we'd like using a reasonable amount of compute resources. A major limitation of the existing approach is that each invocation of the test binary would incur the cost of startup and initialization, which can be substantial when NCCL or NVSHMEM is involved relative to the actual test time. 

This PR refactors the cuDecomp testing binaries to enable running entire suites of tests at a time in a single program launch, eliminating extraneous overheads from startup and repeated initialization of communication libraries. Tests launched using this updated code run in O(10 ms) per argument configuration vs O(1 s) before 🚀 . This significantly improves test throughput for existing tests and enables us to expand our coverage within reasonable compute envelope.  