### PR TITLE
Preserve original user transpose_mem_order settings after grid descriptor creation.

### DIFF
--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -118,6 +118,7 @@ struct cudecompCommInfo {
 struct cudecompGridDesc {
   cudecompGridDescConfig_t config; // configuration struct
   bool gdims_dist_set = false;     // flag to record if gdims_dist was set to non-default values
+  bool transpose_mem_order_set = false;     // flag to record if transpose_mem_order was set to non-default values
 
   int32_t pidx[2]; // processor grid index;
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -483,9 +483,9 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
     auto halo_comm_backend = grid_desc->config.halo_comm_backend;
 
     // If transpose_mem_order not used, set based on transpose_axis_contiguous settings)
-    bool mem_order_set = (config->transpose_mem_order[0][0] >= 0);
+    grid_desc->transpose_mem_order_set = (config->transpose_mem_order[0][0] >= 0);
 
-    if (!mem_order_set) {
+    if (!grid_desc->transpose_mem_order_set) {
       for (int axis = 0; axis < 3; ++axis) {
         for (int i = 0; i < 3; ++i) {
           if (grid_desc->config.transpose_axis_contiguous[axis]) {
@@ -626,6 +626,15 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
       config->gdims_dist[0] = 0;
       config->gdims_dist[1] = 0;
       config->gdims_dist[2] = 0;
+    }
+
+    // If transpose_mem_order was not set, return config with default values
+    if (!grid_desc->transpose_mem_order_set) {
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          config->transpose_mem_order[i][j] = -1;
+        }
+      }
     }
 
   } catch (const cudecomp::BaseException& e) {
@@ -832,6 +841,15 @@ cudecompResult_t cudecompGetGridDescConfig(cudecompHandle_t handle, cudecompGrid
       config->gdims_dist[0] = 0;
       config->gdims_dist[1] = 0;
       config->gdims_dist[2] = 0;
+    }
+
+    // If transpose_mem_order was not set, return config with default values
+    if (!grid_desc->transpose_mem_order_set) {
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          config->transpose_mem_order[i][j] = -1;
+        }
+      }
     }
 
   } catch (const cudecomp::BaseException& e) {


### PR DESCRIPTION
During `cudecompGridDescCreate`,  the `axis_contiguous` setting in the provided `cudecompGridDescConfig` structure is converted internally into a `transpose_mem_order` setting (if `transpose_mem_order` is not set). However, in the current implementation, this internal modification of `transpose_mem_order` is leaked out to the user in both the returned config after `cudecompGridDescCreate` completes, as well as the one returned from `cudecompGetGridDescConfig`. 

This can result in subtle user issues in cases where a user may attempt to reuse the configuration struct with targeted modifications to the `axis_contiguous` settings between calls to `cudecompGridDescCreate`. This "hidden" setting of `transpose_mem_order` would potentially cause these modifications to be ignored.

This PR fixes the issue by ensuring the configuration struct returned to a user preserves the default settings of `transpose_mem_order` in cases that a user only sets `axis_contiguous. 