### PR TITLE
Add performance reporting feature.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ target_sources(cudecomp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/graph.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/nvml_wrap.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/performance.cc
 )
 
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/cudecomp_kernels_rdc.cu PROPERTIES COMPILE_FLAGS -rdc=true)

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -33,11 +33,11 @@ and communication overlap of packing kernels in large scale cases.
 
 Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.
 
-CUDECOMP_ENABLE_PERFORMANCE_REPORTING
--------------------------------------
+CUDECOMP_ENABLE_PERFORMANCE_REPORT
+------------------------------------
 (since v0.5.1)
 
-:code:`CUDECOMP_ENABLE_PERFORMANCE_REPORTING` controls whether cuDecomp performance reporting is enabled.
+:code:`CUDECOMP_ENABLE_PERFORMANCE_REPORT` controls whether cuDecomp performance reporting is enabled.
 
 Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.
 
@@ -45,13 +45,13 @@ CUDECOMP_PERFORMANCE_REPORT_DETAIL
 ----------------------------------
 (since v0.5.1)
 
-:code:`CUDECOMP_PERFORMANCE_REPORT_DETAIL` controls the verbosity of performance reporting when :code:`CUDECOMP_ENABLE_PERFORMANCE_REPORTING` is enabled. This setting determines whether individual sample data is printed in addition to the aggregated performance summary.
+:code:`CUDECOMP_PERFORMANCE_REPORT_DETAIL` controls the verbosity of performance reporting when :code:`CUDECOMP_ENABLE_PERFORMANCE_REPORT` is enabled. This setting determines whether individual sample data is printed in addition to the aggregated performance summary.
 
 The following values are supported:
 
 - :code:`0`: Aggregated report only - prints only the summary table with averaged performance statistics (default)
-- :code:`1`: Per-sample reporting on rank 0 - prints individual sample data for each transpose configuration, but only from rank 0
-- :code:`2`: Per-sample reporting on all ranks - prints individual sample data for each transpose configuration from all ranks, gathered and sorted by rank on rank 0
+- :code:`1`: Per-sample reporting on rank 0 - prints individual sample data for each transpose/halo configuration, but only from rank 0
+- :code:`2`: Per-sample reporting on all ranks - prints individual sample data for each transpose/halo configuration from all ranks, gathered and sorted by rank on rank 0
 
 Default setting is :code:`0`.
 
@@ -59,14 +59,14 @@ CUDECOMP_PERFORMANCE_REPORT_SAMPLES
 -----------------------------------
 (since v0.5.1)
 
-:code:`CUDECOMP_PERFORMANCE_REPORT_SAMPLES` controls the number of performance samples to keep for the final performance report. This setting determines the size of the circular buffer used to store timing measurements for each transpose configuration.
+:code:`CUDECOMP_PERFORMANCE_REPORT_SAMPLES` controls the number of performance samples to keep for the final performance report. This setting determines the size of the circular buffer used to store timing measurements for each transpose/halo configuration.
 
-Default setting is :code:`20` samples. Valid range is 1-1000 samples.
+Default setting is :code:`20` samples.
 
 CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES
 ------------------------------------------
 (since v0.5.1)
 
-:code:`CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES` controls the number of initial samples to ignore for each transpose configuration. This helps exclude outliers from GPU warmup, memory allocation, and other initialization effects from the final performance statistics.
+:code:`CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES` controls the number of initial samples to ignore for each transpose/halo configuration. This helps exclude outliers from GPU warmup, memory allocation, and other initialization effects from the final performance statistics.
 
-Default setting is :code:`3` warmup samples. Valid range is 0-100 samples. Setting this to 0 disables warmup sample filtering.
+Default setting is :code:`3` warmup samples. Setting this to 0 disables warmup sample filtering.

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -32,3 +32,12 @@ CUDECOMP_ENABLE_CUDA_GRAPHS
 and communication overlap of packing kernels in large scale cases.
 
 Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.
+
+CUDECOMP_ENABLE_PERFORMANCE_REPORTING
+-------------------------------------
+(since v0.5.1)
+
+:code:`CUDECOMP_ENABLE_PERFORMANCE_REPORTING` controls whether cuDecomp prints performance reports to the console. With this option enabled, cuDecomp will print performance metrics for each transpose operation called.
+This option requires a device synchronization after each transpose operation to capture event timings which can impact performance.
+
+Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -78,7 +78,7 @@ CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR
 :code:`CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR` controls the directory where CSV performance reports are written when :code:`CUDECOMP_ENABLE_PERFORMANCE_REPORT` is enabled. When this variable is set, cuDecomp will write performance data to CSV files in the specified directory.
 
 CSV files are created with descriptive names encoding the grid configuration, for example:
-:code:`cudecomp-perf-report-transpose-tcomm_1-hcomm_1-pdims_2x2-gdims_256x256x256-memorder_012012012.csv`
+:code:`cudecomp-perf-report-transpose-aggregated-tcomm_1-hcomm_1-pdims_2x2-gdims_256x256x256-memorder_012012012.csv`
 
 The following CSV files are generated:
 

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -37,7 +37,28 @@ CUDECOMP_ENABLE_PERFORMANCE_REPORTING
 -------------------------------------
 (since v0.5.1)
 
-:code:`CUDECOMP_ENABLE_PERFORMANCE_REPORTING` controls whether cuDecomp prints performance reports to the console. With this option enabled, cuDecomp will print performance metrics for each transpose operation called.
-This option requires a device synchronization after each transpose operation to capture event timings which can impact performance.
+:code:`CUDECOMP_ENABLE_PERFORMANCE_REPORTING` controls the level of performance reporting cuDecomp prints to the console. This option requires a device synchronization after each transpose operation to capture event timings which can impact performance.
 
-Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.
+The following values are supported:
+
+- :code:`0`: Performance reporting disabled
+- :code:`1`: Final performance summary only - prints a comprehensive table with averaged performance statistics for all transpose operation configurations when the grid descriptor is destroyed
+- :code:`2`: Verbose reporting - prints both per-operation performance reports and the final performance summary
+
+Default setting is off (:code:`0`).
+
+CUDECOMP_PERFORMANCE_REPORT_SAMPLES
+-----------------------------------
+(since v0.5.1)
+
+:code:`CUDECOMP_PERFORMANCE_REPORT_SAMPLES` controls the number of performance samples to keep for the final performance report. This setting determines the size of the circular buffer used to store timing measurements for each transpose configuration.
+
+Default setting is :code:`20` samples. Valid range is 1-1000 samples.
+
+CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES
+------------------------------------------
+(since v0.5.1)
+
+:code:`CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES` controls the number of initial samples to ignore for each transpose configuration. This helps exclude outliers from GPU warmup, memory allocation, and other initialization effects from the final performance statistics.
+
+Default setting is :code:`2` warmup samples. Valid range is 0-100 samples. Setting this to 0 disables warmup sample filtering.

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -70,3 +70,23 @@ CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES
 :code:`CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES` controls the number of initial samples to ignore for each transpose/halo configuration. This helps exclude outliers from GPU warmup, memory allocation, and other initialization effects from the final performance statistics.
 
 Default setting is :code:`3` warmup samples. Setting this to 0 disables warmup sample filtering.
+
+CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR
+-------------------------------------
+(since v0.5.1)
+
+:code:`CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR` controls the directory where CSV performance reports are written when :code:`CUDECOMP_ENABLE_PERFORMANCE_REPORT` is enabled. When this variable is set, cuDecomp will write performance data to CSV files in the specified directory.
+
+CSV files are created with descriptive names encoding the grid configuration, for example:
+:code:`cudecomp-perf-report-transpose-tcomm_1-hcomm_1-pdims_2x2-gdims_256x256x256-memorder_012012012.csv`
+
+The following CSV files are generated:
+
+- Aggregated transpose performance data
+- Aggregated halo performance data
+- Per-sample transpose data (when :code:`CUDECOMP_PERFORMANCE_REPORT_DETAIL` > 0)
+- Per-sample halo data (when :code:`CUDECOMP_PERFORMANCE_REPORT_DETAIL` > 0)
+
+Each CSV file includes grid configuration information as comments at the top, followed by performance data in comma-separated format.
+
+Default setting is unset (no CSV files written). Setting this variable to a directory path will enable CSV file output.

--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -37,15 +37,23 @@ CUDECOMP_ENABLE_PERFORMANCE_REPORTING
 -------------------------------------
 (since v0.5.1)
 
-:code:`CUDECOMP_ENABLE_PERFORMANCE_REPORTING` controls the level of performance reporting cuDecomp prints to the console. This option requires a device synchronization after each transpose operation to capture event timings which can impact performance.
+:code:`CUDECOMP_ENABLE_PERFORMANCE_REPORTING` controls whether cuDecomp performance reporting is enabled.
+
+Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable this feature.
+
+CUDECOMP_PERFORMANCE_REPORT_DETAIL
+----------------------------------
+(since v0.5.1)
+
+:code:`CUDECOMP_PERFORMANCE_REPORT_DETAIL` controls the verbosity of performance reporting when :code:`CUDECOMP_ENABLE_PERFORMANCE_REPORTING` is enabled. This setting determines whether individual sample data is printed in addition to the aggregated performance summary.
 
 The following values are supported:
 
-- :code:`0`: Performance reporting disabled
-- :code:`1`: Final performance summary only - prints a comprehensive table with averaged performance statistics for all transpose operation configurations when the grid descriptor is destroyed
-- :code:`2`: Verbose reporting - prints both per-operation performance reports and the final performance summary
+- :code:`0`: Aggregated report only - prints only the summary table with averaged performance statistics (default)
+- :code:`1`: Per-sample reporting on rank 0 - prints individual sample data for each transpose configuration, but only from rank 0
+- :code:`2`: Per-sample reporting on all ranks - prints individual sample data for each transpose configuration from all ranks, gathered and sorted by rank on rank 0
 
-Default setting is off (:code:`0`).
+Default setting is :code:`0`.
 
 CUDECOMP_PERFORMANCE_REPORT_SAMPLES
 -----------------------------------
@@ -61,4 +69,4 @@ CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES
 
 :code:`CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES` controls the number of initial samples to ignore for each transpose configuration. This helps exclude outliers from GPU warmup, memory allocation, and other initialization effects from the final performance statistics.
 
-Default setting is :code:`2` warmup samples. Valid range is 0-100 samples. Setting this to 0 disables warmup sample filtering.
+Default setting is :code:`3` warmup samples. Valid range is 0-100 samples. Setting this to 0 disables warmup sample filtering.

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -150,12 +150,13 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 #endif
 
 template <typename T>
-static void
-cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_desc, T* send_buff,
-                 const std::vector<comm_count_t>& send_counts, const std::vector<comm_count_t>& send_offsets,
-                 T* recv_buff, const std::vector<comm_count_t>& recv_counts,
-                 const std::vector<comm_count_t>& recv_offsets, const std::vector<comm_count_t>& recv_offsets_nvshmem,
-                 cudecompCommAxis comm_axis, cudaStream_t stream, cudecompTransposePerformanceSample* current_sample = nullptr) {
+static void cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_desc, T* send_buff,
+                             const std::vector<comm_count_t>& send_counts,
+                             const std::vector<comm_count_t>& send_offsets, T* recv_buff,
+                             const std::vector<comm_count_t>& recv_counts,
+                             const std::vector<comm_count_t>& recv_offsets,
+                             const std::vector<comm_count_t>& recv_offsets_nvshmem, cudecompCommAxis comm_axis,
+                             cudaStream_t stream, cudecompTransposePerformanceSample* current_sample = nullptr) {
   nvtx::rangePush("cudecompAlltoall");
 
   if (handle->performance_report_enable) {
@@ -283,19 +284,17 @@ cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 }
 
 template <typename T>
-static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_desc, T* send_buff,
-                                      const std::vector<comm_count_t>& send_counts,
-                                      const std::vector<comm_count_t>& send_offsets, T* recv_buff,
-                                      const std::vector<comm_count_t>& recv_counts,
-                                      const std::vector<comm_count_t>& recv_offsets,
-                                      const std::vector<comm_count_t>& recv_offsets_nvshmem, cudecompCommAxis comm_axis,
-                                      const std::vector<int>& src_ranks, const std::vector<int>& dst_ranks,
-                                      cudaStream_t stream, bool& synced, cudecompTransposePerformanceSample* current_sample = nullptr) {
+static void
+cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_desc, T* send_buff,
+                          const std::vector<comm_count_t>& send_counts, const std::vector<comm_count_t>& send_offsets,
+                          T* recv_buff, const std::vector<comm_count_t>& recv_counts,
+                          const std::vector<comm_count_t>& recv_offsets,
+                          const std::vector<comm_count_t>& recv_offsets_nvshmem, cudecompCommAxis comm_axis,
+                          const std::vector<int>& src_ranks, const std::vector<int>& dst_ranks, cudaStream_t stream,
+                          bool& synced, cudecompTransposePerformanceSample* current_sample = nullptr) {
 
   // If there are no transfers to complete, quick return
-  if (send_counts.size() == 0 && recv_counts.size() == 0) {
-    return;
-  }
+  if (send_counts.size() == 0 && recv_counts.size() == 0) { return; }
 
   std::ostringstream os;
   os << "cudecompAlltoallPipelined_";
@@ -309,7 +308,8 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
   if (handle->performance_report_enable && src_ranks[0] != self_rank) {
     // Note: skipping self-copy for timing as it should be overlapped
     CHECK_CUDA(cudaStreamWaitEvent(handle->pl_stream, grid_desc->events[dst_ranks[0]], 0));
-    CHECK_CUDA(cudaEventRecord(current_sample->alltoall_start_events[current_sample->alltoall_timing_count], handle->pl_stream));
+    CHECK_CUDA(cudaEventRecord(current_sample->alltoall_start_events[current_sample->alltoall_timing_count],
+                               handle->pl_stream));
   }
 
 #ifdef ENABLE_NVSHMEM
@@ -484,7 +484,8 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
   }
 
   if (handle->performance_report_enable && src_ranks[0] != self_rank) {
-    CHECK_CUDA(cudaEventRecord(current_sample->alltoall_end_events[current_sample->alltoall_timing_count], handle->pl_stream));
+    CHECK_CUDA(
+        cudaEventRecord(current_sample->alltoall_end_events[current_sample->alltoall_timing_count], handle->pl_stream));
     current_sample->alltoall_timing_count++;
   }
   nvtx::rangePop();

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -158,7 +158,7 @@ cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
                  cudecompCommAxis comm_axis, cudaStream_t stream, cudecompPerformanceSample* current_sample = nullptr) {
   nvtx::rangePush("cudecompAlltoall");
 
-  if (handle->performance_report_enable > 0) {
+  if (handle->performance_report_enable) {
     CHECK_CUDA(cudaEventRecord(current_sample->alltoall_start_events[current_sample->alltoall_timing_count], stream));
   }
 
@@ -274,7 +274,7 @@ cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   }
   }
 
