### PR TITLE
Improvements to batched memcpy kernel implementation.

### DIFF
--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -37,7 +37,9 @@
 
 #include "internal/cudecomp_kernels.h"
 
-#define CUDECOMP_CUDA_NTHREADS 256
+#define CUDECOMP_CUDA_NTHREADS (256)
+#define UNROLL_FACTOR (2)
+
 
 namespace cudecomp {
 
@@ -60,7 +62,7 @@ __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
 }
 #endif
 
-template <typename T>
+template <int src_nd, int dest_nd, typename T>
 __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
     void cudecomp_batched_d2d_memcpy_3d_k(cudecompBatchedD2DMemcpy3DParams<T> params, int blocks_per_copy) {
 
@@ -70,23 +72,131 @@ __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
 
   T* src = params.src[copyid];
   T* dest = params.dest[copyid];
-  const size_t src_stride_r = params.src_strides[1][copyid];
-  const size_t src_stride_d = params.src_strides[0][copyid];
-  const size_t dest_stride_r = params.dest_strides[1][copyid];
-  const size_t dest_stride_d = params.dest_strides[0][copyid];
   const size_t width = params.extents[2][copyid];
   const size_t height = params.extents[1][copyid];
   const size_t depth = params.extents[0][copyid];
 
+  size_t src_stride_r, src_stride_d;
+  if (src_nd > 1) {
+    src_stride_r = params.src_strides[1][copyid];
+  }
+  if (src_nd > 2) {
+    src_stride_d = params.src_strides[0][copyid];
+  }
+
+  size_t dest_stride_r, dest_stride_d;
+  if (dest_nd > 1) {
+    dest_stride_r = params.dest_strides[1][copyid];
+  }
+  if (dest_nd > 2) {
+    dest_stride_d = params.dest_strides[0][copyid];
+  }
+
   const size_t tid = (blockIdx.x % blocks_per_copy) * blockDim.x + threadIdx.x;
 
   for (size_t n = tid; n < width * height * depth; n += blocks_per_copy * blockDim.x) {
-    int c = (n % width);
-    int r = (n / width) % height;
-    int d = n / (width * height);
+    T *dptr, *sptr;
 
-    dest[dest_stride_d * d + dest_stride_r * r + c] = src[src_stride_d * d + src_stride_r * r + c];
+    if (src_nd == 1) {
+      sptr = src + n;
+    } else if (src_nd == 2) {
+      size_t c = n % width;
+      size_t r = n / width;
+      sptr = src  + src_stride_r * r + c;
+    } else if (src_nd == 3) {
+      size_t c = (n % width);
+      size_t r = (n / width) % height;
+      size_t d = n / (width * height);
+      sptr = src + src_stride_d * d + src_stride_r * r + c;
+    }
+
+    if (dest_nd == 1) {
+      dptr = dest + n;
+    } else if (dest_nd == 2) {
+      size_t c = n % width;
+      size_t r = n / width;
+      dptr = dest  + dest_stride_r * r + c;
+    } else if (dest_nd == 3) {
+      size_t c = (n % width);
+      size_t r = (n / width) % height;
+      size_t d = n / (width * height);
+      dptr = dest + dest_stride_d * d + dest_stride_r * r + c;
+    }
+
+    *dptr = *sptr;
   }
+
+}
+
+template<typename T>
+void cudecomp_batched_d2d_memcpy_3d_nd_dispatch(const cudecompBatchedD2DMemcpy3DParams<T>& params, cudaStream_t stream) {
+  size_t N = params.extents[0][0] * params.extents[1][0] * params.extents[2][0];
+
+  // Determine reduced copy dimension to simplify indexing
+  int src_nd = 1;
+  int dest_nd = 1;
+  for (int i = 0; i < params.ncopies; ++i) {
+    N = std::max(N, params.extents[0][i] * params.extents[1][i] * params.extents[2][i]);
+    if (params.src_strides[1][i] == params.extents[2][i] &&
+        params.src_strides[0][i] / params.src_strides[1][i] == params.extents[1][i]) {
+      src_nd = std::max(1, src_nd);
+    } else if (params.src_strides[0][i] / params.src_strides[1][i] == params.extents[1][i]) {
+      src_nd = std::max(2, src_nd);
+    } else {
+      src_nd = 3;
+    }
+    if (params.dest_strides[1][i] == params.extents[2][i] &&
+        params.dest_strides[0][i] / params.dest_strides[1][i] == params.extents[1][i]) {
+      dest_nd = std::max(1, dest_nd);
+    } else if (params.dest_strides[0][i] / params.dest_strides[1][i] == params.extents[1][i]) {
+      dest_nd = std::max(2, dest_nd);
+    } else {
+      dest_nd = 3;
+    }
+  }
+
+  int blocks_per_copy = (N + CUDECOMP_CUDA_NTHREADS - 1) / CUDECOMP_CUDA_NTHREADS;
+  blocks_per_copy = (blocks_per_copy + UNROLL_FACTOR - 1)  / UNROLL_FACTOR;
+
+  switch (src_nd) {
+    case 1:
+      switch (dest_nd) {
+        case 1:
+          cudecomp_batched_d2d_memcpy_3d_k<1, 1><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+        case 2:
+          cudecomp_batched_d2d_memcpy_3d_k<1, 2><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+        case 3:
+          cudecomp_batched_d2d_memcpy_3d_k<1, 3><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+      } break;
+    case 2:
+      switch (dest_nd) {
+        case 1:
+          cudecomp_batched_d2d_memcpy_3d_k<2, 1><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+        case 2:
+          cudecomp_batched_d2d_memcpy_3d_k<2, 2><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+        case 3:
+          cudecomp_batched_d2d_memcpy_3d_k<2, 3><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+      } break;
+    case 3:
+      switch (dest_nd) {
+        case 1:
+          cudecomp_batched_d2d_memcpy_3d_k<3, 1><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+        case 2:
+          cudecomp_batched_d2d_memcpy_3d_k<3, 2><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+        case 3:
+          cudecomp_batched_d2d_memcpy_3d_k<3, 3><<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
+              params, blocks_per_copy); break;
+      } break;
+  }
+  CHECK_CUDA_LAUNCH();
 }
 
 } // namespace cudecomp

