### PR TITLE
Add new autotuning options to set per operation halo extent and padding arguments.

### DIFF
--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -73,12 +73,17 @@ _________________________________
   :f logical disable_nvshmem_backends: flag to disable NVSHMEM backend options during autotuning (default: false)
   :f real(c_double) skip_threshold: threshold used to skip testing slow configurations; skip configuration if :code:`skip_threshold * t > t_best`, where :code:`t` is the duration of the first timed trial for the configuration and :code:`t_best` is the average trial time of the current best configuration (default: 0.0)
   :f logical autotune_transpose_backend: flag to enable transpose backend autotuning (default: false)
-  :f logical autotune_halo_backend: flag to enable halo backend autotuning (default: false)
   :f logical transpose_use_inplace_buffers(4): flag to control whether transpose autotuning uses in-place or out-of-place buffers by operation, considering the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X (default: [false, false, false, false])
   :f real(c_double) transpose_op_weights(4): multiplicative weight to apply to trial time contribution by transpose operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X (default: [1.0, 1.0, 1.0, 1.0])
+  :f integer transpose_input_halo_extents(4): input_halo_extents argument to use during autotuning by transpose operation; second index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X, first index specifies halo_extent argument (default: all zeros, no halos)
+  :f integer transpose_output_halo_extents(4): output_halo_extents argument to use during autotuning by transpose operation; second index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X, first index specifies halo_extent argument (default: all zeros, no halos)
+  :f integer transpose_input_padding(4): input_padding argument to use during autotuning by transpose operation; second index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X, first index specifies halo_extent argument (default: all zeros, no padding)
+  :f integer transpose_output_padding(4): output_padding argument to use during autotuning by transpose operation; second index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X, first index specifies halo_extent argument (default: all zeros, no padding)
+  :f logical autotune_halo_backend: flag to enable halo backend autotuning (default: false)
   :f integer halo_extents(3): extents for halo autotuning (default: [0, 0, 0])
   :f logical halo_periods(3): periodicity for halo autotuning (default: [false, false, false])
   :f integer halo_axis: which axis pencils to use for halo autotuning (default: 1, X-pencils)
+  :f integer halo_padding(3): padding argument for halo autotuning (default: [0, 0, 0])
 
 ------
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -1,7 +1,7 @@
 Basic Usage Guide
 =================
 We can now walk through how to set up and run a basic program with cuDecomp. The code snippets in this section are taken from
-the basic usage example [link]. This example assumes we are using 4 GPUs.
+the basic usage example (`C++ <https://github.com/NVIDIA/cuDecomp/blob/main/examples/cc/basic_usage/basic_usage.cu>`_, `Fortran <https://github.com/NVIDIA/cuDecomp/blob/main/examples/fortran/basic_usage/basic_usage.f90>`_). This example assumes we are using 4 GPUs.
 
 Starting up cuDecomp
 --------------------