-  if (handle->performance_report_enable > 0) {
+  if (handle->performance_report_enable) {
     CHECK_CUDA(cudaEventRecord(current_sample->alltoall_end_events[current_sample->alltoall_timing_count], stream));
     current_sample->alltoall_timing_count++;
   }
@@ -306,7 +306,7 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
   nvtx::rangePush(os.str());
 
   int self_rank = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.rank : grid_desc->col_comm_info.rank;
-  if (handle->performance_report_enable > 0 && src_ranks[0] != self_rank) {
+  if (handle->performance_report_enable && src_ranks[0] != self_rank) {
     // Note: skipping self-copy for timing as it should be overlapped
     CHECK_CUDA(cudaStreamWaitEvent(handle->pl_stream, grid_desc->events[dst_ranks[0]], 0));
     CHECK_CUDA(cudaEventRecord(current_sample->alltoall_start_events[current_sample->alltoall_timing_count], handle->pl_stream));
@@ -483,7 +483,7 @@ static void cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cude
   }
   }
 
-  if (handle->performance_report_enable > 0 && src_ranks[0] != self_rank) {
+  if (handle->performance_report_enable && src_ranks[0] != self_rank) {
     CHECK_CUDA(cudaEventRecord(current_sample->alltoall_end_events[current_sample->alltoall_timing_count], handle->pl_stream));
     current_sample->alltoall_timing_count++;
   }

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -108,6 +108,9 @@ struct cudecompHandle {
 
   // CUDA graphs
   bool cuda_graphs_enable = false; // Flag to control whether CUDA graphs are used
+
+  // Performance reporting related entries
+  bool performance_report_enable = false;              // Flag to enable performance reporting
 };
 
 // Structure with information about row/column communicator
@@ -143,6 +146,13 @@ struct cudecompGridDesc {
   cudecomp::ncclComm nccl_comm; // NCCL communicator (global), shared from handle
   cudecomp::ncclComm
       nccl_local_comm; // NCCL communicator (intra-node, or intra-clique on MNNVL systems), shared from handle
+
+  // Performance reporting related entries
+  std::vector<cudaEvent_t> alltoall_start_events;  // events for alltoall timing
+  std::vector<cudaEvent_t> alltoall_end_events;    // events for alltoall timing
+  int32_t alltoall_timing_count = 0;               // count of alltoall timing events pairs (for pipelined alltoall)
+  cudaEvent_t transpose_start_event;               // event for transpose timing
+  cudaEvent_t transpose_end_event;                 // event for transpose timing
 
   bool initialized = false;
 };

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -137,7 +137,7 @@ struct cudecompCommInfo {
 };
 
 // Structure to contain data for transpose performance sample
-struct cudecompPerformanceSample {
+struct cudecompTransposePerformanceSample {
   cudaEvent_t transpose_start_event;
   cudaEvent_t transpose_end_event;
   std::vector<cudaEvent_t> alltoall_start_events;
@@ -147,9 +147,26 @@ struct cudecompPerformanceSample {
   bool valid = false;
 };
 
-// Collection of performance samples for a specific configuration
-struct cudecompPerformanceSampleCollection {
-  std::vector<cudecompPerformanceSample> samples;
+// Collection of transpose performance samples for a specific configuration
+struct cudecompTransposePerformanceSampleCollection {
+  std::vector<cudecompTransposePerformanceSample> samples;
+  int32_t sample_idx = 0;
+  int32_t warmup_count = 0;
+};
+
+// Structure to contain data for halo performance sample
+struct cudecompHaloPerformanceSample {
+  cudaEvent_t halo_start_event;
+  cudaEvent_t halo_end_event;
+  cudaEvent_t sendrecv_start_event;
+  cudaEvent_t sendrecv_end_event;
+  size_t sendrecv_bytes = 0;
+  bool valid = false;
+};
+
+// Collection of halo performance samples for a specific configuration
+struct cudecompHaloPerformanceSampleCollection {
+  std::vector<cudecompHaloPerformanceSample> samples;
   int32_t sample_idx = 0;
   int32_t warmup_count = 0;
 };
@@ -184,7 +201,11 @@ struct cudecompGridDesc {
 
   std::unordered_map<std::tuple<int32_t, int32_t, std::array<int32_t, 3>, std::array<int32_t, 3>,
                                 std::array<int32_t, 3>, std::array<int32_t, 3>, bool, bool, cudecompDataType_t>,
-                     cudecompPerformanceSampleCollection> perf_samples_map;
+                     cudecompTransposePerformanceSampleCollection> transpose_perf_samples_map;
+
+  std::unordered_map<std::tuple<int32_t, int32_t, std::array<int32_t, 3>, std::array<bool, 3>,
+                                std::array<int32_t, 3>, bool, cudecompDataType_t>,
+                     cudecompHaloPerformanceSampleCollection> halo_perf_samples_map;
 
   bool initialized = false;
 };

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -116,11 +116,13 @@ struct cudecompHandle {
   bool cuda_graphs_enable = false; // Flag to control whether CUDA graphs are used
 
   // Performance reporting related entries
-  bool performance_report_enable = false;              // flag to track if performance reporting is enabled
-  int32_t performance_report_detail = 0;               // performance report detail level: 0=aggregated, 1=per-sample rank 0, 2=per-sample all ranks
-  int32_t performance_report_samples = 20;             // number of performance samples to keep for final report
-  int32_t performance_report_warmup_samples = 3;       // number of initial warmup samples to ignore for each configuration
-  std::string performance_report_write_dir = "";       // directory to write CSV performance reports, empty means no file writing
+  bool performance_report_enable = false; // flag to track if performance reporting is enabled
+  int32_t performance_report_detail =
+      0; // performance report detail level: 0=aggregated, 1=per-sample rank 0, 2=per-sample all ranks
+  int32_t performance_report_samples = 20;       // number of performance samples to keep for final report
+  int32_t performance_report_warmup_samples = 3; // number of initial warmup samples to ignore for each configuration
+  std::string performance_report_write_dir =
+      ""; // directory to write CSV performance reports, empty means no file writing
 };
 
 // Structure with information about row/column communicator
@@ -172,7 +174,6 @@ struct cudecompHaloPerformanceSampleCollection {
   int32_t warmup_count = 0;
 };
 
-
 // cuDecomp grid descriptor containing grid-specific information
 struct cudecompGridDesc {
   cudecompGridDescConfig_t config;      // configuration struct
@@ -194,19 +195,21 @@ struct cudecompGridDesc {
       nccl_local_comm; // NCCL communicator (intra-node, or intra-clique on MNNVL systems), shared from handle
 
   // Performance reporting related entries
-  std::vector<cudaEvent_t> alltoall_start_events;  // events for alltoall timing
-  std::vector<cudaEvent_t> alltoall_end_events;    // events for alltoall timing
-  int32_t alltoall_timing_count = 0;               // count of alltoall timing events pairs (for pipelined alltoall)
-  cudaEvent_t transpose_start_event;               // event for transpose timing
-  cudaEvent_t transpose_end_event;                 // event for transpose timing
+  std::vector<cudaEvent_t> alltoall_start_events; // events for alltoall timing
+  std::vector<cudaEvent_t> alltoall_end_events;   // events for alltoall timing
+  int32_t alltoall_timing_count = 0;              // count of alltoall timing events pairs (for pipelined alltoall)
+  cudaEvent_t transpose_start_event;              // event for transpose timing
+  cudaEvent_t transpose_end_event;                // event for transpose timing
 
   std::unordered_map<std::tuple<int32_t, int32_t, std::array<int32_t, 3>, std::array<int32_t, 3>,
                                 std::array<int32_t, 3>, std::array<int32_t, 3>, bool, bool, cudecompDataType_t>,
-                     cudecompTransposePerformanceSampleCollection> transpose_perf_samples_map;
+                     cudecompTransposePerformanceSampleCollection>
+      transpose_perf_samples_map;
 
-  std::unordered_map<std::tuple<int32_t, int32_t, std::array<int32_t, 3>, std::array<bool, 3>,
-                                std::array<int32_t, 3>, bool, cudecompDataType_t>,
-                     cudecompHaloPerformanceSampleCollection> halo_perf_samples_map;
+  std::unordered_map<std::tuple<int32_t, int32_t, std::array<int32_t, 3>, std::array<bool, 3>, std::array<int32_t, 3>,
+                                bool, cudecompDataType_t>,
+                     cudecompHaloPerformanceSampleCollection>
+      halo_perf_samples_map;
 
   bool initialized = false;
 };

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -116,9 +116,10 @@ struct cudecompHandle {
   bool cuda_graphs_enable = false; // Flag to control whether CUDA graphs are used
 
   // Performance reporting related entries
-  int32_t performance_report_enable = 0;               // performance reporting level: 0=off, 1=final only, 2=verbose
+  bool performance_report_enable = false;              // flag to track if performance reporting is enabled
+  int32_t performance_report_detail = 0;               // performance report detail level: 0=aggregated, 1=per-sample rank 0, 2=per-sample all ranks
   int32_t performance_report_samples = 20;             // number of performance samples to keep for final report
-  int32_t performance_report_warmup_samples = 2;       // number of initial warmup samples to ignore for each configuration
+  int32_t performance_report_warmup_samples = 3;       // number of initial warmup samples to ignore for each configuration
 };
 
 // Structure with information about row/column communicator

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -120,6 +120,7 @@ struct cudecompHandle {
   int32_t performance_report_detail = 0;               // performance report detail level: 0=aggregated, 1=per-sample rank 0, 2=per-sample all ranks
   int32_t performance_report_samples = 20;             // number of performance samples to keep for final report
   int32_t performance_report_warmup_samples = 3;       // number of initial warmup samples to ignore for each configuration
+  std::string performance_report_write_dir = "";       // directory to write CSV performance reports, empty means no file writing
 };
 
 // Structure with information about row/column communicator

--- a/include/internal/halo.h
+++ b/include/internal/halo.h
@@ -41,6 +41,8 @@
 #include "internal/comm_routines.h"
 #include "internal/cudecomp_kernels.h"
 #include "internal/nvtx.h"
+#include "internal/performance.h"
+#include "internal/utils.h"
 
 namespace cudecomp {
 
@@ -72,6 +74,17 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
 
   // Quick return if no halos
   if (halo_extents[dim] == 0) { return; }
+
+  cudecompHaloPerformanceSample* current_sample = nullptr;
+  if (handle->performance_report_enable) {
+    auto& samples = getOrCreateHaloPerformanceSamples(handle, grid_desc, createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(), padding.data(), getCudecompDataType<T>()));
+    current_sample = &samples.samples[samples.sample_idx];
+    current_sample->sendrecv_bytes = 0;
+    current_sample->valid = true;
+
+    // Record start event
+    CHECK_CUDA(cudaEventRecord(current_sample->halo_start_event, stream));
+  }
 
   // Check if halos include more than one process (unsupported currently).
   int count = 0;
@@ -120,6 +133,11 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     c = 0;
   } else if (neighbors[0] == -1 && neighbors[1] == -1) {
     // Single rank in this dimension and not periodic. Return.
+    if (handle->performance_report_enable && current_sample) {
+      // Record end event and advance sample even for early return
+      CHECK_CUDA(cudaEventRecord(current_sample->halo_end_event, stream));
+      advanceHaloPerformanceSample(handle, grid_desc, createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(), padding.data(), getCudecompDataType<T>()));
+    }
     return;
   }
 
@@ -204,7 +222,15 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     std::array<size_t, 2> offsets{};
     offsets[1] = halo_size;
 
-    cudecompSendRecvPair(handle, grid_desc, neighbors, send_buff, counts, offsets, recv_buff, counts, offsets, stream);
+    if (handle->performance_report_enable && current_sample) {
+      current_sample->sendrecv_bytes = 0;
+      for (int i = 0; i < 2; ++i) {
+        if (neighbors[i] != -1) {
+          current_sample->sendrecv_bytes += halo_size * sizeof(T);
+        }
+      }
+    }
+    cudecompSendRecvPair(handle, grid_desc, neighbors, send_buff, counts, offsets, recv_buff, counts, offsets, stream, current_sample);
 
     // Unpack
     // Left
@@ -261,9 +287,23 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     lx[dim] = shape_g_h_p[dim] - halo_extents[dim];
     recv_offsets[1] = getPencilPtrOffset(pinfo_h, lx);
 
+    if (handle->performance_report_enable && current_sample) {
+      current_sample->sendrecv_bytes = 0;
+      for (int i = 0; i < 2; ++i) {
+        if (neighbors[i] != -1) {
+          current_sample->sendrecv_bytes += halo_size * sizeof(T);
+        }
+      }
+    }
     cudecompSendRecvPair(handle, grid_desc, neighbors, input, counts, send_offsets, input, counts, recv_offsets,
-                         stream);
+                         stream, current_sample);
   } break;
+  }
+
+  if (handle->performance_report_enable && current_sample) {
+    // Record end event
+    CHECK_CUDA(cudaEventRecord(current_sample->halo_end_event, stream));
+    advanceHaloPerformanceSample(handle, grid_desc, createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(), padding.data(), getCudecompDataType<T>()));
   }
 }
 

--- a/include/internal/halo.h
+++ b/include/internal/halo.h
@@ -77,7 +77,10 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
 
   cudecompHaloPerformanceSample* current_sample = nullptr;
   if (handle->performance_report_enable) {
-    auto& samples = getOrCreateHaloPerformanceSamples(handle, grid_desc, createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(), padding.data(), getCudecompDataType<T>()));
+    auto& samples =
+        getOrCreateHaloPerformanceSamples(handle, grid_desc,
+                                          createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(),
+                                                           padding.data(), getCudecompDataType<T>()));
     current_sample = &samples.samples[samples.sample_idx];
     current_sample->sendrecv_bytes = 0;
     current_sample->valid = true;
@@ -136,7 +139,9 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     if (handle->performance_report_enable && current_sample) {
       // Record end event and advance sample even for early return
       CHECK_CUDA(cudaEventRecord(current_sample->halo_end_event, stream));
-      advanceHaloPerformanceSample(handle, grid_desc, createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(), padding.data(), getCudecompDataType<T>()));
+      advanceHaloPerformanceSample(handle, grid_desc,
+                                   createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(),
+                                                    padding.data(), getCudecompDataType<T>()));
     }
     return;
   }
@@ -225,12 +230,11 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     if (handle->performance_report_enable && current_sample) {
       current_sample->sendrecv_bytes = 0;
       for (int i = 0; i < 2; ++i) {
-        if (neighbors[i] != -1) {
-          current_sample->sendrecv_bytes += halo_size * sizeof(T);
-        }
+        if (neighbors[i] != -1) { current_sample->sendrecv_bytes += halo_size * sizeof(T); }
       }
     }
-    cudecompSendRecvPair(handle, grid_desc, neighbors, send_buff, counts, offsets, recv_buff, counts, offsets, stream, current_sample);
+    cudecompSendRecvPair(handle, grid_desc, neighbors, send_buff, counts, offsets, recv_buff, counts, offsets, stream,
+                         current_sample);
 
     // Unpack
     // Left
@@ -290,20 +294,20 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     if (handle->performance_report_enable && current_sample) {
       current_sample->sendrecv_bytes = 0;
       for (int i = 0; i < 2; ++i) {
-        if (neighbors[i] != -1) {
-          current_sample->sendrecv_bytes += halo_size * sizeof(T);
-        }
+        if (neighbors[i] != -1) { current_sample->sendrecv_bytes += halo_size * sizeof(T); }
       }
     }
-    cudecompSendRecvPair(handle, grid_desc, neighbors, input, counts, send_offsets, input, counts, recv_offsets,
-                         stream, current_sample);
+    cudecompSendRecvPair(handle, grid_desc, neighbors, input, counts, send_offsets, input, counts, recv_offsets, stream,
+                         current_sample);
   } break;
   }
 
   if (handle->performance_report_enable && current_sample) {
     // Record end event
     CHECK_CUDA(cudaEventRecord(current_sample->halo_end_event, stream));
-    advanceHaloPerformanceSample(handle, grid_desc, createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(), padding.data(), getCudecompDataType<T>()));
+    advanceHaloPerformanceSample(handle, grid_desc,
+                                 createHaloConfig(ax, dim, input, halo_extents.data(), halo_periods.data(),
+                                                  padding.data(), getCudecompDataType<T>()));
   }
 }
 

--- a/include/internal/performance.h
+++ b/include/internal/performance.h
@@ -53,19 +53,33 @@ using cudecompTransposeConfigKey = std::tuple<
   cudecompDataType_t               // datatype
 >;
 
-void printPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc,
-                           int ax, int dir, size_t alltoall_bytes, cudecompPerformanceSample* current_sample);
+using cudecompHaloConfigKey = std::tuple<
+  int32_t,                         // ax (axis)
+  int32_t,                         // dim (dimension)
+  std::array<int32_t, 3>,          // halo_extents
+  std::array<bool, 3>,             // halo_periods
+  std::array<int32_t, 3>,          // padding
+  bool,                            // managed_memory
+  cudecompDataType_t               // datatype
+>;
 
 void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc);
 
 void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc);
 
-void advancePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
-                             const cudecompTransposeConfigKey& config);
+void advanceTransposePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                      const cudecompTransposeConfigKey& config);
 
-cudecompPerformanceSampleCollection& getOrCreatePerformanceSamples(const cudecompHandle_t handle,
-                                                                   cudecompGridDesc_t grid_desc,
-                                                                   const cudecompTransposeConfigKey& config);
+cudecompTransposePerformanceSampleCollection& getOrCreateTransposePerformanceSamples(const cudecompHandle_t handle,
+                                                                                    cudecompGridDesc_t grid_desc,
+                                                                                    const cudecompTransposeConfigKey& config);
+
+void advanceHaloPerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                 const cudecompHaloConfigKey& config);
+
+cudecompHaloPerformanceSampleCollection& getOrCreateHaloPerformanceSamples(const cudecompHandle_t handle,
+                                                                           cudecompGridDesc_t grid_desc,
+                                                                           const cudecompHaloConfigKey& config);
 
 // Helper function to create transpose configuration key
 cudecompTransposeConfigKey createTransposeConfig(int ax, int dir, void* input, void* output,
@@ -74,6 +88,13 @@ cudecompTransposeConfigKey createTransposeConfig(int ax, int dir, void* input, v
                                                 const int32_t input_padding_ptr[],
                                                 const int32_t output_padding_ptr[],
                                                 cudecompDataType_t datatype);
+
+// Helper function to create halo configuration key
+cudecompHaloConfigKey createHaloConfig(int ax, int dim, void* input,
+                                      const int32_t halo_extents_ptr[],
+                                      const bool halo_periods_ptr[],
+                                      const int32_t padding_ptr[],
+                                      cudecompDataType_t datatype);
 
 } // namespace cudecomp
 

--- a/include/internal/performance.h
+++ b/include/internal/performance.h
@@ -63,7 +63,7 @@ using cudecompHaloConfigKey = std::tuple<
   cudecompDataType_t               // datatype
 >;
 
-void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc);
+void printPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc);
 
 void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc);
 

