### PR TITLE
Enable usage of NVSHMEM synchronization functions in NVSHMEM backends

### DIFF
--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -23,3 +23,12 @@ CUDECOMP_ENABLE_CUMEM
 some MPI distributions on multi-node NVLink (MNNVL) capable systems.
 
 Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.
+
+CUDECOMP_ENABLE_NVSHMEM_SYNC
+----------------------------
+(since v0.5.1, requires NVSHMEM 2.5.0 or newer)
+
+:code:`CUDECOMP_ENABLE_NVSHMEM_SYNC` controls whether cuDecomp uses NVSHMEM synchronization APIs in communication backends using NVSHMEM. This option makes these backends CPU synchronization free which
+can improve performance in some cases.
+
+Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -61,16 +61,12 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
                  const std::vector<comm_count_t>& send_counts, const std::vector<comm_count_t>& send_offsets,
                  T* recv_buff, const std::vector<comm_count_t>& recv_counts,
                  const std::vector<comm_count_t>& recv_offsets, cudecompCommAxis comm_axis, cudaStream_t stream = 0) {
-  auto comm = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.mpi_comm : grid_desc->col_comm_info.mpi_comm;
-  // auto team =
-  //    (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.nvshmem_team :
-  //    grid_desc->col_comm_info.nvshmem_team;
+  auto team = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.nvshmem_team :
+                                                 grid_desc->col_comm_info.nvshmem_team;
+
   int self_rank = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.rank : grid_desc->col_comm_info.rank;
 
-  // Using cudaStreamSynchronize + barrier instead of nvshmemx_team_sync_on_stream for lower latency
-  CHECK_CUDA(cudaStreamSynchronize(stream));
-  CHECK_MPI(MPI_Barrier(comm));
-  // nvshmemx_team_sync_on_stream(team, stream);
+  nvshmemx_team_sync_on_stream(team, stream);
 
   cudecompNvshmemA2AParams<T> params;
   params.send_buff = send_buff;
@@ -115,12 +111,12 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   CHECK_CUDA(cudaMemcpyAsync(recv_buff + recv_offsets[self_rank], send_buff + send_offsets[self_rank],
                              send_counts[self_rank] * sizeof(T), cudaMemcpyDeviceToDevice, stream));
 
+#if NVSHMEM_VENDOR_VERSION >= 20500
+  nvshmemx_barrier_on_stream(team, stream);
+#else
   nvshmemx_quiet_on_stream(stream);
-
-  // Using cudaStreamSynchronize + barrier instead of nvshmemx_team_sync_on_stream for lower latency
-  CHECK_CUDA(cudaStreamSynchronize(stream));
-  CHECK_MPI(MPI_Barrier(comm));
-  // nvshmemx_team_sync_on_stream(team, stream);
+  nvshmemx_team_sync_on_stream(team, stream);
+#endif
 }
 #endif
 
@@ -273,10 +269,8 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
   case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL: {
 #ifdef ENABLE_NVSHMEM
     if (nvshmem_ptr(send_buff, handle->rank) && nvshmem_ptr(recv_buff, handle->rank)) {
-      auto comm =
-          (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.mpi_comm : grid_desc->col_comm_info.mpi_comm;
-      // auto team = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.nvshmem_team
-      //                                             : grid_desc->col_comm_info.nvshmem_team;
+      auto team = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.nvshmem_team
+                                                   : grid_desc->col_comm_info.nvshmem_team;
       auto pl_stream = handle->pl_stream;
       int self_rank = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.rank : grid_desc->col_comm_info.rank;
 
@@ -292,9 +286,7 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
         } else {
           CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank], 0));
           if (!synced) {
-            // Using cudaStreamSynchronize + barrier instead of nvshmemx_team_sync_on_stream for lower latency
-            CHECK_CUDA(cudaStreamSynchronize(pl_stream));
-            CHECK_MPI(MPI_Barrier(comm));
+            nvshmemx_team_sync_on_stream(team, pl_stream);
             // Only need to sync on the first remote operation of an alltoall sequence to ensure reads on other ranks
             // from previous communication have completed.
             synced = true;
@@ -317,20 +309,21 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
       }
 
       if (barrier) {
+#if NVSHMEM_VENDOR_VERSION >= 20500
+        nvshmemx_barrier_on_stream(team, pl_stream);
+#else
         nvshmemx_quiet_on_stream(pl_stream);
-        // Using cudaStreamSynchronize + barrier instead of nvshmemx_team_sync_on_stream for lower latency
-        CHECK_CUDA(cudaStreamSynchronize(pl_stream));
-        CHECK_MPI(MPI_Barrier(comm));
+        nvshmemx_team_sync_on_stream(team, pl_stream);
+#endif
+        for (int i = 0; i < src_ranks.size(); ++i) {
+          int src_rank = src_ranks[i];
+          int dst_rank = dst_ranks[i];
+          if (src_rank != self_rank) {
+            CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], pl_stream));
+            CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[dst_rank], 0));
+          }
+        }
 
