### PR TITLE
Remove redundant axis-contiguous/transpose_mem_order configurations from halo tests. Update axis-contiguous test configurations to not supply transpose_mem_order argument.

### DIFF
--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -222,12 +222,12 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
     ! Command line arguments
     integer :: gx, gy, gz
     integer :: comm_backend
-    logical :: axis_contiguous(3)
+    logical :: axis_contiguous
     integer :: gdims_dist(3)
     integer :: halo_extents(3)
     logical :: halo_periods(3)
     integer :: padding(3)
-    integer :: mem_order(3, 3)
+    integer :: mem_order(3)
     logical :: use_managed_memory
     integer :: pr, pc
     integer :: axis
@@ -275,12 +275,12 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
     pr = 0
     pc = 0
     comm_backend = 0
-    axis_contiguous(:) = .false.
+    axis_contiguous = .false.
     gdims_dist(:) = 0
     halo_extents(:) = 1
     halo_periods(:) = .true.
     padding(:) = 0
-    mem_order(:, :) = -1
+    mem_order(:) = -1
     axis = 1
     use_managed_memory = .false.
 
@@ -316,20 +316,10 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
           read(args(i+1), *) arg
           read(arg, *) pc
           skip_count = 1
-        case('--acx')
+        case('--ac')
           read(args(i+1), *) arg
           read(arg, *) iarg
-          axis_contiguous(1) = iarg
-          skip_count = 1
-        case('--acy')
-          read(args(i+1), *) arg
-          read(arg, *) iarg
-          axis_contiguous(2) = iarg
-          skip_count = 1
-        case('--acz')
-          read(args(i+1), *) arg
-          read(arg, *) iarg
-          axis_contiguous(3) = iarg
+          axis_contiguous = iarg
           skip_count = 1
         case('--gd')
           read(args(i+1), *) arg
@@ -384,15 +374,11 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
           read(arg, *) axis
           skip_count = 1
         case('--mem_order')
-          l = 1
           do j = 1, 3
-            do k = 1, 3
-              read(args(i+l), *) arg
-              read(arg, *) mem_order(k, j)
-              l = l + 1
-            enddo
+            read(args(i+j), *) arg
+            read(arg, *) mem_order(j)
           enddo
-          skip_count = 9
+          skip_count = 3
         case('-m')
           use_managed_memory = .true.
         case(' ')
@@ -421,8 +407,10 @@ module halo_CUDECOMP_DOUBLE_COMPLEX_mod
     gdims = [gx, gy, gz]
     config%gdims = gdims
     config%gdims_dist = gdims_dist
-    config%transpose_axis_contiguous = axis_contiguous
-    config%transpose_mem_order = mem_order
+    config%transpose_axis_contiguous(:) = axis_contiguous
+    config%transpose_mem_order(:, 1) = mem_order
+    config%transpose_mem_order(:, 2) = mem_order
+    config%transpose_mem_order(:, 3) = mem_order
 
     CHECK_CUDECOMP(cudecompGridDescAutotuneOptionsSetDefaults(options))
     options%halo_extents = halo_extents

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -6,6 +6,7 @@ base: &base
   dtypes: ['R32', 'R64', 'C32', 'C64']
   apply_skips: None
   use_single_pdim: False
+  is_halo_test: False
 
 transpose_test_base: &transpose_test_base
   <<: *base
@@ -104,6 +105,8 @@ transpose_test_ac: &transpose_test_ac
   acy: [0, 1]
   acz: [0, 1]
 
+  test_mem_order: False
+
 transpose_test_cc:
   <<: *transpose_test
   executable_prefix: 'cc/transpose_test'
@@ -196,7 +199,7 @@ halo_test_base: &halo_test_base
   run_autotuning : False
   test_mem_order: True
   fortran_indexing: False
-
+  is_halo_test: True
 
 halo_test: &halo_test
   <<: *halo_test_base
@@ -261,9 +264,8 @@ halo_test_mix: &halo_test_mix
 halo_test_ac: &halo_test_ac
   <<: *halo_test_base
   args : ['backend',
-          'acx', 'acy', 'acz',
           'gx', 'gy', 'gz',
-          'gd',
+          'ac', 'gd',
           'hex' ,'hey', 'hez',
           'hpx', 'hpy', 'hpz',
           'pdx', 'pdy', 'pdz',
@@ -272,9 +274,9 @@ halo_test_ac: &halo_test_ac
   backend: [1] # Limit this testing to one backend
   dtypes: ['R32'] # Limit to one data type
 
-  acx: [0, 1]
-  acy: [0, 1]
-  acz: [0, 1]
+  ac: [0, 1]
+
+  test_mem_order: False
 
 halo_test_cc:
   <<: *halo_test

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -77,19 +77,22 @@ def should_skip_case(arg_dict, key):
 
   return skip
 
-def generate_mem_order_args(zero_indexed):
+def generate_mem_order_args(zero_indexed, is_halo_test=False):
    if zero_indexed:
      orders_ax = [" ".join(x) for x in itertools.permutations(["0", "1", "2"])]
    else:
      orders_ax = [" ".join(x) for x in itertools.permutations(["1", "2", "3"])]
-   args = [" ".join([x, y, x]) for x, y in itertools.product(orders_ax, orders_ax)]
+   if is_halo_test:
+     args = orders_ax
+   else:
+     args = [" ".join([x, y, x]) for x, y in itertools.product(orders_ax, orders_ax)]
 
    return args
 
 def generate_command_lines(config, args):
   if (config["test_mem_order"]):
     config['args'].append("mem_order")
-    config['mem_order'] = generate_mem_order_args(not config["fortran_indexing"])
+    config['mem_order'] = generate_mem_order_args(not config["fortran_indexing"], config["is_halo_test"])
 
   cmds = []
   prs = get_factors(args.ngpu)


### PR DESCRIPTION
It has come to my attention that the existing halo testing configurations contain a lot of redundant cases. In particular, the halo testing only runs on a single pencil orientation at a time, but the current testing configuration runs through a full set of pencil memory order settings for all pencil axes. This PR removes these redundant halo test cases. Additionally, it fixes an issue with the axis-contiguous transpose and halo tests, where the `transpose_mem_order` argument was provided unnecessarily.  