--- a/include/internal/performance.h
+++ b/include/internal/performance.h
@@ -41,27 +41,25 @@
 
 namespace cudecomp {
 
-using cudecompTransposeConfigKey = std::tuple<
-  int32_t,                         // ax (axis)
-  int32_t,                         // dir (direction)
-  std::array<int32_t, 3>,          // input_halo_extents
-  std::array<int32_t, 3>,          // output_halo_extents
-  std::array<int32_t, 3>,          // input_padding
-  std::array<int32_t, 3>,          // output_padding
-  bool,                            // inplace
-  bool,                            // managed_memory
-  cudecompDataType_t               // datatype
->;
+using cudecompTransposeConfigKey = std::tuple<int32_t,                // ax (axis)
+                                              int32_t,                // dir (direction)
+                                              std::array<int32_t, 3>, // input_halo_extents
+                                              std::array<int32_t, 3>, // output_halo_extents
+                                              std::array<int32_t, 3>, // input_padding
+                                              std::array<int32_t, 3>, // output_padding
+                                              bool,                   // inplace
+                                              bool,                   // managed_memory
+                                              cudecompDataType_t      // datatype
+                                              >;
 
-using cudecompHaloConfigKey = std::tuple<
-  int32_t,                         // ax (axis)
-  int32_t,                         // dim (dimension)
-  std::array<int32_t, 3>,          // halo_extents
-  std::array<bool, 3>,             // halo_periods
-  std::array<int32_t, 3>,          // padding
-  bool,                            // managed_memory
-  cudecompDataType_t               // datatype
->;
+using cudecompHaloConfigKey = std::tuple<int32_t,                // ax (axis)
+                                         int32_t,                // dim (dimension)
+                                         std::array<int32_t, 3>, // halo_extents
+                                         std::array<bool, 3>,    // halo_periods
+                                         std::array<int32_t, 3>, // padding
+                                         bool,                   // managed_memory
+                                         cudecompDataType_t      // datatype
+                                         >;
 
 // Helper structure for transpose statistics
 struct TransposePerformanceStats {
@@ -123,12 +121,12 @@ void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t g
 void advanceTransposePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
                                        const cudecompTransposeConfigKey& config);
 
-cudecompTransposePerformanceSampleCollection& getOrCreateTransposePerformanceSamples(const cudecompHandle_t handle,
-                                                                                     cudecompGridDesc_t grid_desc,
-                                                                                     const cudecompTransposeConfigKey& config);
+cudecompTransposePerformanceSampleCollection&
+getOrCreateTransposePerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                       const cudecompTransposeConfigKey& config);
 
 void advanceHaloPerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
-                                 const cudecompHaloConfigKey& config);
+                                  const cudecompHaloConfigKey& config);
 
 cudecompHaloPerformanceSampleCollection& getOrCreateHaloPerformanceSamples(const cudecompHandle_t handle,
                                                                            cudecompGridDesc_t grid_desc,
@@ -138,15 +136,12 @@ cudecompHaloPerformanceSampleCollection& getOrCreateHaloPerformanceSamples(const
 cudecompTransposeConfigKey createTransposeConfig(int ax, int dir, void* input, void* output,
                                                  const int32_t input_halo_extents_ptr[],
                                                  const int32_t output_halo_extents_ptr[],
-                                                 const int32_t input_padding_ptr[],
-                                                 const int32_t output_padding_ptr[],
+                                                 const int32_t input_padding_ptr[], const int32_t output_padding_ptr[],
                                                  cudecompDataType_t datatype);
 
 // Helper function to create halo configuration key
-cudecompHaloConfigKey createHaloConfig(int ax, int dim, void* input,
-                                       const int32_t halo_extents_ptr[],
-                                       const bool halo_periods_ptr[],
-                                       const int32_t padding_ptr[],
+cudecompHaloConfigKey createHaloConfig(int ax, int dim, void* input, const int32_t halo_extents_ptr[],
+                                       const bool halo_periods_ptr[], const int32_t padding_ptr[],
                                        cudecompDataType_t datatype);
 
 } // namespace cudecomp

--- a/include/internal/performance.h
+++ b/include/internal/performance.h
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CUDECOMP_PERFORMANCE_H
+#define CUDECOMP_PERFORMANCE_H
+
+#include <array>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "internal/common.h"
+
+namespace cudecomp {
+
+using cudecompTransposeConfigKey = std::tuple<
+  int32_t,                         // ax (axis)
+  int32_t,                         // dir (direction)
+  std::array<int32_t, 3>,          // input_halo_extents
+  std::array<int32_t, 3>,          // output_halo_extents
+  std::array<int32_t, 3>,          // input_padding
+  std::array<int32_t, 3>,          // output_padding
+  bool,                            // inplace
+  bool,                            // managed_memory
+  cudecompDataType_t               // datatype
+>;
+
+void printPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc,
+                           int ax, int dir, size_t alltoall_bytes, cudecompPerformanceSample* current_sample);
+
+void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc);
+
+void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc);
+
+void advancePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                             const cudecompTransposeConfigKey& config);
+
+cudecompPerformanceSampleCollection& getOrCreatePerformanceSamples(const cudecompHandle_t handle,
+                                                                   cudecompGridDesc_t grid_desc,
+                                                                   const cudecompTransposeConfigKey& config);
+
+// Helper function to create transpose configuration key
+cudecompTransposeConfigKey createTransposeConfig(int ax, int dir, void* input, void* output,
+                                                const int32_t input_halo_extents_ptr[],
+                                                const int32_t output_halo_extents_ptr[],
+                                                const int32_t input_padding_ptr[],
+                                                const int32_t output_padding_ptr[],
+                                                cudecompDataType_t datatype);
+
+} // namespace cudecomp
+
+#endif // CUDECOMP_PERFORMANCE_H

--- a/include/internal/performance.h
+++ b/include/internal/performance.h
@@ -63,16 +63,67 @@ using cudecompHaloConfigKey = std::tuple<
   cudecompDataType_t               // datatype
 >;
 
+// Helper structure for transpose statistics
+struct TransposePerformanceStats {
+  std::string operation;
+  std::string datatype;
+  std::string halos;
+  std::string padding;
+  std::string inplace;
+  std::string managed;
+  int samples;
+  float total_time_avg;
+  float alltoall_time_avg;
+  float local_time_avg;
+  float alltoall_bw_avg;
+};
+
+// Helper structure for halo statistics
+struct HaloPerformanceStats {
+  std::string operation;
+  std::string datatype;
+  int dim;
+  std::string halos;
+  std::string periods;
+  std::string padding;
+  std::string managed;
+  int samples;
+  float total_time_avg;
+  float sendrecv_time_avg;
+  float local_time_avg;
+  float sendrecv_bw_avg;
+};
+
+// Helper structure to hold pre-computed transpose timing data
+struct TransposeConfigTimingData {
+  TransposePerformanceStats stats;
+  std::vector<float> total_times;
+  std::vector<float> alltoall_times;
+  std::vector<float> local_times;
+  std::vector<float> alltoall_bws;
+  std::vector<int> sample_indices;
+};
+
+// Helper structure to hold pre-computed halo timing data
+struct HaloConfigTimingData {
+  HaloPerformanceStats stats;
+  std::vector<float> total_times;
+  std::vector<float> sendrecv_times;
+  std::vector<float> local_times;
+  std::vector<float> sendrecv_bws;
+  std::vector<int> sample_indices;
+};
+
 void printPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc);
 
 void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc);
 
 void advanceTransposePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
-                                      const cudecompTransposeConfigKey& config);
+                                       const cudecompTransposeConfigKey& config);
 
 cudecompTransposePerformanceSampleCollection& getOrCreateTransposePerformanceSamples(const cudecompHandle_t handle,
-                                                                                    cudecompGridDesc_t grid_desc,
-                                                                                    const cudecompTransposeConfigKey& config);
+                                                                                     cudecompGridDesc_t grid_desc,
+                                                                                     const cudecompTransposeConfigKey& config);
 
 void advanceHaloPerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
                                  const cudecompHaloConfigKey& config);
@@ -83,18 +134,18 @@ cudecompHaloPerformanceSampleCollection& getOrCreateHaloPerformanceSamples(const
 
 // Helper function to create transpose configuration key
 cudecompTransposeConfigKey createTransposeConfig(int ax, int dir, void* input, void* output,
-                                                const int32_t input_halo_extents_ptr[],
-                                                const int32_t output_halo_extents_ptr[],
-                                                const int32_t input_padding_ptr[],
-                                                const int32_t output_padding_ptr[],
-                                                cudecompDataType_t datatype);
+                                                 const int32_t input_halo_extents_ptr[],
+                                                 const int32_t output_halo_extents_ptr[],
+                                                 const int32_t input_padding_ptr[],
+                                                 const int32_t output_padding_ptr[],
+                                                 cudecompDataType_t datatype);
 
 // Helper function to create halo configuration key
 cudecompHaloConfigKey createHaloConfig(int ax, int dim, void* input,
-                                      const int32_t halo_extents_ptr[],
-                                      const bool halo_periods_ptr[],
-                                      const int32_t padding_ptr[],
-                                      cudecompDataType_t datatype);
+                                       const int32_t halo_extents_ptr[],
+                                       const bool halo_periods_ptr[],
+                                       const int32_t padding_ptr[],
+                                       cudecompDataType_t datatype);
 
 } // namespace cudecomp
 

--- a/include/internal/performance.h
+++ b/include/internal/performance.h
@@ -67,8 +67,10 @@ using cudecompHaloConfigKey = std::tuple<
 struct TransposePerformanceStats {
   std::string operation;
   std::string datatype;
-  std::string halos;
-  std::string padding;
+  std::string input_halos;
+  std::string output_halos;
+  std::string input_padding;
+  std::string output_padding;
   std::string inplace;
   std::string managed;
   int samples;

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -254,7 +254,11 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
   cudecompTransposePerformanceSample* current_sample = nullptr;
   if (handle->performance_report_enable) {
-    auto& samples = getOrCreateTransposePerformanceSamples(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
+    auto& samples =
+        getOrCreateTransposePerformanceSamples(handle, grid_desc,
+                                               createTransposeConfig(ax, dir, input, output, input_halo_extents.data(),
+                                                                     output_halo_extents.data(), input_padding.data(),
+                                                                     output_padding.data(), getCudecompDataType<T>()));
     current_sample = &samples.samples[samples.sample_idx];
     current_sample->alltoall_timing_count = 0;
     current_sample->alltoall_bytes = pinfo_a.size * sizeof(T);
@@ -276,7 +280,10 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
           if (handle->performance_report_enable) {
             // Record performance data
             CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-            advanceTransposePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
+            advanceTransposePerformanceSample(handle, grid_desc,
+                                              createTransposeConfig(ax, dir, input, output, input_halo_extents.data(),
+                                                                    output_halo_extents.data(), input_padding.data(),
+                                                                    output_padding.data(), getCudecompDataType<T>()));
           }
           return;
         }
@@ -545,7 +552,10 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       // o1 is output. Return.
       if (handle->performance_report_enable) {
         CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-        advanceTransposePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
+        advanceTransposePerformanceSample(handle, grid_desc,
+                                          createTransposeConfig(ax, dir, input, output, input_halo_extents.data(),
+                                                                output_halo_extents.data(), input_padding.data(),
+                                                                output_padding.data(), getCudecompDataType<T>()));
       }
       return;
     }
@@ -633,7 +643,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
           if (o2 != o1) {
             cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced, current_sample);
+                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced,
+                                      current_sample);
           }
 
           if (o2 != o3) {
@@ -728,7 +739,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
           if (o2 != o1) {
             cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced, current_sample);
+                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced,
+                                      current_sample);
           }
         }
 
@@ -785,7 +797,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
         if (o2 != o1) {
           cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                    recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced, current_sample);
+                                    recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced,
+                                    current_sample);
         }
       }
 
@@ -822,9 +835,11 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   if (handle->performance_report_enable) {
     // Record performance data
     CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-    advanceTransposePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
+    advanceTransposePerformanceSample(handle, grid_desc,
+                                      createTransposeConfig(ax, dir, input, output, input_halo_extents.data(),
+                                                            output_halo_extents.data(), input_padding.data(),
+                                                            output_padding.data(), getCudecompDataType<T>()));
   }
-
 }
 
 template <typename T>

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -252,9 +252,9 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
     CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, stream));
   }
 
-  cudecompPerformanceSample* current_sample = nullptr;
+  cudecompTransposePerformanceSample* current_sample = nullptr;
   if (handle->performance_report_enable) {
-    auto& samples = getOrCreatePerformanceSamples(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
+    auto& samples = getOrCreateTransposePerformanceSamples(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
     current_sample = &samples.samples[samples.sample_idx];
     current_sample->alltoall_timing_count = 0;
     current_sample->alltoall_bytes = pinfo_a.size * sizeof(T);
@@ -276,7 +276,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
           if (handle->performance_report_enable) {
             // Record performance data
             CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-            advancePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
+            advanceTransposePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
           }
           return;
         }
@@ -545,7 +545,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       // o1 is output. Return.
       if (handle->performance_report_enable) {
         CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-        advancePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
+        advanceTransposePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
       }
       return;
     }
@@ -822,7 +822,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   if (handle->performance_report_enable) {
     // Record performance data
     CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-    advancePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
+    advanceTransposePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
   }
 
 }

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -253,7 +253,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   }
 
   cudecompPerformanceSample* current_sample = nullptr;
-  if (handle->performance_report_enable > 0) {
+  if (handle->performance_report_enable) {
     auto& samples = getOrCreatePerformanceSamples(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
     current_sample = &samples.samples[samples.sample_idx];
     current_sample->alltoall_timing_count = 0;
@@ -273,10 +273,9 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       if (inplace) {
         if (halos_padding_equal) {
           // Single rank, in place, Pack -> Unpack: No transpose necessary.
-          if (handle->performance_report_enable > 0) {
-            // Print performance report
+          if (handle->performance_report_enable) {
+            // Record performance data
             CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-            printPerformanceReport(handle, grid_desc, ax, dir, pinfo_a.size * sizeof(T), current_sample);
             advancePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
           }
           return;
@@ -544,9 +543,8 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
     if (o1 == output) {
       // o1 is output. Return.
-      if (handle->performance_report_enable > 0) {
+      if (handle->performance_report_enable) {
         CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-        printPerformanceReport(handle, grid_desc, ax, dir, pinfo_a.size * sizeof(T), current_sample);
         advancePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
       }
       return;
@@ -821,10 +819,9 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
     }
   }
 
-  if (handle->performance_report_enable > 0) {
-    // Print performance report
+  if (handle->performance_report_enable) {
+    // Record performance data
     CHECK_CUDA(cudaEventRecord(current_sample->transpose_end_event, stream));
-    printPerformanceReport(handle, grid_desc, ax, dir, pinfo_a.size * sizeof(T), current_sample);
     advancePerformanceSample(handle, grid_desc, createTransposeConfig(ax, dir, input, output, input_halo_extents.data(), output_halo_extents.data(), input_padding.data(), output_padding.data(), getCudecompDataType<T>()));
   }
 

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -157,6 +157,36 @@ static void localPermute(const cudecompHandle_t handle, const std::array<int64_t
 }
 #endif
 
+static void printPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc, int ax, int dir, size_t alltoall_bytes) {
+
+  // Compute total timing by summing all individual timings
+  float alltoall_timing_ms = 0.0f;
+  float transpose_timing_ms = 0.0f;
+  for (int i = 0; i < grid_desc->alltoall_timing_count; ++i) {
+    float elapsed_time;
+    CHECK_CUDA(cudaEventElapsedTime(&elapsed_time, grid_desc->alltoall_start_events[i], grid_desc->alltoall_end_events[i]));
+    alltoall_timing_ms += elapsed_time;
+  }
+  CHECK_CUDA(cudaEventElapsedTime(&transpose_timing_ms, grid_desc->transpose_start_event, grid_desc->transpose_end_event));
+  // Report on rank 0 only for now.
+  if (handle->rank == 0) {
+    std::string op_name;
+    if (ax == 0) {
+      op_name = "cudecompTransposeXToY";
+    } else if (ax == 1 && dir == 1) {
+      op_name = "cudecompTransposeYToZ";
+    } else if (ax == 2) {
+      op_name = "cudecompTransposeZToY";
+    } else if (ax == 1 && dir == -1) {
+      op_name = "cudecompTransposeYToX";
+    }
+    float alltoall_bw = (alltoall_timing_ms > 0) ? alltoall_bytes * 1e-6/ alltoall_timing_ms : 0;
+    printf("CUDECOMP:PERFORMANCE: rank: %d, op: %s, total time: %.3f ms, alltoall time: %.3f ms, local operation time: %.3f ms, alltoall bw: %.3f GB/s\n",
+           handle->rank, op_name.c_str(), transpose_timing_ms, alltoall_timing_ms, transpose_timing_ms - alltoall_timing_ms, alltoall_bw);
+  }
+
+}
+
 template <typename T>
 static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc,
                                T* input, T* output, T* work, const int32_t input_halo_extents_ptr[] = nullptr,
@@ -250,6 +280,10 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
     CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, stream));
   }
 
+  if (handle->performance_report_enable) {
+    CHECK_CUDA(cudaEventRecord(grid_desc->transpose_start_event, stream));
+  }
+
   // Adjust pointers to handle special cases
   bool direct_pack = false;
   bool direct_transpose = false;
@@ -259,6 +293,12 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       if (inplace) {
         if (halos_padding_equal) {
           // Single rank, in place, Pack -> Unpack: No transpose necessary.
+          if (handle->performance_report_enable) {
+            // Synchronize and print performance report
+            CHECK_CUDA(cudaEventRecord(grid_desc->transpose_end_event, stream));
+            CHECK_CUDA(cudaDeviceSynchronize());
+            printPerformanceReport(handle, grid_desc, ax, dir, pinfo_a.size * sizeof(T));
+          }
           return;
         }
       } else {
@@ -333,6 +373,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   }
 
   bool data_transposed = false;
+
   if (o1 != i1) {
     if (pinfo_b.order[2] == ax_a && !orders_equal) {
       // Transpose/Pack
@@ -523,6 +564,12 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
     if (o1 == output) {
       // o1 is output. Return.
+      if (handle->performance_report_enable) {
+        // Synchronize and print performance report
+        CHECK_CUDA(cudaEventRecord(grid_desc->transpose_end_event, stream));
+        CHECK_CUDA(cudaDeviceSynchronize());
+        printPerformanceReport(handle, grid_desc, ax, dir, pinfo_a.size * sizeof(T));
+      }
       return;
     }
   } else {
@@ -794,6 +841,17 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       }
     }
   }
+
+  if (handle->performance_report_enable) {
+    // Synchronize and print performance report
+    CHECK_CUDA(cudaEventRecord(grid_desc->transpose_end_event, stream));
+    CHECK_CUDA(cudaDeviceSynchronize());
+    printPerformanceReport(handle, grid_desc, ax, dir, pinfo_a.size * sizeof(T));
+
+    // Reset count for next report
+    grid_desc->alltoall_timing_count = 0;
+  }
+
 }
 
 template <typename T>

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -396,11 +396,6 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       // Clear CUDA graph cache between backend/process decomposition pairs
       grid_desc->graph_cache.clear();
 
-      // Print performance report for this configuration if enabled
-      if (handle->performance_report_enable && !skip_case) {
-        printFinalPerformanceReport(handle, grid_desc);
-      }
-
       auto times = processTimings(handle, trial_times);
       auto times_w = processTimings(handle, trial_times_w);
       auto xy_times = processTimings(handle, trial_xy_times);
@@ -438,6 +433,11 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
                  t_skipped[1], zy_times[0], zy_times[1], zy_times[2], zy_times[3], t_skipped[2], yx_times[0],
                  yx_times[1], yx_times[2], yx_times[3], t_skipped[3]);
         }