--- a/examples/cc/basic_usage/basic_usage_autotune.cu
+++ b/examples/cc/basic_usage/basic_usage_autotune.cu
@@ -163,7 +163,7 @@ int main(int argc, char** argv) {
   options.transpose_input_halo_extents[0][0] = 1; // set input_halo_extent to [1, 1, 1] for X-to-Y transpose
   options.transpose_input_halo_extents[0][1] = 1;
   options.transpose_input_halo_extents[0][2] = 1;
-  options.transpose_output_halo_extents[3][0] = 1; // set input_halo_extent to [1, 1, 1] for Y-to-X transpose
+  options.transpose_output_halo_extents[3][0] = 1; // set output_halo_extent to [1, 1, 1] for Y-to-X transpose
   options.transpose_output_halo_extents[3][1] = 1;
   options.transpose_output_halo_extents[3][2] = 1;
 

--- a/examples/cc/basic_usage/basic_usage_autotune.cu
+++ b/examples/cc/basic_usage/basic_usage_autotune.cu
@@ -152,18 +152,18 @@ int main(int argc, char** argv) {
 
   // Transpose communication backend autotuning options
   options.autotune_transpose_backend = true;
-  options.transpose_use_inplace_buffers[0] = true;
-  options.transpose_use_inplace_buffers[1] = true;
-  options.transpose_use_inplace_buffers[2] = true;
-  options.transpose_use_inplace_buffers[3] = true;
-  options.transpose_op_weights[0] = 1.0;
-  options.transpose_op_weights[1] = 1.0;
-  options.transpose_op_weights[2] = 1.0;
-  options.transpose_op_weights[3] = 1.0;
-  options.transpose_input_halo_extents[0][0] = 1;
+  options.transpose_use_inplace_buffers[0] = true; // use in-place buffers for X-to-Y transpose
+  options.transpose_use_inplace_buffers[1] = true; // use in-place buffers for Y-to-Z transpose
+  options.transpose_use_inplace_buffers[2] = true; // use in-place buffers for Z-to-Y transpose
+  options.transpose_use_inplace_buffers[3] = true; // use in-place buffers for Y-to-X transpose
+  options.transpose_op_weights[0] = 1.0; // apply 1.0 multiplier to X-to-Y transpose timings
+  options.transpose_op_weights[1] = 1.0; // apply 1.0 multiplier to Y-to-Z transpose timings
+  options.transpose_op_weights[2] = 1.0; // apply 1.0 multiplier to Z-to-Y transpose timings
+  options.transpose_op_weights[3] = 1.0; // apply 1.0 multiplier to Y-to-X transpose timings
+  options.transpose_input_halo_extents[0][0] = 1; // set input_halo_extent to [1, 1, 1] for X-to-Y transpose
   options.transpose_input_halo_extents[0][1] = 1;
   options.transpose_input_halo_extents[0][2] = 1;
-  options.transpose_output_halo_extents[3][0] = 1;
+  options.transpose_output_halo_extents[3][0] = 1; // set input_halo_extent to [1, 1, 1] for Y-to-X transpose
   options.transpose_output_halo_extents[3][1] = 1;
   options.transpose_output_halo_extents[3][2] = 1;
 

--- a/examples/cc/basic_usage/basic_usage_autotune.cu
+++ b/examples/cc/basic_usage/basic_usage_autotune.cu
@@ -160,6 +160,12 @@ int main(int argc, char** argv) {
   options.transpose_op_weights[1] = 1.0;
   options.transpose_op_weights[2] = 1.0;
   options.transpose_op_weights[3] = 1.0;
+  options.transpose_input_halo_extents[0][0] = 1;
+  options.transpose_input_halo_extents[0][1] = 1;
+  options.transpose_input_halo_extents[0][2] = 1;
+  options.transpose_output_halo_extents[3][0] = 1;
+  options.transpose_output_halo_extents[3][1] = 1;
+  options.transpose_output_halo_extents[3][2] = 1;
 
   // Halo communication backend autotuning options
   options.autotune_halo_backend = true;

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -120,7 +120,7 @@ program main
   options%transpose_op_weights(3) = 1.0 ! apply 1.0 multiplier to Z-to-Y transpose timings
   options%transpose_op_weights(4) = 1.0 ! apply 1.0 multiplier to Y-to-X transpose timings
   options%transpose_input_halo_extents(:, 1) = [1, 1, 1] ! set input_halo_extent to [1, 1, 1] for X-to-Y transpose
-  options%transpose_output_halo_extents(:, 4) = [1, 1, 1] ! set input_halo_extent to [1, 1, 1] for Y-to-X transpose
+  options%transpose_output_halo_extents(:, 4) = [1, 1, 1] ! set output_halo_extent to [1, 1, 1] for Y-to-X transpose
 
   ! Halo communication backend autotuning options
   options%autotune_halo_backend = .true.

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -111,16 +111,16 @@ program main
 
   ! Transpose communication backend autotuning options
   options%autotune_transpose_backend = .true.
-  options%transpose_use_inplace_buffers(1) = .true.
-  options%transpose_use_inplace_buffers(2) = .true.
-  options%transpose_use_inplace_buffers(3) = .true.
-  options%transpose_use_inplace_buffers(4) = .true.
-  options%transpose_op_weights(1) = 1.0
-  options%transpose_op_weights(2) = 1.0
-  options%transpose_op_weights(3) = 1.0
-  options%transpose_op_weights(4) = 1.0
-  options%transpose_input_halo_extents(:, 1) = [1, 1, 1]
-  options%transpose_output_halo_extents(:, 4) = [1, 1, 1]
+  options%transpose_use_inplace_buffers(1) = .true. ! use in-place buffers for X-to-Y transpose
+  options%transpose_use_inplace_buffers(2) = .true. ! use in-place buffers for Y-to-Z transpose
+  options%transpose_use_inplace_buffers(3) = .true. ! use in-place buffers for Z-to-Y transpose
+  options%transpose_use_inplace_buffers(4) = .true. ! use in-place buffers for Y-to-X transpose
+  options%transpose_op_weights(1) = 1.0 ! apply 1.0 multiplier to X-to-Y transpose timings
+  options%transpose_op_weights(2) = 1.0 ! apply 1.0 multiplier to Y-to-Z transpose timings
+  options%transpose_op_weights(3) = 1.0 ! apply 1.0 multiplier to Z-to-Y transpose timings
+  options%transpose_op_weights(4) = 1.0 ! apply 1.0 multiplier to Y-to-X transpose timings
+  options%transpose_input_halo_extents(:, 1) = [1, 1, 1] ! set input_halo_extent to [1, 1, 1] for X-to-Y transpose
+  options%transpose_output_halo_extents(:, 4) = [1, 1, 1] ! set input_halo_extent to [1, 1, 1] for Y-to-X transpose
 
   ! Halo communication backend autotuning options
   options%autotune_halo_backend = .true.

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -119,6 +119,8 @@ program main
   options%transpose_op_weights(2) = 1.0
   options%transpose_op_weights(3) = 1.0
   options%transpose_op_weights(4) = 1.0
+  options%transpose_input_halo_extents(:, 1) = [1, 1, 1]
+  options%transpose_output_halo_extents(:, 4) = [1, 1, 1]
 
   ! Halo communication backend autotuning options
   options%autotune_halo_backend = .true.

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -176,11 +176,30 @@ typedef struct {
                                   ///< in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X
                                   ///< (default: [1.0, 1.0, 1.0, 1.0])
 
+  int32_t transpose_input_halo_extents[4][3];  ///< input_halo_extents argument to use during autotuning by transpose operation
+                                               ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to X,
+                                               ///< second index specifies halo_extent argument
+                                               ///< (default: all zeros, no halos)
+  int32_t transpose_output_halo_extents[4][3]; ///< output_halo_extents argument to use during autotuning by transpose operation in
+                                               ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to X,
+                                               ///< second index specifies halo_extent argument
+                                               ///< (default: all zeros, no halos)
+
+  int32_t transpose_input_padding[4][3];  ///< input_padding argument to use during autotuning by transpose operation
+                                          ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to X,
+                                          ///< second index specifies input_padding argument
+                                          ///< (default: all zeros, no padding)
+  int32_t transpose_output_padding[4][3]; ///< output_padding argument to use during autotuning by transpose operation
+                                          ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to X,
+                                          ///< second index specifies input_padding argument
+                                          ///< (default: all zeros, no padding)
+
   // Halo-specific options
   bool autotune_halo_backend; ///< flag to enable halo backend autotuning (default: false)
   int32_t halo_extents[3];    ///< extents for halo autotuning (default: [0, 0, 0])
   bool halo_periods[3];       ///< periodicity for halo autotuning (default: [false, false, false])
   int32_t halo_axis;          ///< which axis pencils to use for halo autotuning (default: 0, X-pencils)
+  int32_t halo_padding[3];    ///< padding argument for halo autotuning (default: [0, 0, 0])
 } cudecompGridDescAutotuneOptions_t;
 
 /**

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -176,21 +176,21 @@ typedef struct {
                                   ///< in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X
                                   ///< (default: [1.0, 1.0, 1.0, 1.0])
 
-  int32_t transpose_input_halo_extents[4][3];  ///< input_halo_extents argument to use during autotuning by transpose operation
-                                               ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to X,
+  int32_t transpose_input_halo_extents[4][3];  ///< input_halo_extents argument to use during autotuning by transpose operation;
+                                               ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X,
                                                ///< second index specifies halo_extent argument
                                                ///< (default: all zeros, no halos)
-  int32_t transpose_output_halo_extents[4][3]; ///< output_halo_extents argument to use during autotuning by transpose operation in
-                                               ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to X,
+  int32_t transpose_output_halo_extents[4][3]; ///< output_halo_extents argument to use during autotuning by transpose operation;
+                                               ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X,
                                                ///< second index specifies halo_extent argument
                                                ///< (default: all zeros, no halos)
 
-  int32_t transpose_input_padding[4][3];  ///< input_padding argument to use during autotuning by transpose operation
-                                          ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to X,
+  int32_t transpose_input_padding[4][3];  ///< input_padding argument to use during autotuning by transpose operation;
+                                          ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X,
                                           ///< second index specifies input_padding argument
                                           ///< (default: all zeros, no padding)
-  int32_t transpose_output_padding[4][3]; ///< output_padding argument to use during autotuning by transpose operation
-                                          ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to X,
+  int32_t transpose_output_padding[4][3]; ///< output_padding argument to use during autotuning by transpose operation;
+                                          ///< first index specifies operation in the following order: X-to-Y, Y-to-Z, Z-to-Y, Y-to-X,
                                           ///< second index specifies input_padding argument
                                           ///< (default: all zeros, no padding)
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -756,6 +756,12 @@ cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAuto
     for (int i = 0; i < 4; ++i) {
       options->transpose_use_inplace_buffers[i] = false;
       options->transpose_op_weights[i] = 1.0;
+      for (int j = 0; j < 3; ++j) {
+        options->transpose_input_halo_extents[i][j] = 0;
+        options->transpose_output_halo_extents[i][j] = 0;
+        options->transpose_input_padding[i][j] = 0;
+        options->transpose_output_padding[i][j] = 0;
+      }
     }
 
     // Halo-specific options
@@ -764,6 +770,7 @@ cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAuto
     for (int i = 0; i < 3; ++i) {
       options->halo_extents[i] = 0;
       options->halo_periods[i] = false;
+      options->halo_padding[i] = 0;
     }
 
   } catch (const cudecomp::BaseException& e) {

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -142,12 +142,17 @@ module cudecomp
     logical(c_bool) :: autotune_transpose_backend ! flag to enable transpose backend autotuning
     logical(c_bool) :: transpose_use_inplace_buffers(4) ! flag to control whether transpose autotuning uses in-place or out-of-place buffers
     real(c_double) :: transpose_op_weights(4) ! multiplicative weight to apply to trial time contribution by transpose operation
+    integer(c_int32_t) :: transpose_input_halo_extents(3, 4) ! input_halo_extents argument to use during autotuning by transpose operation
+    integer(c_int32_t) :: transpose_output_halo_extents(3, 4) ! output_halo_extents argument to use during autotuning by transpose operation
+    integer(c_int32_t) :: transpose_input_padding(3, 4) ! input_padding argument to use during autotuning by transpose operation
+    integer(c_int32_t) :: transpose_output_padding(3, 4) ! output_padding argument to use during autotuning by transpose operation
 
     ! Halo-specific options
     logical(c_bool) :: autotune_halo_backend ! flag to enable halo backend autotuning
-    integer(c_int32_t) :: halo_extents(3) ! halo configuration for autotuning
-    logical(c_bool) :: halo_periods(3) ! halo configuration for autotuning
-    integer(c_int32_t) :: halo_axis ! halo configuration for autotuning
+    integer(c_int32_t) :: halo_extents(3) ! extents for halo autotuning
+    logical(c_bool) :: halo_periods(3) ! periodicity for halo autotuning
+    integer(c_int32_t) :: halo_axis ! which axis pencils to use for halo autotuning
+    integer(c_int32_t) :: halo_padding(3) ! padding argument for halo autotuning
   end type cudecompGridDescAutotuneOptions
 
   ! Info structure containing pencil specific information


### PR DESCRIPTION
The current autotuning implementation in cuDecomp does not allow users to specify non-default values of some of the optional arguments to the `cudecompTranpose*` and `cudecompUpdateHalo*` that control input and output halo extents and padding for transposes and padding for halo updates. Non-default values of these arguments can alter the path cuDecomp takes to perform a transpose or halo update; in particular, the presence of halos or padding can disable certain optimizations (e.g. bypassing copies into the work buffer). 

To improve autotuning accuracy in these situtions, this PR adds the ability for users to specify per operation halo extent and padding arguments to use during autotuning via new entries in the `cudecompGridDescAutotuneOptions_t` structure. This enables users to more precisely control the arguments to the transpose/halo operations run during autotuning if they require non-default halo extent and padding arguments.