-        // nvshmemx_team_sync_on_stream(team, pl_stream);
-        // for (int i = 0; i < src_ranks.size(); ++i) {
-        //  int src_rank = src_ranks[i];
-        //  int dst_rank = dst_ranks[i];
-        //  if (src_rank != self_rank) {
-        //    CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], pl_stream));
-        //    CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[dst_rank], 0));
-        //  }
-        //}
       }
       break;
     } else {
@@ -456,8 +449,12 @@ static void cudecompSendRecvPair(const cudecompHandle_t& handle, const cudecompG
   case CUDECOMP_HALO_COMM_NVSHMEM_BLOCKING: {
 #ifdef ENABLE_NVSHMEM
     if (nvshmem_ptr(send_buff, handle->rank) && nvshmem_ptr(recv_buff, handle->rank)) {
+#if NVSHMEM_VENDOR_VERSION >= 20500
+      nvshmemx_barrier_all_on_stream(stream);
+#else
       nvshmemx_quiet_on_stream(stream);
       nvshmemx_sync_all_on_stream(stream);
+#endif
       for (int i = 0; i < send_counts.size(); ++i) {
         if (peer_ranks[i] == handle->rank) {
           // Self-copy with cudaMemcpy
@@ -470,14 +467,22 @@ static void cudecompSendRecvPair(const cudecompHandle_t& handle, const cudecompG
           }
         }
         if (grid_desc->config.halo_comm_backend == CUDECOMP_HALO_COMM_NVSHMEM_BLOCKING) {
+#if NVSHMEM_VENDOR_VERSION >= 20500
+          nvshmemx_barrier_all_on_stream(stream);
+#else
           nvshmemx_quiet_on_stream(stream);
           nvshmemx_sync_all_on_stream(stream);
+#endif
         }
       }
 
       if (grid_desc->config.halo_comm_backend == CUDECOMP_HALO_COMM_NVSHMEM) {
+#if NVSHMEM_VENDOR_VERSION >= 20500
+        nvshmemx_barrier_all_on_stream(stream);
+#else
         nvshmemx_quiet_on_stream(stream);
         nvshmemx_sync_all_on_stream(stream);
+#endif
       };
       break;
     } else {

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -92,6 +92,7 @@ struct cudecompHandle {
   bool nvshmem_vmm;                                      // Flag to track if NVSHMEM is using VMM allocations
   std::unordered_map<void*, size_t> nvshmem_allocations; // Table to record NVSHMEM allocations
   size_t nvshmem_allocation_size = 0;                    // Total of NVSHMEM allocations
+  bool nvshmem_sync_enable = false; // Flag to control whether NVSHMEM synchrnoization APIs are used
 
   // Multi-node NVLINK (MNNVL)
   bool cuda_cumem_enable = false; // Flag to control whether cuMem* APIs are used for cudecompMalloc/Free


### PR DESCRIPTION
Currently, NVSHMEM communication backends in cuDecomp utilize `MPI_Barrier` calls (in combination with CUDA device synchronization functions) for synchronization. Historically, the MPI-based synchronization provided greater performance than the equivalent NVSHMEM functionalities (e.g. `nvshmem_sync`/`nvshmem_barrier`). The primary issue with this approach is that it introduces CPU/device synchronization, which would not be required in a pure NVSHMEM-based approach. This additional synchronization can be problematic in cases at the limits of strong scaling, where kernel launch latency overheads might be exacerbated by excessive device synchronization.

This PR introduces an optional path to use NVSHMEM synchronization functions, enabled via environment variable `CUDECOMP_ENABLE_NVSHMEM_SYNC`. Enabling this option will use NVSHMEM synchronization functions in place of the existing `MPI_Barrier`-based synchronization in the NVSHMEM cmomunication backends, making them CPU synchronization free. This feature is currently disabled by default.