+      }
+
+      // Print performance report for this configuration if enabled
+      if (handle->performance_report_enable && !skip_case) {
+        printPerformanceReport(handle, grid_desc);
       }
 
       if (skip_case) continue;
@@ -758,11 +758,6 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
         }
       }
 
-      // Print performance report for this configuration if enabled
-      if (handle->performance_report_enable && !skip_case) {
-        printFinalPerformanceReport(handle, grid_desc);
-      }
-
       auto times = processTimings(handle, trial_times, 1000.);
 
       if (handle->rank == 0) {
@@ -778,6 +773,11 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
                  cudecompHaloCommBackendToString(grid_desc->config.halo_comm_backend), times[0], times[1], times[2],
                  times[3]);
         }
+      }
+
+      // Print performance report for this configuration if enabled
+      if (handle->performance_report_enable && !skip_case) {
+        printPerformanceReport(handle, grid_desc);
       }
 
       if (skip_case) continue;

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -289,6 +289,9 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       if (transposeBackendRequiresNvshmem(comm)) { w = work_nvshmem; }
 #endif
 
+      // Reset performance samples
+      resetPerformanceSamples(handle, grid_desc);
+
       // Warmup
       for (int i = 0; i < options->n_warmup_trials; ++i) {
         if (options->transpose_op_weights[0] != 0.0) {
@@ -316,9 +319,6 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
                                                pinfo_y3.padding, pinfo_x3.padding, 0));
         }
       }
-
-      // Reset performance samples after warmup to ensure clean measurement
-      resetPerformanceSamples(handle, grid_desc);
 
       // Trials
       std::vector<float> trial_times(options->n_trials);
@@ -397,7 +397,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       grid_desc->graph_cache.clear();
 
       // Print performance report for this configuration if enabled
-      if (handle->performance_report_enable > 0 && !skip_case) {
+      if (handle->performance_report_enable && !skip_case) {
         printFinalPerformanceReport(handle, grid_desc);
       }
 

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -436,9 +436,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       }
 
       // Print performance report for this configuration if enabled
-      if (handle->performance_report_enable && !skip_case) {
-        printPerformanceReport(handle, grid_desc);
-      }
+      if (handle->performance_report_enable && !skip_case) { printPerformanceReport(handle, grid_desc); }
 
       if (skip_case) continue;
 
@@ -776,9 +774,7 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       }
 
       // Print performance report for this configuration if enabled
-      if (handle->performance_report_enable && !skip_case) {
-        printPerformanceReport(handle, grid_desc);
-      }
+      if (handle->performance_report_enable && !skip_case) { printPerformanceReport(handle, grid_desc); }
 
       if (skip_case) continue;
 

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -694,6 +694,9 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       if (haloBackendRequiresNvshmem(comm)) { w = work_nvshmem; }
 #endif
 
+      // Reset performance samples
+      resetPerformanceSamples(handle, grid_desc);
+
       // Warmup
       for (int i = 0; i < options->n_warmup_trials; ++i) {
         for (int dim = 0; dim < 3; ++dim) {
@@ -754,6 +757,12 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
           }
         }
       }
