### PR TITLE
Improve initial NVSHMEM team synchronzation for transpose ops.

### DIFF
--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -130,6 +130,9 @@ struct cudecompGridDesc {
   cudecompCommInfo col_comm_info; // column communicator information
 
   std::vector<cudaEvent_t> events{nullptr}; // CUDA events used for scheduling
+#ifdef ENABLE_NVSHMEM
+  cudaEvent_t nvshmem_sync_event = nullptr; // NVSHMEM event used for synchronization
+#endif
 
   cudecomp::graphCache graph_cache; // CUDA graph cache
 

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -246,6 +246,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   if (transposeBackendRequiresNvshmem(grid_desc->config.transpose_comm_backend)) {
     auto max_pencil_size_a = getGlobalMaxPencilSize(handle, grid_desc, ax_a);
     o2 = work + max_pencil_size_a;
+    // Record event at start of transpose op for NVSHMEM team synchronization
+    CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, stream));
   }
 
   // Adjust pointers to handle special cases

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -564,6 +564,9 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
     for (auto& event : grid_desc->events) {
       CHECK_CUDA(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
     }
+#ifdef ENABLE_NVSHMEM
+    CHECK_CUDA(cudaEventCreateWithFlags(&grid_desc->nvshmem_sync_event, cudaEventDisableTiming));
+#endif
 
     // Disable decompositions with empty pencils
     if (!autotune_pdims &&
@@ -673,6 +676,10 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
     for (auto e : grid_desc->events) {
       if (e) { CHECK_CUDA(cudaEventDestroy(e)); }
     }
+
+#ifdef ENABLE_NVSHMEM
+    if (grid_desc->nvshmem_sync_event) { CHECK_CUDA(cudaEventDestroy(grid_desc->nvshmem_sync_event)); }
+#endif
 
     if (transposeBackendRequiresNccl(grid_desc->config.transpose_comm_backend) ||
         haloBackendRequiresNccl(grid_desc->config.halo_comm_backend)) {


### PR DESCRIPTION
The NVSHMEM backends in cuDecomp require team synchronization between transpose operations to ensure remote write operations for the current operation do not occur before the previous operation has completed (e.g. remote operations complete and received data has been fully unpacked). Currently, this is accomplished by syncing the CPU to the CUDA stream provided to the transpose operation and calling `MPI_Barrier` right before scheduling new NVSHMEM remote operations (for example: https://github.com/NVIDIA/cuDecomp/blob/80eb854e33926fa6786796bbbc9a8bb48acf3132/include/internal/comm_routines.h#L70-L73)

The issue is that the CUDA stream at this synchronization point will have initial pack/transpose kernels scheduled. This means the current NVSHMEM team sync procedure waits until after the initial pack/transpose kernels complete before running the `MPI_Barrier`, when really, the `MPI_Barrier` should be able to overlap with these kernels.

This PR adjust the NVSHMEM synchronization process in cuDecomp to achieve this overlap and operate a bit more efficiently.

I plan on revisting NVSHMEM synchronization more broadly in a future release, but this is a simple change for better performance now.