--- a/src/cudecomp_kernels.cu
+++ b/src/cudecomp_kernels.cu
@@ -36,47 +36,18 @@
 namespace cudecomp {
 
 void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<float>& params, cudaStream_t stream) {
-  size_t N = params.extents[0][0] * params.extents[1][0] * params.extents[2][0];
-  for (int i = 1; i < params.ncopies; ++i) {
-    N = std::max(N, params.extents[0][i] * params.extents[1][i] * params.extents[2][i]);
-  }
-  int blocks_per_copy = (N + CUDECOMP_CUDA_NTHREADS - 1) / CUDECOMP_CUDA_NTHREADS;
-  cudecomp_batched_d2d_memcpy_3d_k<<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
-      params, blocks_per_copy);
-  CHECK_CUDA_LAUNCH();
+  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
 }
 void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<double>& params, cudaStream_t stream) {
-  size_t N = params.extents[0][0] * params.extents[1][0] * params.extents[2][0];
-  for (int i = 1; i < params.ncopies; ++i) {
-    N = std::max(N, params.extents[0][i] * params.extents[1][i] * params.extents[2][i]);
-  }
-  int blocks_per_copy = (N + CUDECOMP_CUDA_NTHREADS - 1) / CUDECOMP_CUDA_NTHREADS;
-  cudecomp_batched_d2d_memcpy_3d_k<<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
-      params, blocks_per_copy);
-  CHECK_CUDA_LAUNCH();
+  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
 }
 void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<float>>& params,
                                     cudaStream_t stream) {
-  size_t N = params.extents[0][0] * params.extents[1][0] * params.extents[2][0];
-  for (int i = 1; i < params.ncopies; ++i) {
-    N = std::max(N, params.extents[0][i] * params.extents[1][i] * params.extents[2][i]);
-  }
-  int blocks_per_copy = (N + CUDECOMP_CUDA_NTHREADS - 1) / CUDECOMP_CUDA_NTHREADS;
-  cudecomp_batched_d2d_memcpy_3d_k<<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
-      params, blocks_per_copy);
-  CHECK_CUDA_LAUNCH();
+  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
 }
 void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<double>>& params,
                                     cudaStream_t stream) {
-  size_t N = params.extents[0][0] * params.extents[1][0] * params.extents[2][0];
-  for (int i = 1; i < params.ncopies; ++i) {
-    N = std::max(N, params.extents[0][i] * params.extents[1][i] * params.extents[2][i]);
-  }
-  int blocks_per_copy = (N + CUDECOMP_CUDA_NTHREADS - 1) / CUDECOMP_CUDA_NTHREADS;
-
-  cudecomp_batched_d2d_memcpy_3d_k<<<params.ncopies * blocks_per_copy, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(
-      params, blocks_per_copy);
-  CHECK_CUDA_LAUNCH();
+  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
 }
 
 } // namespace cudecomp


### PR DESCRIPTION
This PR improves the performance of the batched memcpy kernel used in cuDecomp for packing/unpacking. The existing implementation was found to not achieve as high percentages of peak HBM bandwidth on the latest NVIDIA platforms (e.g. B200). This modified implementation significantly improves performance on newer platforms while maintaining (or slightly improving) performance on existing platforms. 