### PR TITLE
Fix undefined NVML_GPU_FABRIC_UUID_LEN usage for builds against older CUDA toolkits.

### DIFF
--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -49,7 +49,11 @@
 #include "internal/graph.h"
 
 namespace cudecomp {
+#if NVML_API_VERSION >= 12 && CUDART_VERSION >= 12040
 typedef std::pair<std::array<unsigned char, NVML_GPU_FABRIC_UUID_LEN>, unsigned int> mnnvl_info;
+#else
+typedef std::pair<std::array<unsigned char, 1>, unsigned int> mnnvl_info;
+#endif
 typedef std::shared_ptr<ncclComm_t> ncclComm;
 }
 


### PR DESCRIPTION
As part of a implementing a basic CI, I found that builds of the most recent cuDecomp release against old CUDA versions are currently broken due to the unguarded use of `NVML_GPU_FABRIC_UUID_LEN`. This PR fixes the issue.