+
+      // Print performance report for this configuration if enabled
+      if (handle->performance_report_enable && !skip_case) {
+        printFinalPerformanceReport(handle, grid_desc);
+      }
+
       auto times = processTimings(handle, trial_times, 1000.);
 
       if (handle->rank == 0) {
@@ -834,6 +843,9 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
   CHECK_MPI(MPI_Barrier(handle->mpi_comm));
   double t_end = MPI_Wtime();
   if (handle->rank == 0) printf("CUDECOMP: halo autotuning time [s]: %f\n", t_end - t_start);
+
+  // Reset performance samples after autotuning
+  resetPerformanceSamples(handle, grid_desc);
 }
 
 } // namespace cudecomp

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -332,7 +332,9 @@ static void getCudecompEnvVars(cudecompHandle_t& handle) {
 
   // Check CUDECOMP_ENABLE_PERFORMANCE_REPORT (Performance reporting)
   const char* performance_report_str = std::getenv("CUDECOMP_ENABLE_PERFORMANCE_REPORT");
-  if (performance_report_str) { handle->performance_report_enable = std::strtol(performance_report_str, nullptr, 10) == 1; }
+  if (performance_report_str) {
+    handle->performance_report_enable = std::strtol(performance_report_str, nullptr, 10) == 1;
+  }
 
   // Check CUDECOMP_PERFORMANCE_REPORT_DETAIL (Performance report detail level)
   const char* performance_detail_str = std::getenv("CUDECOMP_PERFORMANCE_REPORT_DETAIL");
@@ -349,11 +351,11 @@ static void getCudecompEnvVars(cudecompHandle_t& handle) {
   const char* performance_samples_str = std::getenv("CUDECOMP_PERFORMANCE_REPORT_SAMPLES");
   if (performance_samples_str) {
     int32_t samples = std::strtol(performance_samples_str, nullptr, 10);
-    if (samples > 0) {  // Only require positive values
+    if (samples > 0) { // Only require positive values
       handle->performance_report_samples = samples;
     } else if (handle->rank == 0) {
-      printf("CUDECOMP:WARN: Invalid CUDECOMP_PERFORMANCE_REPORT_SAMPLES value (%d). Using default (%d).\n",
-             samples, handle->performance_report_samples);
+      printf("CUDECOMP:WARN: Invalid CUDECOMP_PERFORMANCE_REPORT_SAMPLES value (%d). Using default (%d).\n", samples,
+             handle->performance_report_samples);
     }
   }
 
@@ -361,7 +363,7 @@ static void getCudecompEnvVars(cudecompHandle_t& handle) {
   const char* performance_warmup_str = std::getenv("CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES");
   if (performance_warmup_str) {
     int32_t warmup_samples = std::strtol(performance_warmup_str, nullptr, 10);
-    if (warmup_samples >= 0) {  // Only require non-negative values
+    if (warmup_samples >= 0) { // Only require non-negative values
       handle->performance_report_warmup_samples = warmup_samples;
     } else if (handle->rank == 0) {
       printf("CUDECOMP:WARN: Invalid CUDECOMP_PERFORMANCE_REPORT_WARMUP_SAMPLES value (%d). Using default (%d).\n",
@@ -371,9 +373,7 @@ static void getCudecompEnvVars(cudecompHandle_t& handle) {
 
   // Check CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR (Directory for CSV performance reports)
   const char* performance_write_dir_str = std::getenv("CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR");
-  if (performance_write_dir_str) {
-    handle->performance_report_write_dir = std::string(performance_write_dir_str);
-  }
+  if (performance_write_dir_str) { handle->performance_report_write_dir = std::string(performance_write_dir_str); }
 }
 
 #ifdef ENABLE_NVSHMEM
@@ -778,8 +778,12 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
         for (auto& sample : collection.samples) {
           CHECK_CUDA(cudaEventDestroy(sample.transpose_start_event));
           CHECK_CUDA(cudaEventDestroy(sample.transpose_end_event));
-          for (auto& event : sample.alltoall_start_events) { CHECK_CUDA(cudaEventDestroy(event)); }
-          for (auto& event : sample.alltoall_end_events) { CHECK_CUDA(cudaEventDestroy(event)); }
+          for (auto& event : sample.alltoall_start_events) {
+            CHECK_CUDA(cudaEventDestroy(event));
+          }
+          for (auto& event : sample.alltoall_end_events) {
+            CHECK_CUDA(cudaEventDestroy(event));
+          }
         }
       }
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -764,8 +764,8 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
 
     // Destroy timing events for AlltoAll operations
     if (handle->performance_report_enable) {
-      // Print final performance report before destroying events
-      printFinalPerformanceReport(handle, grid_desc);
+      // Print performance report before destroying events
+      printPerformanceReport(handle, grid_desc);
 
       // Destroy all transpose performance sample events in the map
       for (auto& entry : grid_desc->transpose_perf_samples_map) {

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -368,6 +368,12 @@ static void getCudecompEnvVars(cudecompHandle_t& handle) {
              warmup_samples, handle->performance_report_warmup_samples);
     }
   }
+
+  // Check CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR (Directory for CSV performance reports)
+  const char* performance_write_dir_str = std::getenv("CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR");
+  if (performance_write_dir_str) {
+    handle->performance_report_write_dir = std::string(performance_write_dir_str);
+  }
 }
 
 #ifdef ENABLE_NVSHMEM

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -332,12 +332,16 @@ static void getCudecompEnvVars(cudecompHandle_t& handle) {
 
   // Check CUDECOMP_ENABLE_PERFORMANCE_REPORTING (Performance reporting)
   const char* performance_report_str = std::getenv("CUDECOMP_ENABLE_PERFORMANCE_REPORTING");
-  if (performance_report_str) {
-    int32_t level = std::strtol(performance_report_str, nullptr, 10);
-    if (level >= 0 && level <= 2) {
-      handle->performance_report_enable = level;
+  if (performance_report_str) { handle->performance_report_enable = std::strtol(performance_report_str, nullptr, 10) == 1; }
+
+  // Check CUDECOMP_PERFORMANCE_REPORT_DETAIL (Performance report detail level)
+  const char* performance_detail_str = std::getenv("CUDECOMP_PERFORMANCE_REPORT_DETAIL");
+  if (performance_detail_str) {
+    int32_t detail = std::strtol(performance_detail_str, nullptr, 10);
+    if (detail >= 0 && detail <= 2) {
+      handle->performance_report_detail = detail;
     } else if (handle->rank == 0) {
-      printf("CUDECOMP:WARN: Invalid CUDECOMP_ENABLE_PERFORMANCE_REPORTING value (%d). Using default (0).\n", level);
+      printf("CUDECOMP:WARN: Invalid CUDECOMP_PERFORMANCE_REPORT_DETAIL value (%d). Using default (0).\n", detail);
     }
   }
 
@@ -759,7 +763,7 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
 #endif
 
     // Destroy timing events for AlltoAll operations
-    if (handle->performance_report_enable > 0) {
+    if (handle->performance_report_enable) {
       // Print final performance report before destroying events
       printFinalPerformanceReport(handle, grid_desc);
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -762,7 +762,6 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
     if (grid_desc->nvshmem_sync_event) { CHECK_CUDA(cudaEventDestroy(grid_desc->nvshmem_sync_event)); }
 #endif
 
-    // Destroy timing events for AlltoAll operations
     if (handle->performance_report_enable) {
       // Print performance report before destroying events
       printPerformanceReport(handle, grid_desc);

--- a/src/performance.cc
+++ b/src/performance.cc
@@ -75,15 +75,40 @@ cudecompTransposeConfigKey createTransposeConfig(int ax, int dir, void* input, v
                          input_padding, output_padding, inplace, managed_memory, datatype);
 }
 
-// Helper function to get or create performance sample collection for a configuration
-cudecompPerformanceSampleCollection& getOrCreatePerformanceSamples(const cudecompHandle_t handle,
-                                                                   cudecompGridDesc_t grid_desc,
-                                                                   const cudecompTransposeConfigKey& config) {
-  auto& samples_map = grid_desc->perf_samples_map;
+// Helper function to create halo configuration key
+cudecompHaloConfigKey createHaloConfig(int ax, int dim, void* input,
+                                      const int32_t halo_extents_ptr[],
+                                      const bool halo_periods_ptr[],
+                                      const int32_t padding_ptr[],
+                                      cudecompDataType_t datatype) {
+  std::array<int32_t, 3> halo_extents{0, 0, 0};
+  std::array<bool, 3> halo_periods{false, false, false};
+  std::array<int32_t, 3> padding{0, 0, 0};
+
+  if (halo_extents_ptr) {
+    std::copy(halo_extents_ptr, halo_extents_ptr + 3, halo_extents.begin());
+  }
+  if (halo_periods_ptr) {
+    std::copy(halo_periods_ptr, halo_periods_ptr + 3, halo_periods.begin());
+  }
+  if (padding_ptr) {
+    std::copy(padding_ptr, padding_ptr + 3, padding.begin());
+  }
+
+  bool managed_memory = isManagedPointer(input);
+
+  return std::make_tuple(ax, dim, halo_extents, halo_periods, padding, managed_memory, datatype);
+}
+
+// Helper function to get or create transpose performance sample collection for a configuration
+cudecompTransposePerformanceSampleCollection& getOrCreateTransposePerformanceSamples(const cudecompHandle_t handle,
+                                                                                    cudecompGridDesc_t grid_desc,
+                                                                                    const cudecompTransposeConfigKey& config) {
+  auto& samples_map = grid_desc->transpose_perf_samples_map;
 
   if (samples_map.find(config) == samples_map.end()) {
     // Create new sample collection for this configuration
-    cudecompPerformanceSampleCollection collection;
+    cudecompTransposePerformanceSampleCollection collection;
     collection.samples.resize(handle->performance_report_samples);
     collection.sample_idx = 0;
 
@@ -108,6 +133,33 @@ cudecompPerformanceSampleCollection& getOrCreatePerformanceSamples(const cudecom
   return samples_map[config];
 }
 
+// Helper function to get or create halo performance sample collection for a configuration
+cudecompHaloPerformanceSampleCollection& getOrCreateHaloPerformanceSamples(const cudecompHandle_t handle,
+                                                                           cudecompGridDesc_t grid_desc,
+                                                                           const cudecompHaloConfigKey& config) {
+  auto& samples_map = grid_desc->halo_perf_samples_map;
+
+  if (samples_map.find(config) == samples_map.end()) {
+    // Create new sample collection for this configuration
+    cudecompHaloPerformanceSampleCollection collection;
+    collection.samples.resize(handle->performance_report_samples);
+    collection.sample_idx = 0;
+
+    // Create events for each sample
+    for (auto& sample : collection.samples) {
+      CHECK_CUDA(cudaEventCreate(&sample.halo_start_event));
+      CHECK_CUDA(cudaEventCreate(&sample.halo_end_event));
+      CHECK_CUDA(cudaEventCreate(&sample.sendrecv_start_event));
+      CHECK_CUDA(cudaEventCreate(&sample.sendrecv_end_event));
+      sample.valid = false;
+    }
+
+    samples_map[config] = std::move(collection);
+  }
+
+  return samples_map[config];
+}
+
 // Helper function to format array as compact string
 std::string formatArray(const std::array<int32_t, 3>& arr) {
   std::ostringstream oss;
@@ -115,8 +167,8 @@ std::string formatArray(const std::array<int32_t, 3>& arr) {
   return oss.str();
 }
 
-// Helper function to get operation name from config
-std::string getOperationName(const cudecompTransposeConfigKey& config) {
+// Helper function to get operation name from transpose config
+std::string getTransposeOperationName(const cudecompTransposeConfigKey& config) {
   int ax = std::get<0>(config);
   int dir = std::get<1>(config);
 
@@ -132,6 +184,20 @@ std::string getOperationName(const cudecompTransposeConfigKey& config) {
   return "Unknown";
 }
 
+// Helper function to get operation name from halo config
+std::string getHaloOperationName(const cudecompHaloConfigKey& config) {
+  int ax = std::get<0>(config);
+
+  if (ax == 0) {
+    return "HaloX";
+  } else if (ax == 1) {
+    return "HaloY";
+  } else if (ax == 2) {
+    return "HaloZ";
+  }
+  return "Unknown";
+}
+
 // Helper function to convert datatype to string
 std::string getDatatypeString(cudecompDataType_t datatype) {
   switch (datatype) {
@@ -143,8 +209,8 @@ std::string getDatatypeString(cudecompDataType_t datatype) {
   }
 }
 
-// Helper structure for statistics
-struct PerformanceStats {
+// Helper structure for transpose statistics
+struct TransposePerformanceStats {
   std::string operation;
   std::string datatype;
   std::string halos;        // Combined input/output halos
@@ -158,9 +224,25 @@ struct PerformanceStats {
   float alltoall_bw_avg;
 };
 
-// Helper structure to hold pre-computed timing data
-struct ConfigTimingData {
-  PerformanceStats stats;
+// Helper structure for halo statistics
+struct HaloPerformanceStats {
+  std::string operation;
+  std::string datatype;
+  int dim;
+  std::string halos;
+  std::string periods;
+  std::string padding;
+  std::string managed;
+  int samples;
+  float total_time_avg;
+  float sendrecv_time_avg;
+  float local_time_avg;
+  float sendrecv_bw_avg;
+};
+
+// Helper structure to hold pre-computed transpose timing data
+struct TransposeConfigTimingData {
+  TransposePerformanceStats stats;
   std::vector<float> total_times;
   std::vector<float> alltoall_times;
   std::vector<float> local_times;
@@ -168,18 +250,28 @@ struct ConfigTimingData {
   std::vector<int> sample_indices;
 };
 
+// Helper structure to hold pre-computed halo timing data
+struct HaloConfigTimingData {
+  HaloPerformanceStats stats;
+  std::vector<float> total_times;
+  std::vector<float> sendrecv_times;
+  std::vector<float> local_times;
+  std::vector<float> sendrecv_bws;
+  std::vector<int> sample_indices;
+};
+
 void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc) {
   // Synchronize to ensure all events are recorded
   CHECK_CUDA(cudaDeviceSynchronize());
 
-  // Collect all statistics and timing data
-  std::vector<ConfigTimingData> all_config_data;
+  // Collect all transpose statistics and timing data
+  std::vector<TransposeConfigTimingData> all_transpose_config_data;
 
-  for (const auto& entry : grid_desc->perf_samples_map) {
+  for (const auto& entry : grid_desc->transpose_perf_samples_map) {
     const auto& config = entry.first;
     const auto& collection = entry.second;
 
-    ConfigTimingData config_data;
+    TransposeConfigTimingData config_data;
 
     // Collect valid samples and compute elapsed times once
     for (int i = 0; i < collection.samples.size(); ++i) {
@@ -208,8 +300,8 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
     if (config_data.total_times.empty()) continue;
 
     // Prepare aggregated statistics
-    PerformanceStats& stats = config_data.stats;
-    stats.operation = getOperationName(config);
+    TransposePerformanceStats& stats = config_data.stats;
+    stats.operation = getTransposeOperationName(config);
     stats.datatype = getDatatypeString(std::get<8>(config));
 
     // Format combined halos and padding
@@ -240,7 +332,76 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
     stats.local_time_avg /= handle->nranks;
     stats.alltoall_bw_avg /= handle->nranks;
 
-    all_config_data.push_back(std::move(config_data));
+    all_transpose_config_data.push_back(std::move(config_data));
+  }
+
+  // Collect all halo statistics and timing data
+  std::vector<HaloConfigTimingData> all_halo_config_data;
+
+  for (const auto& entry : grid_desc->halo_perf_samples_map) {
+    const auto& config = entry.first;
+    const auto& collection = entry.second;
+
+    HaloConfigTimingData config_data;
+
+    // Collect valid samples and compute elapsed times once
+    for (int i = 0; i < collection.samples.size(); ++i) {
+      const auto& sample = collection.samples[i];
+      if (!sample.valid) continue;
+
+      float sendrecv_timing_ms = 0.0f;
+      if (sample.sendrecv_bytes > 0) {
+        CHECK_CUDA(cudaEventElapsedTime(&sendrecv_timing_ms, sample.sendrecv_start_event, sample.sendrecv_end_event));
+      }
+
+      float halo_timing_ms;
+      CHECK_CUDA(cudaEventElapsedTime(&halo_timing_ms, sample.halo_start_event, sample.halo_end_event));
+
+      config_data.total_times.push_back(halo_timing_ms);
+      config_data.sendrecv_times.push_back(sendrecv_timing_ms);
+      config_data.local_times.push_back(halo_timing_ms - sendrecv_timing_ms);
+
+      float sendrecv_bw = (sendrecv_timing_ms > 0) ? sample.sendrecv_bytes * 1e-6 / sendrecv_timing_ms : 0;
+      config_data.sendrecv_bws.push_back(sendrecv_bw);
+      config_data.sample_indices.push_back(i);
+    }
+
+    if (config_data.total_times.empty()) continue;
+
+    // Prepare aggregated statistics
+    HaloPerformanceStats& stats = config_data.stats;
+    stats.operation = getHaloOperationName(config);
+    stats.datatype = getDatatypeString(std::get<6>(config));
+    stats.dim = std::get<1>(config);
+
+    // Format halo extents, periods, and padding
+    auto halo_extents = std::get<2>(config);
+    auto halo_periods = std::get<3>(config);
+    auto padding = std::get<4>(config);
+
+    stats.halos = formatArray(halo_extents);
+    stats.periods = "[" + std::to_string(halo_periods[0]) + "," + std::to_string(halo_periods[1]) + "," + std::to_string(halo_periods[2]) + "]";
+    stats.padding = formatArray(padding);
+    stats.managed = std::get<5>(config) ? "Y" : "N";
+    stats.samples = config_data.total_times.size();
+
+    // Compute average statistics across all ranks
+    stats.total_time_avg = std::accumulate(config_data.total_times.begin(), config_data.total_times.end(), 0.0f) / config_data.total_times.size();
+    stats.sendrecv_time_avg = std::accumulate(config_data.sendrecv_times.begin(), config_data.sendrecv_times.end(), 0.0f) / config_data.sendrecv_times.size();
+    stats.local_time_avg = std::accumulate(config_data.local_times.begin(), config_data.local_times.end(), 0.0f) / config_data.local_times.size();
+    stats.sendrecv_bw_avg = std::accumulate(config_data.sendrecv_bws.begin(), config_data.sendrecv_bws.end(), 0.0f) / config_data.sendrecv_bws.size();
+
+    CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.total_time_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
+    CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.sendrecv_time_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
+    CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.local_time_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
+    CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.sendrecv_bw_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
+
+    stats.total_time_avg /= handle->nranks;
+    stats.sendrecv_time_avg /= handle->nranks;
+    stats.local_time_avg /= handle->nranks;
+    stats.sendrecv_bw_avg /= handle->nranks;
+
+    all_halo_config_data.push_back(std::move(config_data));
   }
 
   // Print summary information on rank 0 only
@@ -251,6 +412,8 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
     printf("CUDECOMP: Grid Configuration:\n");
     printf("CUDECOMP:\tTranspose backend: %s\n",
            cudecompTransposeCommBackendToString(grid_desc->config.transpose_comm_backend));
+    printf("CUDECOMP:\tHalo backend: %s\n",
+           cudecompHaloCommBackendToString(grid_desc->config.halo_comm_backend));
     printf("CUDECOMP:\tProcess grid: [%d, %d]\n",
            grid_desc->config.pdims[0], grid_desc->config.pdims[1]);
     printf("CUDECOMP:\tGlobal dimensions: [%d, %d, %d]\n",
@@ -267,42 +430,83 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
     printf("\n");
 
     printf("CUDECOMP:\n");
-    printf("CUDECOMP: Transpose Performance Data:\n");
-    printf("CUDECOMP:\n");
 
-    if (all_config_data.empty()) {
+    if (all_transpose_config_data.empty() && all_halo_config_data.empty()) {
       printf("CUDECOMP: No performance data collected\n");
       printf("CUDECOMP: ================================\n");
       return;
     }
 
-    // Print compact table header
-    printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
-           "operation", "dtype", "halo extents", "padding", "inplace", "managed", "samples",
-           "total", "A2A", "local", "A2A BW");
-    printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
-           "", "", "", "", "", "", "",
-           "[ms]", "[ms]", "[ms]", "[GB/s]");
-    printf("CUDECOMP: ");
-    for (int i = 0; i < 120; ++i) printf("-");
-    printf("\n");
+    // Print transpose performance data
+    if (!all_transpose_config_data.empty()) {
+      printf("CUDECOMP: Transpose Performance Data:\n");
+      printf("CUDECOMP:\n");
 
-    // Print table rows
-    for (const auto& config_data : all_config_data) {
-      const auto& stats = config_data.stats;
-      printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8d %-9.3f %-9.3f %-9.3f %-9.3f\n",
-             stats.operation.c_str(),
-             stats.datatype.c_str(),
-             stats.halos.c_str(),
-             stats.padding.c_str(),
-             stats.inplace.c_str(),
-             stats.managed.c_str(),
-             stats.samples,
-             stats.total_time_avg,
-             stats.alltoall_time_avg,
-             stats.local_time_avg,
-             stats.alltoall_bw_avg
-             );
+      // Print compact table header
+      printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+             "operation", "dtype", "halo extents", "padding", "inplace", "managed", "samples",
+             "total", "A2A", "local", "A2A BW");
+      printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+             "", "", "", "", "", "", "",
+             "[ms]", "[ms]", "[ms]", "[GB/s]");
+      printf("CUDECOMP: ");
+      for (int i = 0; i < 120; ++i) printf("-");
+      printf("\n");
+
+      // Print table rows
+      for (const auto& config_data : all_transpose_config_data) {
+        const auto& stats = config_data.stats;
+        printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+               stats.operation.c_str(),
+               stats.datatype.c_str(),
+               stats.halos.c_str(),
+               stats.padding.c_str(),
+               stats.inplace.c_str(),
+               stats.managed.c_str(),
+               stats.samples,
+               stats.total_time_avg,
+               stats.alltoall_time_avg,
+               stats.local_time_avg,
+               stats.alltoall_bw_avg
+               );
+      }
+    }
+
+    // Print halo performance data
+    if (!all_halo_config_data.empty()) {
+      printf("CUDECOMP:\n");
+      printf("CUDECOMP: Halo Performance Data:\n");
+      printf("CUDECOMP:\n");
+
+      // Print compact table header
+      printf("CUDECOMP: %-12s %-6s %-5s %-12s %-12s %-12s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+             "operation", "dtype", "dim", "halo extent", "periods", "padding", "managed", "samples",
+             "total", "SR", "local", "SR BW");
+      printf("CUDECOMP: %-12s %-6s %-5s %-12s %-12s %-12s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+             "", "", "", "", "", "", "", "",
+             "[ms]", "[ms]", "[ms]", "[GB/s]");
+      printf("CUDECOMP: ");
+      for (int i = 0; i < 125; ++i) printf("-");
+      printf("\n");
+
+      // Print table rows
+      for (const auto& config_data : all_halo_config_data) {
+        const auto& stats = config_data.stats;
+        printf("CUDECOMP: %-12s %-6s %-5d %-12s %-12s %-12s %-8s %-8d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+               stats.operation.c_str(),
+               stats.datatype.c_str(),
+               stats.dim,
+               stats.halos.c_str(),
+               stats.periods.c_str(),
+               stats.padding.c_str(),
+               stats.managed.c_str(),
+               stats.samples,
+               stats.total_time_avg,
+               stats.sendrecv_time_avg,
+               stats.local_time_avg,
+               stats.sendrecv_bw_avg
+               );
+      }
     }
   }
 
@@ -314,7 +518,7 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
       printf("CUDECOMP:\n");
     }
 
-    for (const auto& config_data : all_config_data) {
+    for (const auto& config_data : all_transpose_config_data) {
       const auto& stats = config_data.stats;
 
       // Print configuration header on rank 0
@@ -409,6 +613,104 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
         printf("CUDECOMP:\n");
       }
     }
+
+    // Print halo per-sample details
+    for (const auto& config_data : all_halo_config_data) {
+      const auto& stats = config_data.stats;
+
+      // Print configuration header on rank 0
+      if (handle->rank == 0) {
+        printf("CUDECOMP: %s (dtype=%s, dim=%d, halos=%s, periods=%s, padding=%s, managed=%s) samples:\n",
+               stats.operation.c_str(),
+               stats.datatype.c_str(),
+               stats.dim,
+               stats.halos.c_str(),
+               stats.periods.c_str(),
+               stats.padding.c_str(),
+               stats.managed.c_str());
+      }
+
+      const auto& total_times = config_data.total_times;
+      const auto& sendrecv_times = config_data.sendrecv_times;
+      const auto& local_times = config_data.local_times;
+      const auto& sendrecv_bws = config_data.sendrecv_bws;
+      const auto& sample_indices = config_data.sample_indices;
+
+      if (total_times.empty()) continue;
+
+      if (handle->performance_report_detail == 1) {
+        // Print per-sample data for rank 0 only
+        if (handle->rank == 0) {
+          printf("CUDECOMP: %-6s %-12s %-9s %-9s %-9s %-9s\n",
+                 "rank", "sample", "total", "SR", "local", "SR BW");
+          printf("CUDECOMP: %-6s %-12s %-9s %-9s %-9s %-9s\n",
+                 "", "", "[ms]", "[ms]", "[ms]", "[GB/s]");
+
+          for (int i = 0; i < total_times.size(); ++i) {
+            printf("CUDECOMP: %-6d %-12d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+                   handle->rank, sample_indices[i], total_times[i], sendrecv_times[i],
+                   local_times[i], sendrecv_bws[i]);
+          }
+        }
+      } else if (handle->performance_report_detail == 2) {
+        // Gather data from all ranks to rank 0
+        // Note: We assume all entries have the same number of samples per rank
+        int num_samples = total_times.size();
+
+        if (handle->rank == 0) {
+          // Use MPI_Gather instead of MPI_Gatherv since all ranks have the same number of samples
+          std::vector<float> all_total_times(num_samples * handle->nranks);
+          std::vector<float> all_sendrecv_times(num_samples * handle->nranks);
+          std::vector<float> all_local_times(num_samples * handle->nranks);
+          std::vector<float> all_sendrecv_bws(num_samples * handle->nranks);
+          std::vector<int> all_sample_indices(num_samples * handle->nranks);
+
+          CHECK_MPI(MPI_Gather(total_times.data(), num_samples, MPI_FLOAT,
+                               all_total_times.data(), num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(sendrecv_times.data(), num_samples, MPI_FLOAT,
+                               all_sendrecv_times.data(), num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(local_times.data(), num_samples, MPI_FLOAT,
+                               all_local_times.data(), num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(sendrecv_bws.data(), num_samples, MPI_FLOAT,
+                               all_sendrecv_bws.data(), num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(sample_indices.data(), num_samples, MPI_INT,
+                               all_sample_indices.data(), num_samples, MPI_INT, 0, handle->mpi_comm));
+
+          // Print header
+          printf("CUDECOMP: %-6s %-12s %-9s %-9s %-9s %-9s\n",
+                 "rank", "sample", "total", "SR", "local", "SR BW");
+          printf("CUDECOMP: %-6s %-12s %-9s %-9s %-9s %-9s\n",
+                 "", "", "[ms]", "[ms]", "[ms]", "[GB/s]");
+
+          // Print data sorted by rank
+          for (int r = 0; r < handle->nranks; ++r) {
+            for (int s = 0; s < num_samples; ++s) {
+              int idx = r * num_samples + s;
+              printf("CUDECOMP: %-6d %-12d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+                     r, all_sample_indices[idx], all_total_times[idx],
+                     all_sendrecv_times[idx], all_local_times[idx],
+                     all_sendrecv_bws[idx]);
+            }
+          }
+        } else {
+          // Non-rank-0 processes just send their data
+          CHECK_MPI(MPI_Gather(total_times.data(), num_samples, MPI_FLOAT,
+                               nullptr, num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(sendrecv_times.data(), num_samples, MPI_FLOAT,
+                               nullptr, num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(local_times.data(), num_samples, MPI_FLOAT,
+                               nullptr, num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(sendrecv_bws.data(), num_samples, MPI_FLOAT,
+                               nullptr, num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(sample_indices.data(), num_samples, MPI_INT,
+                               nullptr, num_samples, MPI_INT, 0, handle->mpi_comm));
+        }
+      }
+
+      if (handle->rank == 0) {
+        printf("CUDECOMP:\n");
+      }
+    }
   }
 
   if (handle->rank == 0) {
@@ -419,8 +721,8 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
 void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc) {
   if (!handle->performance_report_enable) return;
 
-  // Reset all sample collections in the map
-  for (auto& entry : grid_desc->perf_samples_map) {
+  // Reset all transpose sample collections in the map
+  for (auto& entry : grid_desc->transpose_perf_samples_map) {
     auto& collection = entry.second;
     collection.sample_idx = 0;
     collection.warmup_count = 0;
@@ -432,14 +734,45 @@ void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t g
       sample.alltoall_bytes = 0;
     }
   }
+
+  // Reset all halo sample collections in the map
+  for (auto& entry : grid_desc->halo_perf_samples_map) {
+    auto& collection = entry.second;
+    collection.sample_idx = 0;
+    collection.warmup_count = 0;
+
+    // Mark all samples as invalid and reset counters
+    for (auto& sample : collection.samples) {
+      sample.valid = false;
+      sample.sendrecv_bytes = 0;
+    }
+  }
 }
 
-// Helper function to advance sample index with warmup handling
-void advancePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
-                             const cudecompTransposeConfigKey& config) {
+// Helper function to advance transpose sample index with warmup handling
+void advanceTransposePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                      const cudecompTransposeConfigKey& config) {
   if (!handle->performance_report_enable) return;
 
-  auto& collection = getOrCreatePerformanceSamples(handle, grid_desc, config);
+  auto& collection = getOrCreateTransposePerformanceSamples(handle, grid_desc, config);
+
+  // Check if we're still in warmup phase
+  if (collection.warmup_count < handle->performance_report_warmup_samples) {
+    collection.warmup_count++;
+    // During warmup, don't advance the circular buffer, just mark current sample as invalid
+    collection.samples[collection.sample_idx].valid = false;
+  } else {
+    // Past warmup, advance the circular buffer normally
+    collection.sample_idx = (collection.sample_idx + 1) % handle->performance_report_samples;
+  }
+}
+
+// Helper function to advance halo sample index with warmup handling
+void advanceHaloPerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                 const cudecompHaloConfigKey& config) {
+  if (!handle->performance_report_enable) return;
+
+  auto& collection = getOrCreateHaloPerformanceSamples(handle, grid_desc, config);
 
   // Check if we're still in warmup phase
   if (collection.warmup_count < handle->performance_report_warmup_samples) {

--- a/src/performance.cc
+++ b/src/performance.cc
@@ -260,7 +260,7 @@ struct HaloConfigTimingData {
   std::vector<int> sample_indices;
 };
 
-void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc) {
+void printPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc) {
   // Synchronize to ensure all events are recorded
   CHECK_CUDA(cudaDeviceSynchronize());
 
@@ -406,6 +406,7 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
 
   // Print summary information on rank 0 only
   if (handle->rank == 0) {
+    printf("CUDECOMP:\n");
     printf("CUDECOMP: ===== Performance Summary =====\n");
 
     // Print grid descriptor configuration information
@@ -434,6 +435,7 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
     if (all_transpose_config_data.empty() && all_halo_config_data.empty()) {
       printf("CUDECOMP: No performance data collected\n");
       printf("CUDECOMP: ================================\n");
+      printf("CUDECOMP:\n");
       return;
     }
 
@@ -715,6 +717,7 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
 
   if (handle->rank == 0) {
     printf("CUDECOMP: ================================\n");
+    printf("CUDECOMP:\n");
   }
 }
 

--- a/src/performance.cc
+++ b/src/performance.cc
@@ -287,6 +287,8 @@ bool compareHaloConfigData(const HaloConfigTimingData& a,
 
 // Function to compute average across ranks
 float computeGlobalAverage(const std::vector<float>& values, const cudecompHandle_t handle) {
+  if (values.size() == 0) { return 0.0f; }
+
   float value = std::accumulate(values.begin(), values.end(), 0.0f);
   value /= values.size();
   CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &value, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
@@ -338,10 +340,6 @@ TransposeConfigTimingData processTransposeConfig(const cudecompTransposeConfigKe
 
     float alltoall_bw = (alltoall_timing_ms > 0) ? sample.alltoall_bytes * 1e-6 / alltoall_timing_ms : 0;
     config_data.alltoall_bws.push_back(alltoall_bw);
-  }
-
-  if (config_data.total_times.empty()) {
-    return config_data;
   }
 
   // Prepare aggregated statistics
@@ -400,10 +398,6 @@ HaloConfigTimingData processHaloConfig(const cudecompHaloConfigKey& config,
 
     float sendrecv_bw = (sendrecv_timing_ms > 0) ? sample.sendrecv_bytes * 1e-6 / sendrecv_timing_ms : 0;
     config_data.sendrecv_bws.push_back(sendrecv_bw);
-  }
-
-  if (config_data.total_times.empty()) {
-    return config_data;
   }
 
   // Prepare aggregated statistics

--- a/src/performance.cc
+++ b/src/performance.cc
@@ -476,7 +476,6 @@ TransposeConfigTimingData processTransposeConfig(const cudecompTransposeConfigKe
   stats.operation = getTransposeOperationName(config);
   stats.datatype = getDatatypeString(std::get<8>(config));
 
-  // Format separate halos and padding
   auto input_halos = std::get<2>(config);
   auto output_halos = std::get<3>(config);
   auto input_padding = std::get<4>(config);
@@ -591,21 +590,21 @@ void printTransposePerformanceTable(const std::vector<TransposeConfigTimingData>
   printf("CUDECOMP:\n");
 
   // Print compact table header
-  printf("CUDECOMP: %-12s %-6s %-16s %-16s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
-         "operation", "dtype", "input halos", "output halos", "input padding", "output padding", "inplace", "managed", "samples",
+  printf("CUDECOMP: %-12s %-6s %-15s %-15s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+    "operation", "dtype", "halo extents", "padding", "inplace", "managed", "samples",
          "total", "A2A", "local", "A2A BW");
-  printf("CUDECOMP: %-12s %-6s %-16s %-16s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
-         "", "", "", "", "", "", "", "", "",
+  printf("CUDECOMP: %-12s %-6s %-15s %-15s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+         "", "", "", "", "", "", "",
          "[ms]", "[ms]", "[ms]", "[GB/s]");
   printf("CUDECOMP: ");
-  for (int i = 0; i < 152; ++i) printf("-");
+  for (int i = 0; i < 120; ++i) printf("-");
   printf("\n");
 
   // Print table rows
   for (const auto& config_data : all_transpose_config_data) {
     const auto& stats = config_data.stats;
     if (stats.samples > 0) {
-      printf("CUDECOMP: %-12s %-6s %-16s %-16s %-16s %-16s %-8s %-8s %-8d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+      printf("CUDECOMP: %-12s %-6s %-7s/%-7s %-7s/%-7s %-8s %-8s %-8d %-9.3f %-9.3f %-9.3f %-9.3f\n",
              stats.operation.c_str(),
              stats.datatype.c_str(),
              stats.input_halos.c_str(),
@@ -695,7 +694,7 @@ void printTransposePerSampleDetailsForConfig(const TransposeConfigTimingData& co
     if (handle->rank != 0) return;
   }
 
-  printf("CUDECOMP: %s (dtype=%s, input_halos=%s, output_halos=%s, input_padding=%s, output_padding=%s, inplace=%s, managed=%s) samples:\n",
+  printf("CUDECOMP: %s (dtype=%s, halo extents=%s/%s, padding=%s/%s, inplace=%s, managed=%s) samples:\n",
          stats.operation.c_str(),
          stats.datatype.c_str(),
          stats.input_halos.c_str(),

--- a/src/performance.cc
+++ b/src/performance.cc
@@ -1,0 +1,374 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <string>
+
+#include <mpi.h>
+
+#include "cudecomp.h"
+#include "internal/checks.h"
+#include "internal/performance.h"
+
+namespace cudecomp {
+
+// Helper function to create transpose configuration key (no longer template)
+cudecompTransposeConfigKey createTransposeConfig(int ax, int dir, void* input, void* output,
+                                                const int32_t input_halo_extents_ptr[],
+                                                const int32_t output_halo_extents_ptr[],
+                                                const int32_t input_padding_ptr[],
+                                                const int32_t output_padding_ptr[],
+                                                cudecompDataType_t datatype) {
+  std::array<int32_t, 3> input_halo_extents{0, 0, 0};
+  std::array<int32_t, 3> output_halo_extents{0, 0, 0};
+  std::array<int32_t, 3> input_padding{0, 0, 0};
+  std::array<int32_t, 3> output_padding{0, 0, 0};
+
+  if (input_halo_extents_ptr) {
+    std::copy(input_halo_extents_ptr, input_halo_extents_ptr + 3, input_halo_extents.begin());
+  }
+  if (output_halo_extents_ptr) {
+    std::copy(output_halo_extents_ptr, output_halo_extents_ptr + 3, output_halo_extents.begin());
+  }
+  if (input_padding_ptr) {
+    std::copy(input_padding_ptr, input_padding_ptr + 3, input_padding.begin());
+  }
+  if (output_padding_ptr) {
+    std::copy(output_padding_ptr, output_padding_ptr + 3, output_padding.begin());
+  }
+
+  bool inplace = (input == output);
+  bool managed_memory = isManagedPointer(input) || isManagedPointer(output);
+
+  return std::make_tuple(ax, dir, input_halo_extents, output_halo_extents,
+                         input_padding, output_padding, inplace, managed_memory, datatype);
+}
+
+// Helper function to get or create performance sample collection for a configuration
+cudecompPerformanceSampleCollection& getOrCreatePerformanceSamples(const cudecompHandle_t handle,
+                                                                   cudecompGridDesc_t grid_desc,
+                                                                   const cudecompTransposeConfigKey& config) {
+  auto& samples_map = grid_desc->perf_samples_map;
+
+  if (samples_map.find(config) == samples_map.end()) {
+    // Create new sample collection for this configuration
+    cudecompPerformanceSampleCollection collection;
+    collection.samples.resize(handle->performance_report_samples);
+    collection.sample_idx = 0;
+
+    // Create events for each sample
+    for (auto& sample : collection.samples) {
+      CHECK_CUDA(cudaEventCreate(&sample.transpose_start_event));
+      CHECK_CUDA(cudaEventCreate(&sample.transpose_end_event));
+      sample.alltoall_start_events.resize(handle->nranks);
+      sample.alltoall_end_events.resize(handle->nranks);
+      for (auto& event : sample.alltoall_start_events) {
+        CHECK_CUDA(cudaEventCreate(&event));
+      }
+      for (auto& event : sample.alltoall_end_events) {
+        CHECK_CUDA(cudaEventCreate(&event));
+      }
+      sample.valid = false;
+    }
+
+    samples_map[config] = std::move(collection);
+  }
+
+  return samples_map[config];
+}
+
+void printPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc,
+                           int ax, int dir, size_t alltoall_bytes, cudecompPerformanceSample* current_sample) {
+  // Only print per-operation reports at level 2
+  if (handle->performance_report_enable != 2) return;
+
+  // Synchronize to ensure all events are recorded
+  CHECK_CUDA(cudaDeviceSynchronize());
+
+  // Compute total timing by summing all individual timings
+  float alltoall_timing_ms = 0.0f;
+  float transpose_timing_ms = 0.0f;
+
+  for (int i = 0; i < current_sample->alltoall_timing_count; ++i) {
+    float elapsed_time;
+    CHECK_CUDA(cudaEventElapsedTime(&elapsed_time, current_sample->alltoall_start_events[i], current_sample->alltoall_end_events[i]));
+    alltoall_timing_ms += elapsed_time;
+  }
+  CHECK_CUDA(cudaEventElapsedTime(&transpose_timing_ms, current_sample->transpose_start_event, current_sample->transpose_end_event));
+
+  // Report on rank 0 only for now.
+  if (handle->rank == 0) {
+    std::string op_name;
+    if (ax == 0) {
+      op_name = "TransposeXY";
+    } else if (ax == 1 && dir == 1) {
+      op_name = "TransposeYZ";
+    } else if (ax == 2) {
+      op_name = "TransposeZY";
+    } else if (ax == 1 && dir == -1) {
+      op_name = "TransposeYX";
+    }
+
+    float alltoall_bw = 0.0f;
+    if (alltoall_timing_ms > 0) {
+      alltoall_bw = alltoall_bytes * 1e-6 / alltoall_timing_ms;
+    }
+    printf("CUDECOMP: rank: %d, op: %s, total time: %.3f ms, alltoall time: %.3f ms, local operation time: %.3f ms, alltoall bw: %.3f GB/s\n",
+           handle->rank, op_name.c_str(), transpose_timing_ms, alltoall_timing_ms, transpose_timing_ms - alltoall_timing_ms, alltoall_bw);
+  }
+}
+
+// Helper function to format array as compact string
+std::string formatArray(const std::array<int32_t, 3>& arr) {
+  std::ostringstream oss;
+  oss << "[" << arr[0] << "," << arr[1] << "," << arr[2] << "]";
+  return oss.str();
+}
+
+// Helper function to get operation name from config
+std::string getOperationName(const cudecompTransposeConfigKey& config) {
+  int ax = std::get<0>(config);
+  int dir = std::get<1>(config);
+
+  if (ax == 0) {
+    return "TransposeXY";
+  } else if (ax == 1 && dir == 1) {
+    return "TransposeYZ";
+  } else if (ax == 2) {
+    return "TransposeZY";
+  } else if (ax == 1 && dir == -1) {
+    return "TransposeYX";
+  }
+  return "Unknown";
+}
+
+// Helper function to convert datatype to string
+std::string getDatatypeString(cudecompDataType_t datatype) {
+  switch (datatype) {
+    case CUDECOMP_FLOAT: return "S";
+    case CUDECOMP_DOUBLE: return "D";
+    case CUDECOMP_FLOAT_COMPLEX: return "C";
+    case CUDECOMP_DOUBLE_COMPLEX: return "Z";
+    default: return "unknown";
+  }
+}
+
+// Helper structure for statistics
+struct PerformanceStats {
+  std::string operation;
+  std::string datatype;
+  std::string halos;        // Combined input/output halos
+  std::string padding;      // Combined input/output padding
+  std::string inplace;
+  std::string managed;
+  int samples;
+  float total_time_avg;
+  float alltoall_time_avg;
+  float local_time_avg;
+  float alltoall_bw_avg;
+};
+
+void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc) {
+  // Synchronize to ensure all events are recorded
+  CHECK_CUDA(cudaDeviceSynchronize());
+
+  // Collect all statistics
+  std::vector<PerformanceStats> all_stats;
+
+  for (const auto& entry : grid_desc->perf_samples_map) {
+    const auto& config = entry.first;
+    const auto& collection = entry.second;
+
+    // Collect valid samples
+    std::vector<float> total_times, alltoall_times, local_times, alltoall_bws;
+
+    for (const auto& sample : collection.samples) {
+      if (!sample.valid) continue;
+
+      float alltoall_timing_ms = 0.0f;
+      for (int j = 0; j < sample.alltoall_timing_count; ++j) {
+        float elapsed_time;
+        CHECK_CUDA(cudaEventElapsedTime(&elapsed_time, sample.alltoall_start_events[j], sample.alltoall_end_events[j]));
+        alltoall_timing_ms += elapsed_time;
+      }
+
+      float transpose_timing_ms;
+      CHECK_CUDA(cudaEventElapsedTime(&transpose_timing_ms, sample.transpose_start_event, sample.transpose_end_event));
+
+      total_times.push_back(transpose_timing_ms);
+      alltoall_times.push_back(alltoall_timing_ms);
+      local_times.push_back(transpose_timing_ms - alltoall_timing_ms);
+
+      float alltoall_bw = (alltoall_timing_ms > 0) ? sample.alltoall_bytes * 1e-6 / alltoall_timing_ms : 0;
+      alltoall_bws.push_back(alltoall_bw);
+    }
+
+    if (total_times.empty()) continue;
+
+    PerformanceStats stats;
+    stats.operation = getOperationName(config);
+    stats.datatype = getDatatypeString(std::get<8>(config));
+
+    // Format combined halos and padding
+    auto input_halos = std::get<2>(config);
+    auto output_halos = std::get<3>(config);
+    auto input_padding = std::get<4>(config);
+    auto output_padding = std::get<5>(config);
+
+    stats.halos = formatArray(input_halos) + "/" + formatArray(output_halos);
+    stats.padding = formatArray(input_padding) + "/" + formatArray(output_padding);
+    stats.inplace = std::get<6>(config) ? "Y" : "N";
+    stats.managed = std::get<7>(config) ? "Y" : "N";
+    stats.samples = total_times.size();
+
+    // Compute average statistics across all ranks
+    stats.total_time_avg = std::accumulate(total_times.begin(), total_times.end(), 0.0f) / total_times.size();
+    stats.alltoall_time_avg = std::accumulate(alltoall_times.begin(), alltoall_times.end(), 0.0f) / alltoall_times.size();
+    stats.local_time_avg = std::accumulate(local_times.begin(), local_times.end(), 0.0f) / local_times.size();
+    stats.alltoall_bw_avg = std::accumulate(alltoall_bws.begin(), alltoall_bws.end(), 0.0f) / alltoall_bws.size();
+
+    CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.total_time_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
+    CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.alltoall_time_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
+    CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.local_time_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
+    CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.alltoall_bw_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
+
+    stats.total_time_avg /= handle->nranks;
+    stats.alltoall_time_avg /= handle->nranks;
+    stats.local_time_avg /= handle->nranks;
+    stats.alltoall_bw_avg /= handle->nranks;
+
+    all_stats.push_back(stats);
+  }
+
+  if (handle->rank != 0) return; // Only print on rank 0
+
+  printf("CUDECOMP: ===== Performance Summary =====\n");
+
+  // Print grid descriptor configuration information
+  printf("CUDECOMP: Grid Configuration:\n");
+  printf("CUDECOMP:\tTranspose backend: %s\n",
+         cudecompTransposeCommBackendToString(grid_desc->config.transpose_comm_backend));
+  printf("CUDECOMP:\tProcess grid: [%d, %d]\n",
+         grid_desc->config.pdims[0], grid_desc->config.pdims[1]);
+  printf("CUDECOMP:\tGlobal dimensions: [%d, %d, %d]\n",
+         grid_desc->config.gdims[0], grid_desc->config.gdims[1], grid_desc->config.gdims[2]);
+
+  // Print memory ordering information
+  printf("CUDECOMP:\tMemory order: ");
+  for (int axis = 0; axis < 3; ++axis) {
+    printf("[%d,%d,%d]", grid_desc->config.transpose_mem_order[axis][0],
+                        grid_desc->config.transpose_mem_order[axis][1],
+                        grid_desc->config.transpose_mem_order[axis][2]);
+    if (axis < 2) printf("; ");
+  }
+  printf("\n");
+
+  printf("CUDECOMP:\n");
+  printf("CUDECOMP: Transpose Performance Data:\n");
+  printf("CUDECOMP:\n");
+
+  if (all_stats.empty()) {
+    printf("CUDECOMP: No performance data collected\n");
+    printf("CUDECOMP: ================================\n");
+    return;
+  }
+
+  // Print compact table header
+  printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+         "operation", "dtype", "halo extents", "padding", "inplace", "managed", "samples",
+         "total", "A2A", "local", "A2A BW");
+  printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+         "", "", "", "", "", "", "",
+         "[ms]", "[ms]", "[ms]", "[GB/s]");
+  printf("CUDECOMP: ");
+  for (int i = 0; i < 120; ++i) printf("-");
+  printf("\n");
+
+  // Print table rows
+  for (const auto& stats : all_stats) {
+    printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+           stats.operation.c_str(),
+           stats.datatype.c_str(),
+           stats.halos.c_str(),
+           stats.padding.c_str(),
+           stats.inplace.c_str(),
+           stats.managed.c_str(),
+           stats.samples,
+           stats.total_time_avg,
+           stats.alltoall_time_avg,
+           stats.local_time_avg,
+           stats.alltoall_bw_avg
+           );
+  }
+
+  printf("CUDECOMP: ================================\n");
+}
+
+void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc) {
+  if (handle->performance_report_enable == 0) return;
+
+  // Reset all sample collections in the map
+  for (auto& entry : grid_desc->perf_samples_map) {
+    auto& collection = entry.second;
+    collection.sample_idx = 0;
+    collection.warmup_count = 0;
+
+    // Mark all samples as invalid and reset counters
+    for (auto& sample : collection.samples) {
+      sample.valid = false;
+      sample.alltoall_timing_count = 0;
+      sample.alltoall_bytes = 0;
+    }
+  }
+}
+
+// Helper function to advance sample index with warmup handling
+void advancePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                             const cudecompTransposeConfigKey& config) {
+  if (handle->performance_report_enable == 0) return;
+
+  auto& collection = getOrCreatePerformanceSamples(handle, grid_desc, config);
+
+  // Check if we're still in warmup phase
+  if (collection.warmup_count < handle->performance_report_warmup_samples) {
+    collection.warmup_count++;
+    // During warmup, don't advance the circular buffer, just mark current sample as invalid
+    collection.samples[collection.sample_idx].valid = false;
+  } else {
+    // Past warmup, advance the circular buffer normally
+    collection.sample_idx = (collection.sample_idx + 1) % handle->performance_report_samples;
+  }
+}
+
+} // namespace cudecomp

--- a/src/performance.cc
+++ b/src/performance.cc
@@ -108,47 +108,6 @@ cudecompPerformanceSampleCollection& getOrCreatePerformanceSamples(const cudecom
   return samples_map[config];
 }
 
-void printPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc,
-                           int ax, int dir, size_t alltoall_bytes, cudecompPerformanceSample* current_sample) {
-  // Only print per-operation reports at level 2
-  if (handle->performance_report_enable != 2) return;
-
-  // Synchronize to ensure all events are recorded
-  CHECK_CUDA(cudaDeviceSynchronize());
-
-  // Compute total timing by summing all individual timings
-  float alltoall_timing_ms = 0.0f;
-  float transpose_timing_ms = 0.0f;
-
-  for (int i = 0; i < current_sample->alltoall_timing_count; ++i) {
-    float elapsed_time;
-    CHECK_CUDA(cudaEventElapsedTime(&elapsed_time, current_sample->alltoall_start_events[i], current_sample->alltoall_end_events[i]));
-    alltoall_timing_ms += elapsed_time;
-  }
-  CHECK_CUDA(cudaEventElapsedTime(&transpose_timing_ms, current_sample->transpose_start_event, current_sample->transpose_end_event));
-
-  // Report on rank 0 only for now.
-  if (handle->rank == 0) {
-    std::string op_name;
-    if (ax == 0) {
-      op_name = "TransposeXY";
-    } else if (ax == 1 && dir == 1) {
-      op_name = "TransposeYZ";
-    } else if (ax == 2) {
-      op_name = "TransposeZY";
-    } else if (ax == 1 && dir == -1) {
-      op_name = "TransposeYX";
-    }
-
-    float alltoall_bw = 0.0f;
-    if (alltoall_timing_ms > 0) {
-      alltoall_bw = alltoall_bytes * 1e-6 / alltoall_timing_ms;
-    }
-    printf("CUDECOMP: rank: %d, op: %s, total time: %.3f ms, alltoall time: %.3f ms, local operation time: %.3f ms, alltoall bw: %.3f GB/s\n",
-           handle->rank, op_name.c_str(), transpose_timing_ms, alltoall_timing_ms, transpose_timing_ms - alltoall_timing_ms, alltoall_bw);
-  }
-}
-
 // Helper function to format array as compact string
 std::string formatArray(const std::array<int32_t, 3>& arr) {
   std::ostringstream oss;
@@ -199,21 +158,32 @@ struct PerformanceStats {
   float alltoall_bw_avg;
 };
 
+// Helper structure to hold pre-computed timing data
+struct ConfigTimingData {
+  PerformanceStats stats;
+  std::vector<float> total_times;
+  std::vector<float> alltoall_times;
+  std::vector<float> local_times;
+  std::vector<float> alltoall_bws;
+  std::vector<int> sample_indices;
+};
+
 void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc) {
   // Synchronize to ensure all events are recorded
   CHECK_CUDA(cudaDeviceSynchronize());
 
-  // Collect all statistics
-  std::vector<PerformanceStats> all_stats;
+  // Collect all statistics and timing data
+  std::vector<ConfigTimingData> all_config_data;
 
   for (const auto& entry : grid_desc->perf_samples_map) {
     const auto& config = entry.first;
     const auto& collection = entry.second;
 
-    // Collect valid samples
-    std::vector<float> total_times, alltoall_times, local_times, alltoall_bws;
+    ConfigTimingData config_data;
 
-    for (const auto& sample : collection.samples) {
+    // Collect valid samples and compute elapsed times once
+    for (int i = 0; i < collection.samples.size(); ++i) {
+      const auto& sample = collection.samples[i];
       if (!sample.valid) continue;
 
       float alltoall_timing_ms = 0.0f;
@@ -226,17 +196,19 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
       float transpose_timing_ms;
       CHECK_CUDA(cudaEventElapsedTime(&transpose_timing_ms, sample.transpose_start_event, sample.transpose_end_event));
 
-      total_times.push_back(transpose_timing_ms);
-      alltoall_times.push_back(alltoall_timing_ms);
-      local_times.push_back(transpose_timing_ms - alltoall_timing_ms);
+      config_data.total_times.push_back(transpose_timing_ms);
+      config_data.alltoall_times.push_back(alltoall_timing_ms);
+      config_data.local_times.push_back(transpose_timing_ms - alltoall_timing_ms);
 
       float alltoall_bw = (alltoall_timing_ms > 0) ? sample.alltoall_bytes * 1e-6 / alltoall_timing_ms : 0;
-      alltoall_bws.push_back(alltoall_bw);
+      config_data.alltoall_bws.push_back(alltoall_bw);
+      config_data.sample_indices.push_back(i);
     }
 
-    if (total_times.empty()) continue;
+    if (config_data.total_times.empty()) continue;
 
-    PerformanceStats stats;
+    // Prepare aggregated statistics
+    PerformanceStats& stats = config_data.stats;
     stats.operation = getOperationName(config);
     stats.datatype = getDatatypeString(std::get<8>(config));
 
@@ -250,13 +222,13 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
     stats.padding = formatArray(input_padding) + "/" + formatArray(output_padding);
     stats.inplace = std::get<6>(config) ? "Y" : "N";
     stats.managed = std::get<7>(config) ? "Y" : "N";
-    stats.samples = total_times.size();
+    stats.samples = config_data.total_times.size();
 
     // Compute average statistics across all ranks
-    stats.total_time_avg = std::accumulate(total_times.begin(), total_times.end(), 0.0f) / total_times.size();
-    stats.alltoall_time_avg = std::accumulate(alltoall_times.begin(), alltoall_times.end(), 0.0f) / alltoall_times.size();
-    stats.local_time_avg = std::accumulate(local_times.begin(), local_times.end(), 0.0f) / local_times.size();
-    stats.alltoall_bw_avg = std::accumulate(alltoall_bws.begin(), alltoall_bws.end(), 0.0f) / alltoall_bws.size();
+    stats.total_time_avg = std::accumulate(config_data.total_times.begin(), config_data.total_times.end(), 0.0f) / config_data.total_times.size();
+    stats.alltoall_time_avg = std::accumulate(config_data.alltoall_times.begin(), config_data.alltoall_times.end(), 0.0f) / config_data.alltoall_times.size();
+    stats.local_time_avg = std::accumulate(config_data.local_times.begin(), config_data.local_times.end(), 0.0f) / config_data.local_times.size();
+    stats.alltoall_bw_avg = std::accumulate(config_data.alltoall_bws.begin(), config_data.alltoall_bws.end(), 0.0f) / config_data.alltoall_bws.size();
 
     CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.total_time_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
     CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &stats.alltoall_time_avg, 1, MPI_FLOAT, MPI_SUM, handle->mpi_comm));
@@ -268,75 +240,184 @@ void printFinalPerformanceReport(const cudecompHandle_t handle, const cudecompGr
     stats.local_time_avg /= handle->nranks;
     stats.alltoall_bw_avg /= handle->nranks;
 
-    all_stats.push_back(stats);
+    all_config_data.push_back(std::move(config_data));
   }
 
-  if (handle->rank != 0) return; // Only print on rank 0
+  // Print summary information on rank 0 only
+  if (handle->rank == 0) {
+    printf("CUDECOMP: ===== Performance Summary =====\n");
 
-  printf("CUDECOMP: ===== Performance Summary =====\n");
+    // Print grid descriptor configuration information
+    printf("CUDECOMP: Grid Configuration:\n");
+    printf("CUDECOMP:\tTranspose backend: %s\n",
+           cudecompTransposeCommBackendToString(grid_desc->config.transpose_comm_backend));
+    printf("CUDECOMP:\tProcess grid: [%d, %d]\n",
+           grid_desc->config.pdims[0], grid_desc->config.pdims[1]);
+    printf("CUDECOMP:\tGlobal dimensions: [%d, %d, %d]\n",
+           grid_desc->config.gdims[0], grid_desc->config.gdims[1], grid_desc->config.gdims[2]);
 
-  // Print grid descriptor configuration information
-  printf("CUDECOMP: Grid Configuration:\n");
-  printf("CUDECOMP:\tTranspose backend: %s\n",
-         cudecompTransposeCommBackendToString(grid_desc->config.transpose_comm_backend));
-  printf("CUDECOMP:\tProcess grid: [%d, %d]\n",
-         grid_desc->config.pdims[0], grid_desc->config.pdims[1]);
-  printf("CUDECOMP:\tGlobal dimensions: [%d, %d, %d]\n",
-         grid_desc->config.gdims[0], grid_desc->config.gdims[1], grid_desc->config.gdims[2]);
+    // Print memory ordering information
+    printf("CUDECOMP:\tMemory order: ");
+    for (int axis = 0; axis < 3; ++axis) {
+      printf("[%d,%d,%d]", grid_desc->config.transpose_mem_order[axis][0],
+                          grid_desc->config.transpose_mem_order[axis][1],
+                          grid_desc->config.transpose_mem_order[axis][2]);
+      if (axis < 2) printf("; ");
+    }
+    printf("\n");
 
-  // Print memory ordering information
-  printf("CUDECOMP:\tMemory order: ");
-  for (int axis = 0; axis < 3; ++axis) {
-    printf("[%d,%d,%d]", grid_desc->config.transpose_mem_order[axis][0],
-                        grid_desc->config.transpose_mem_order[axis][1],
-                        grid_desc->config.transpose_mem_order[axis][2]);
-    if (axis < 2) printf("; ");
+    printf("CUDECOMP:\n");
+    printf("CUDECOMP: Transpose Performance Data:\n");
+    printf("CUDECOMP:\n");
+
+    if (all_config_data.empty()) {
+      printf("CUDECOMP: No performance data collected\n");
+      printf("CUDECOMP: ================================\n");
+      return;
+    }
+
+    // Print compact table header
+    printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+           "operation", "dtype", "halo extents", "padding", "inplace", "managed", "samples",
+           "total", "A2A", "local", "A2A BW");
+    printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
+           "", "", "", "", "", "", "",
+           "[ms]", "[ms]", "[ms]", "[GB/s]");
+    printf("CUDECOMP: ");
+    for (int i = 0; i < 120; ++i) printf("-");
+    printf("\n");
+
+    // Print table rows
+    for (const auto& config_data : all_config_data) {
+      const auto& stats = config_data.stats;
+      printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+             stats.operation.c_str(),
+             stats.datatype.c_str(),
+             stats.halos.c_str(),
+             stats.padding.c_str(),
+             stats.inplace.c_str(),
+             stats.managed.c_str(),
+             stats.samples,
+             stats.total_time_avg,
+             stats.alltoall_time_avg,
+             stats.local_time_avg,
+             stats.alltoall_bw_avg
+             );
+    }
   }
-  printf("\n");
 
-  printf("CUDECOMP:\n");
-  printf("CUDECOMP: Transpose Performance Data:\n");
-  printf("CUDECOMP:\n");
+  // Print per-sample data if detail level > 0
+  if (handle->performance_report_detail > 0) {
+    if (handle->rank == 0) {
+      printf("CUDECOMP:\n");
+      printf("CUDECOMP: Per-Sample Details:\n");
+      printf("CUDECOMP:\n");
+    }
 
-  if (all_stats.empty()) {
-    printf("CUDECOMP: No performance data collected\n");
+    for (const auto& config_data : all_config_data) {
+      const auto& stats = config_data.stats;
+
+      // Print configuration header on rank 0
+      if (handle->rank == 0) {
+        printf("CUDECOMP: %s (dtype=%s, halos=%s, padding=%s, inplace=%s, managed=%s) samples:\n",
+               stats.operation.c_str(),
+               stats.datatype.c_str(),
+               stats.halos.c_str(),
+               stats.padding.c_str(),
+               stats.inplace.c_str(),
+               stats.managed.c_str());
+      }
+
+      const auto& total_times = config_data.total_times;
+      const auto& alltoall_times = config_data.alltoall_times;
+      const auto& local_times = config_data.local_times;
+      const auto& alltoall_bws = config_data.alltoall_bws;
+      const auto& sample_indices = config_data.sample_indices;
+
+      if (total_times.empty()) continue;
+
+      if (handle->performance_report_detail == 1) {
+        // Print per-sample data for rank 0 only
+        if (handle->rank == 0) {
+          printf("CUDECOMP: %-6s %-12s %-9s %-9s %-9s %-9s\n",
+                 "rank", "sample", "total", "A2A", "local", "A2A BW");
+          printf("CUDECOMP: %-6s %-12s %-9s %-9s %-9s %-9s\n",
+                 "", "", "[ms]", "[ms]", "[ms]", "[GB/s]");
+
+          for (int i = 0; i < total_times.size(); ++i) {
+            printf("CUDECOMP: %-6d %-12d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+                   handle->rank, sample_indices[i], total_times[i], alltoall_times[i],
+                   local_times[i], alltoall_bws[i]);
+          }
+        }
+      } else if (handle->performance_report_detail == 2) {
+        // Gather data from all ranks to rank 0
+        // Note: We assume all entries have the same number of samples per rank
+        int num_samples = total_times.size();
+
+        if (handle->rank == 0) {
+          // Use MPI_Gather instead of MPI_Gatherv since all ranks have the same number of samples
+          std::vector<float> all_total_times(num_samples * handle->nranks);
+          std::vector<float> all_alltoall_times(num_samples * handle->nranks);
+          std::vector<float> all_local_times(num_samples * handle->nranks);
+          std::vector<float> all_alltoall_bws(num_samples * handle->nranks);
+          std::vector<int> all_sample_indices(num_samples * handle->nranks);
+
+          CHECK_MPI(MPI_Gather(total_times.data(), num_samples, MPI_FLOAT,
+                               all_total_times.data(), num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(alltoall_times.data(), num_samples, MPI_FLOAT,
+                               all_alltoall_times.data(), num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(local_times.data(), num_samples, MPI_FLOAT,
+                               all_local_times.data(), num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(alltoall_bws.data(), num_samples, MPI_FLOAT,
+                               all_alltoall_bws.data(), num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(sample_indices.data(), num_samples, MPI_INT,
+                               all_sample_indices.data(), num_samples, MPI_INT, 0, handle->mpi_comm));
+
+          // Print header
+          printf("CUDECOMP: %-6s %-12s %-9s %-9s %-9s %-9s\n",
+                 "rank", "sample", "total", "A2A", "local", "A2A BW");
+          printf("CUDECOMP: %-6s %-12s %-9s %-9s %-9s %-9s\n",
+                 "", "", "[ms]", "[ms]", "[ms]", "[GB/s]");
+
+          // Print data sorted by rank
+          for (int r = 0; r < handle->nranks; ++r) {
+            for (int s = 0; s < num_samples; ++s) {
+              int idx = r * num_samples + s;
+              printf("CUDECOMP: %-6d %-12d %-9.3f %-9.3f %-9.3f %-9.3f\n",
+                     r, all_sample_indices[idx], all_total_times[idx],
+                     all_alltoall_times[idx], all_local_times[idx],
+                     all_alltoall_bws[idx]);
+            }
+          }
+        } else {
+          // Non-rank-0 processes just send their data
+          CHECK_MPI(MPI_Gather(total_times.data(), num_samples, MPI_FLOAT,
+                               nullptr, num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(alltoall_times.data(), num_samples, MPI_FLOAT,
+                               nullptr, num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(local_times.data(), num_samples, MPI_FLOAT,
+                               nullptr, num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(alltoall_bws.data(), num_samples, MPI_FLOAT,
+                               nullptr, num_samples, MPI_FLOAT, 0, handle->mpi_comm));
+          CHECK_MPI(MPI_Gather(sample_indices.data(), num_samples, MPI_INT,
+                               nullptr, num_samples, MPI_INT, 0, handle->mpi_comm));
+        }
+      }
+
+      if (handle->rank == 0) {
+        printf("CUDECOMP:\n");
+      }
+    }
+  }
+
+  if (handle->rank == 0) {
     printf("CUDECOMP: ================================\n");
-    return;
   }
-
-  // Print compact table header
-  printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
-         "operation", "dtype", "halo extents", "padding", "inplace", "managed", "samples",
-         "total", "A2A", "local", "A2A BW");
-  printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8s %-9s %-9s %-9s %-9s\n",
-         "", "", "", "", "", "", "",
-         "[ms]", "[ms]", "[ms]", "[GB/s]");
-  printf("CUDECOMP: ");
-  for (int i = 0; i < 120; ++i) printf("-");
-  printf("\n");
-
-  // Print table rows
-  for (const auto& stats : all_stats) {
-    printf("CUDECOMP: %-12s %-6s %-16s %-16s %-8s %-8s %-8d %-9.3f %-9.3f %-9.3f %-9.3f\n",
-           stats.operation.c_str(),
-           stats.datatype.c_str(),
-           stats.halos.c_str(),
-           stats.padding.c_str(),
-           stats.inplace.c_str(),
-           stats.managed.c_str(),
-           stats.samples,
-           stats.total_time_avg,
-           stats.alltoall_time_avg,
-           stats.local_time_avg,
-           stats.alltoall_bw_avg
-           );
-  }
-
-  printf("CUDECOMP: ================================\n");
 }
 
 void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc) {
-  if (handle->performance_report_enable == 0) return;
+  if (!handle->performance_report_enable) return;
 
   // Reset all sample collections in the map
   for (auto& entry : grid_desc->perf_samples_map) {
@@ -356,7 +437,7 @@ void resetPerformanceSamples(const cudecompHandle_t handle, cudecompGridDesc_t g
 // Helper function to advance sample index with warmup handling
 void advancePerformanceSample(const cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
                              const cudecompTransposeConfigKey& config) {
-  if (handle->performance_report_enable == 0) return;
+  if (!handle->performance_report_enable) return;
 
   auto& collection = getOrCreatePerformanceSamples(handle, grid_desc, config);
 

--- a/tests/cc/halo_test.cc
+++ b/tests/cc/halo_test.cc
@@ -587,6 +587,21 @@ int main(int argc, char** argv) {
   }
 
   // Finalize
+  // Free grid descriptors
+  for (auto& entry : grid_desc_cache) {
+    auto& backend = entry.first;
+    auto& grid_desc = entry.second;
+    // If backend matches workspace, free workspace
+    if (std::get<0>(workspace) == static_cast<int>(backend)) {
+      CHECK_CUDECOMP(cudecompFree(handle, grid_desc, std::get<1>(workspace)));
+      std::get<0>(workspace) = -1;
+      std::get<1>(workspace) = nullptr;
+      std::get<2>(workspace) = 0;
+    }
+    CHECK_CUDECOMP(cudecompGridDescDestroy(handle, grid_desc));
+  }
+  grid_desc_cache.clear();
+
   CHECK_CUDECOMP_EXIT(cudecompFinalize(handle));
   CHECK_MPI_EXIT(MPI_Finalize());
 

--- a/tests/cc/transpose_test.cc
+++ b/tests/cc/transpose_test.cc
@@ -651,6 +651,21 @@ int main(int argc, char** argv) {
   }
 
   // Finalize
+  // Free grid descriptors
+  for (auto& entry : grid_desc_cache) {
+    auto& backend = entry.first;
+    auto& grid_desc = entry.second;
+    // Free workspace using correct grid descriptor
+    if (std::get<0>(workspace) == static_cast<int>(backend)) {
+      CHECK_CUDECOMP(cudecompFree(handle, grid_desc, std::get<1>(workspace)));
+      std::get<0>(workspace) = -1;
+      std::get<1>(workspace) = nullptr;
+      std::get<2>(workspace) = 0;
+    }
+    CHECK_CUDECOMP(cudecompGridDescDestroy(handle, grid_desc));
+  }
+  grid_desc_cache.clear();
+
   CHECK_CUDECOMP_EXIT(cudecompFinalize(handle));
   CHECK_MPI_EXIT(MPI_Finalize());
 

--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -630,6 +630,17 @@ program main
     if (nfailed /= 0) retcode = 1;
   endif
 
+  ! Free grid descriptors
+  do i = 1, 5
+    if (grid_desc_cache_set(i)) then
+      ! Free workspace with correct grid descriptor
+      if (work_backend == i) then
+        CHECK_CUDECOMP_EXIT(cudecompFree(handle, grid_desc_cache(i), work_d))
+      endif
+      CHECK_CUDECOMP_EXIT(cudecompGridDescDestroy(handle, grid_desc_cache(i)))
+    endif
+  end do
+
   CHECK_CUDECOMP_EXIT(cudecompFinalize(handle))
   call MPI_Finalize(ierr)
 

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -654,6 +654,17 @@ program main
     if (nfailed /= 0) retcode = 1;
   endif
 
+  ! Free grid descriptors
+  do i = 1, 7
+    if (grid_desc_cache_set(i)) then
+      ! Free workspace with correct grid descriptor
+      if (work_backend == i) then
+        CHECK_CUDECOMP_EXIT(cudecompFree(handle, grid_desc_cache(i), work_d))
+      endif
+      CHECK_CUDECOMP_EXIT(cudecompGridDescDestroy(handle, grid_desc_cache(i)))
+    endif
+  end do
+
   CHECK_CUDECOMP_EXIT(cudecompFinalize(handle))
   call MPI_Finalize(ierr)
 


### PR DESCRIPTION
This PR introduces a detailed performance reporting feature to cuDecomp, enabled with a new environment variable `CUDECOMP_ENABLE_PERFORMANCE_REPORT`. The purpose of this feature is to enable users to extract fine-grained performance information from transpose and halo operations invoked in their programs.

 When this feature is enabled, cuDecomp will capture timing information inside all calls to `cudecompTranspose*` and `cudecompUpdateHalo*`. The timing information captured is the time spent in communication (alltoall, sendrecv) and time spent in local operations (including overheads). The number of samples stored is configurable via `CUDECOMP_PERFORMANCE_REPORT_NSAMPLES` and defaults to 20 samples per transpose/halo configuration. A performance report is printed to the terminal upon grid descriptor destruction. See the updated documentation for more configuration variables.

By default, only an aggregated performance report is printed. Here is an example of what that report looks like:
```
CUDECOMP:
CUDECOMP: ===== Performance Summary =====
CUDECOMP: Grid Configuration:
CUDECOMP:       Transpose backend: MPI_P2P
CUDECOMP:       Halo backend: MPI
CUDECOMP:       Process grid: [2, 2]
CUDECOMP:       Global dimensions: [256, 256, 256]
CUDECOMP:       Memory order: [0,1,2]; [1,2,0]; [2,0,1]
CUDECOMP:
CUDECOMP: Transpose Performance Data:
CUDECOMP:
CUDECOMP: operation    dtype  halo extents    padding         inplace  managed  samples  total     A2A       local     A2A BW   
CUDECOMP:                                                                                [ms]      [ms]      [ms]      [GB/s]   
CUDECOMP: ------------------------------------------------------------------------------------------------------------------------
CUDECOMP: TransposeXY  Z      [0,0,0]/[0,0,0] [0,0,0]/[0,0,0] T        F        5        1.866     1.504     0.361     44.607   
CUDECOMP: TransposeYZ  Z      [0,0,0]/[0,0,0] [0,0,0]/[0,0,0] T        F        5        1.867     1.505     0.361     44.580   
CUDECOMP: TransposeZY  Z      [0,0,0]/[0,0,0] [0,0,0]/[0,0,0] T        F        5        1.876     1.503     0.373     44.646   
CUDECOMP: TransposeYX  Z      [0,0,0]/[0,0,0] [0,0,0]/[0,0,0] T        F        5        1.879     1.507     0.373     44.543   
CUDECOMP: ================================
CUDECOMP:
``` 
This timings and bandwidths reported in this table are averaged across samples and all ranks.

To retrieve more verbose per-sample output, the environment variable `CUDECOMP_PERFORMANCE_REPORT_DETAIL` can be used. Setting this variable to `1` will print per-sample output for rank 0 only, which `2` will print per-sample output for all ranks. For example, running with `CUDECOMP_PERFORMANCE_REPORT_DETAIL=2` will generate output like:
```
CUDECOMP:
CUDECOMP: ===== Performance Summary =====
CUDECOMP: Grid Configuration:
CUDECOMP:       Transpose backend: MPI_P2P
CUDECOMP:       Halo backend: MPI
CUDECOMP:       Process grid: [2, 2]
CUDECOMP:       Global dimensions: [256, 256, 256]
CUDECOMP:       Memory order: [0,1,2]; [1,2,0]; [2,0,1]
CUDECOMP:
CUDECOMP: Transpose Performance Data:
CUDECOMP:
CUDECOMP: operation    dtype  halo extents    padding         inplace  managed  samples  total     A2A       local     A2A BW   
CUDECOMP:                                                                                [ms]      [ms]      [ms]      [GB/s]   
CUDECOMP: ------------------------------------------------------------------------------------------------------------------------
CUDECOMP: TransposeXY  Z      [0,0,0]/[0,0,0] [0,0,0]/[0,0,0] T        F        5        1.867     1.505     0.362     44.594   
CUDECOMP: TransposeYZ  Z      [0,0,0]/[0,0,0] [0,0,0]/[0,0,0] T        F        5        1.874     1.513     0.361     44.359   
CUDECOMP: TransposeZY  Z      [0,0,0]/[0,0,0] [0,0,0]/[0,0,0] T        F        5        1.876     1.504     0.372     44.624   
CUDECOMP: TransposeYX  Z      [0,0,0]/[0,0,0] [0,0,0]/[0,0,0] T        F        5        1.884     1.512     0.372     44.393   
CUDECOMP:
CUDECOMP: Per-Sample Details:
CUDECOMP:
CUDECOMP: TransposeXY (dtype=Z, halo extents=[0,0,0]/[0,0,0], padding=[0,0,0]/[0,0,0], inplace=T, managed=F) samples:
CUDECOMP: rank   sample       total     A2A       local     A2A BW   
CUDECOMP:                     [ms]      [ms]      [ms]      [GB/s]   
CUDECOMP: 0      0            1.867     1.504     0.362     44.613   
CUDECOMP: 0      1            1.865     1.504     0.360     44.613   
CUDECOMP: 0      2            1.865     1.503     0.361     44.643   
CUDECOMP: 0      3            1.872     1.506     0.366     44.552   
CUDECOMP: 0      4            1.870     1.504     0.366     44.613   
CUDECOMP: 1      0            1.869     1.507     0.361     44.522   
CUDECOMP: 1      1            1.866     1.504     0.361     44.613   
CUDECOMP: 1      2            1.865     1.504     0.360     44.613   
CUDECOMP: 1      3            1.865     1.503     0.361     44.643   
CUDECOMP: 1      4            1.865     1.502     0.362     44.673   
CUDECOMP: 2      0            1.868     1.506     0.361     44.552   
CUDECOMP: 2      1            1.865     1.505     0.359     44.582   
CUDECOMP: 2      2            1.866     1.504     0.361     44.613   
CUDECOMP: 2      3            1.869     1.508     0.360     44.492   
CUDECOMP: 2      4            1.867     1.504     0.362     44.613   
CUDECOMP: 3      0            1.870     1.507     0.362     44.522   
CUDECOMP: 3      1            1.867     1.506     0.360     44.552   
CUDECOMP: 3      2            1.865     1.503     0.361     44.643   
CUDECOMP: 3      3            1.865     1.503     0.361     44.643   
CUDECOMP: 3      4            1.866     1.505     0.360     44.582   
CUDECOMP:
CUDECOMP: TransposeYZ (dtype=Z, halo extents=[0,0,0]/[0,0,0], padding=[0,0,0]/[0,0,0], inplace=T, managed=F) samples:
CUDECOMP: rank   sample       total     A2A       local     A2A BW   
CUDECOMP:                     [ms]      [ms]      [ms]      [GB/s]   
CUDECOMP: 0      0            1.869     1.504     0.365     44.613   
CUDECOMP: 0      1            1.864     1.503     0.360     44.643   
CUDECOMP: 0      2            1.864     1.504     0.359     44.613
... (output continues) ...
```

Finally, users can set `CUDECOMP_PERFORMANCE_REPORT_WRITE_DIR` to enable write this data to CSV files. Please refer to the documentation for details on this setting. As an example, a CSV file corresponding to the aggregated transpose performance data looks like:
```
$ cat cudecomp-perf-report-transpose-aggregated-tcomm_1-hcomm_1-pdims_2x2-gdims_256x256x256-memorder_012120201.csv
# Transpose backend: MPI_P2P
# Halo backend: MPI
# Process grid: [2, 2]
# Global dimensions: [256, 256, 256]
# Memory order: [0,1,2]; [1,2,0]; [2,0,1]
#
operation,dtype,input_halo_extents,output_halo_extents,input_padding,output_padding,inplace,managed,samples,total_ms,A2A_ms,local_ms,A2A_BW_GBps
TransposeXY,Z,"[0,0,0]","[0,0,0]","[0,0,0]","[0,0,0]",T,F,5,1.866,1.505,0.361,44.599
TransposeYZ,Z,"[0,0,0]","[0,0,0]","[0,0,0]","[0,0,0]",T,F,5,1.868,1.507,0.361,44.539
TransposeZY,Z,"[0,0,0]","[0,0,0]","[0,0,0]","[0,0,0]",T,F,5,1.877,1.504,0.372,44.607
TransposeYX,Z,"[0,0,0]","[0,0,0]","[0,0,0]","[0,0,0]",T,F,5,1.878,1.507,0.371,44.530
```

Reasonable effort has been made to ensure these timings are accurate, but users are still encouraged to use profiling tools like Nsight Systems if more detailed understanding of performance data is required.