### PR TITLE
Fix C++ std::filesystem linking for older GCC toolchains.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: "NVHPC SDK 25.5, CUDA 12.9"
+          - name: "NVHPC SDK 25.5, CUDA 12.9, Ubuntu 22.04"
             image: "nvcr.io/nvidia/nvhpc:25.5-devel-cuda12.9-ubuntu22.04"
             cmake_options: "-DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1"
-          - name: "NVHPC SDK 25.5, CUDA 12.9, no NVSHMEM"
+          - name: "NVHPC SDK 25.5, CUDA 12.9, Rocky Linux 8"
+            image: "nvcr.io/nvidia/nvhpc:25.5-devel-cuda12.9-rockylinux8"
+            cmake_options: "-DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1"
+          - name: "NVHPC SDK 25.5, CUDA 12.9, Ubuntu 22.04, no NVSHMEM"
             image: "nvcr.io/nvidia/nvhpc:25.5-devel-cuda12.9-ubuntu22.04"
             cmake_options: "-DCUDECOMP_BUILD_EXTRAS=1"
-          - name: "NVHPC SDK 22.11, CUDA 11.8"
+          - name: "NVHPC SDK 22.11, CUDA 11.8, Ubuntu 20.04"
             image: "nvcr.io/nvidia/nvhpc:22.11-devel-cuda11.8-ubuntu20.04"
             cmake_options: "-DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1"
-          - name: "NVHPC SDK 22.11, CUDA 11.8, no NVSHMEM"
+          - name: "NVHPC SDK 22.11, CUDA 11.8, Ubuntu 20.04, no NVSHMEM"
             image: "nvcr.io/nvidia/nvhpc:22.11-devel-cuda11.8-ubuntu20.04"
             cmake_options: "-DCUDECOMP_BUILD_EXTRAS=1"
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,17 @@ if (CRAY_CC_BIN)
   target_link_libraries(cudecomp PRIVATE ${GDRCOPY_LIBRARY})
 endif()
 
+# Test for std::filesystem linking
+try_compile(
+  TEST_STD_FS_RESULT
+  ${CMAKE_BINARY_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_std_fs.cc
+)
+if (NOT TEST_STD_FS_RESULT)
+  message(STATUS "GCC toolchain version does not link std::filesystem symbols by default. Adding explicit -lstdc++fs link.")
+  target_link_libraries(cudecomp PRIVATE -lstdc++fs)
+endif()
+
 if (CUDECOMP_ENABLE_NVTX)
   target_compile_definitions(cudecomp PRIVATE ENABLE_NVTX)
 endif()

--- a/cmake/test_std_fs.cc
+++ b/cmake/test_std_fs.cc
@@ -1,0 +1,5 @@
+#include <filesystem>
+
+int main() {
+  std::filesystem::path path = "/dev/null";
+}


### PR DESCRIPTION
#75 added usage of `std::filesystem` utilities available in C++17. It was brought to my attention that older GCC toolchains (e.g. GCC 8) require an additional explicit link to `-lstdc++fs` when these utilities are used.

This PR adds a compile time check to determine if this explicit link is required and adds it if necessary. This fixes builds on systems with older GCC toolchains (with C++17 support). Additionally I added a CI build test against Rocky Linux 8 which uses GCC 8 to validate this change.  