### PR TITLE
0.5.1 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,8 @@ jobs:
         include:
           - name: "NVHPC SDK 25.5, CUDA 12.9, Ubuntu 22.04"
             image: "nvcr.io/nvidia/nvhpc:25.5-devel-cuda12.9-ubuntu22.04"
-            cmake_options: "-DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1"
-          - name: "NVHPC SDK 25.5, CUDA 12.9, Ubuntu 22.04, no NVSHMEM"
-            image: "nvcr.io/nvidia/nvhpc:25.5-devel-cuda12.9-ubuntu22.04"
-            cmake_options: "-DCUDECOMP_BUILD_EXTRAS=1"
           - name: "NVHPC SDK 22.11, CUDA 11.8, Ubuntu 20.04"
             image: "nvcr.io/nvidia/nvhpc:22.11-devel-cuda11.8-ubuntu20.04"
-            cmake_options: "-DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1"
-          - name: "NVHPC SDK 22.11, CUDA 11.8, Ubuntu 20.04, no NVSHMEM"
-            image: "nvcr.io/nvidia/nvhpc:22.11-devel-cuda11.8-ubuntu20.04"
-            cmake_options: "-DCUDECOMP_BUILD_EXTRAS=1"
     
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -30,10 +22,17 @@ jobs:
     steps:
     - name: "Checkout code"
       uses: actions/checkout@v4
-      
-    - name: "Compile"
+
+    - name: "Build with NVSHMEM"
       run: |
-        mkdir -p build
-        cd build
-        cmake ${{ matrix.cmake_options }} ..
+        mkdir -p build-nvshmem
+        cd build-nvshmem
+        cmake -DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1 ..
+        make -j$(nproc)
+
+    - name: "Build without NVSHMEM"
+      run: |
+        mkdir -p build-no-nvshmem
+        cd build-no-nvshmem
+        cmake -DCUDECOMP_BUILD_EXTRAS=1 ..
         make -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: "NVHPC SDK 25.7, CUDA 12.9, Ubuntu 24.04"
+            image: "nvcr.io/nvidia/nvhpc:25.7-devel-cuda12.9-ubuntu24.04"
           - name: "NVHPC SDK 25.5, CUDA 12.9, Ubuntu 22.04"
             image: "nvcr.io/nvidia/nvhpc:25.5-devel-cuda12.9-ubuntu22.04"
           - name: "NVHPC SDK 22.11, CUDA 11.8, Ubuntu 20.04"
@@ -23,16 +25,16 @@ jobs:
     - name: "Checkout code"
       uses: actions/checkout@v4
 
-    - name: "Build with NVSHMEM"
+    - name: "Full build with NVSHMEM"
       run: |
         mkdir -p build-nvshmem
         cd build-nvshmem
         cmake -DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1 ..
         make -j$(nproc)
 
-    - name: "Build without NVSHMEM"
+    - name: "Library only build without NVSHMEM"
       run: |
         mkdir -p build-no-nvshmem
         cd build-no-nvshmem
-        cmake -DCUDECOMP_BUILD_EXTRAS=1 ..
+        cmake ..
         make -j$(nproc)

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -42,7 +42,7 @@
 
 #define CUDECOMP_MAJOR 0
 #define CUDECOMP_MINOR 5
-#define CUDECOMP_PATCH 0
+#define CUDECOMP_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Preparation for 0.5.1 release. Updating version in headers. Adding NVHPC 25.7 to CI coverage and making the existing build CI a bit more efficient.