### PR TITLE
Add user option for column-major rank assignment.

### DIFF
--- a/docs/env_vars.rst
+++ b/docs/env_vars.rst
@@ -90,3 +90,11 @@ The following CSV files are generated:
 Each CSV file includes grid configuration information as comments at the top, followed by performance data in comma-separated format.
 
 Default setting is unset (no CSV files written). Setting this variable to a directory path will enable CSV file output.
+
+CUDECOMP_USE_COL_MAJOR_RANK_ORDER
+--------------------------------------
+(since v0.6.0)
+
+:code:`CUDECOMP_USE_COL_MAJOR_RANK_ORDER` controls the rank assignment order in the process grid. By default, ranks are assigned in row-major order for consistency with :code:`MPI_Cart_*` routines. When enabled, ranks are assigned in column-major order.
+
+Default setting is off (:code:`0`). Setting this variable to :code:`1` will enable column-major rank assignment.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -33,8 +33,8 @@ cuDecomp can distribute 3D Cartesian domains with dimensions :math:`[X, Y, Z]`, 
 the *global grid*. The global grid is decomposed
 across :math:`N_{\text{GPU}}` processes in a 2D **process grid** with dimensions :math:`P_{\text{row}} \times P_{\text{col}}`. The processes
 are logically grouped by column and row index into :math:`P_{\text{row}}` *row* communicators and :math:`P_{\text{col}}` *column* communicators.
-For consistency with :code:`MPI_Cart_*` routines, the ranks are assigned in a row-major ordering (i.e. row communicators
-are composed of sequential ranks).
+By default, for consistency with :code:`MPI_Cart_*` routines, the ranks are assigned in a row-major ordering (i.e. row communicators
+are composed of sequential ranks). This can be changed to column-major ordering using the :code:`CUDECOMP_USE_COL_MAJOR_RANK_ORDER` environment variable (see :ref:`env-var-section-ref`).
 
 cuDecomp will distribute the global domain data so that each process is assigned a unique *pencil* of data, with three different
 pencil configurations corresponding to different transposed configurations of the global domain. The domain can be

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -125,9 +125,8 @@ struct cudecompHandle {
       ""; // directory to write CSV performance reports, empty means no file writing
 
   // Miscellaneous
-  int32_t device_p2p_ce_count = 0; // number of P2P CEs available
+  int32_t device_p2p_ce_count = 0;       // number of P2P CEs available
   bool use_col_major_rank_order = false; // Flag to control whether to use column-major rank order
-
 };
 
 // Structure with information about row/column communicator
@@ -226,7 +225,8 @@ using comm_count_t = int32_t;
 enum cudecompCommAxis { CUDECOMP_COMM_COL = 0, CUDECOMP_COMM_ROW = 1 };
 
 // Helper function to convert row or column rank to global rank
-static inline int getGlobalRank(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc, cudecompCommAxis axis, int axis_rank) {
+static inline int getGlobalRank(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc,
+                                cudecompCommAxis axis, int axis_rank) {
   if (handle->use_col_major_rank_order) {
     // Column-major rank order
     return (axis == CUDECOMP_COMM_ROW) ? grid_desc->pidx[0] + axis_rank * grid_desc->config.pdims[0]

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -126,6 +126,8 @@ struct cudecompHandle {
 
   // Miscellaneous
   int32_t device_p2p_ce_count = 0; // number of P2P CEs available
+  bool use_col_major_rank_order = false; // Flag to control whether to use column-major rank order
+
 };
 
 // Structure with information about row/column communicator
@@ -224,9 +226,16 @@ using comm_count_t = int32_t;
 enum cudecompCommAxis { CUDECOMP_COMM_COL = 0, CUDECOMP_COMM_ROW = 1 };
 
 // Helper function to convert row or column rank to global rank
-static inline int getGlobalRank(const cudecompGridDesc_t grid_desc, cudecompCommAxis axis, int axis_rank) {
-  return (axis == CUDECOMP_COMM_ROW) ? grid_desc->config.pdims[1] * grid_desc->pidx[0] + axis_rank
-                                     : grid_desc->pidx[1] + axis_rank * grid_desc->config.pdims[1];
+static inline int getGlobalRank(const cudecompHandle_t handle, const cudecompGridDesc_t grid_desc, cudecompCommAxis axis, int axis_rank) {
+  if (handle->use_col_major_rank_order) {
+    // Column-major rank order
+    return (axis == CUDECOMP_COMM_ROW) ? grid_desc->pidx[0] + axis_rank * grid_desc->config.pdims[0]
+                                       : grid_desc->config.pdims[0] * grid_desc->pidx[1] + axis_rank;
+  } else {
+    // Row-major rank order (default)
+    return (axis == CUDECOMP_COMM_ROW) ? grid_desc->config.pdims[1] * grid_desc->pidx[0] + axis_rank
+                                       : grid_desc->pidx[1] + axis_rank * grid_desc->config.pdims[1];
+  }
 }
 
 // Helper function to return maximum pencil size across all processes for a given axis
@@ -320,7 +329,7 @@ static void setCommInfo(cudecompHandle_t& handle, cudecompGridDesc_t& grid_desc,
     // Count occurences of hostname in row/col communicator
     std::map<std::string, int> host_counts;
     for (int i = 0; i < info.nranks; ++i) {
-      int peer_rank_global = getGlobalRank(grid_desc, comm_axis, i);
+      int peer_rank_global = getGlobalRank(handle, grid_desc, comm_axis, i);
       std::string hostname = std::string(handle->hostnames[peer_rank_global].data());
       host_counts[hostname]++;
     }
@@ -338,7 +347,7 @@ static void setCommInfo(cudecompHandle_t& handle, cudecompGridDesc_t& grid_desc,
     // For MNNVL configurations, count occurences of clique in row/col communicator
     std::map<unsigned int, int> clique_counts;
     for (int i = 0; i < info.nranks; ++i) {
-      int peer_rank_global = getGlobalRank(grid_desc, comm_axis, i);
+      int peer_rank_global = getGlobalRank(handle, grid_desc, comm_axis, i);
       unsigned int clique = handle->rank_to_clique[peer_rank_global];
       clique_counts[clique]++;
     }

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -155,8 +155,13 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
   for (auto& pdim1 : pdim1_list) {
     grid_desc->config.pdims[0] = handle->nranks / pdim1;
     grid_desc->config.pdims[1] = pdim1;
-    grid_desc->pidx[0] = handle->rank / grid_desc->config.pdims[1];
-    grid_desc->pidx[1] = handle->rank % grid_desc->config.pdims[1];
+    if (handle->use_col_major_rank_order) {
+      grid_desc->pidx[0] = handle->rank % grid_desc->config.pdims[0];
+      grid_desc->pidx[1] = handle->rank / grid_desc->config.pdims[0];
+    } else {
+      grid_desc->pidx[0] = handle->rank / grid_desc->config.pdims[1];
+      grid_desc->pidx[1] = handle->rank % grid_desc->config.pdims[1];
+    }
 
     cudecompPencilInfo_t pinfo_x0, pinfo_x3;
     cudecompPencilInfo_t pinfo_y0, pinfo_y1, pinfo_y2, pinfo_y3;
@@ -583,8 +588,13 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
   for (auto& pdim1 : pdim1_list) {
     grid_desc->config.pdims[0] = handle->nranks / pdim1;
     grid_desc->config.pdims[1] = pdim1;
-    grid_desc->pidx[0] = handle->rank / grid_desc->config.pdims[1];
-    grid_desc->pidx[1] = handle->rank % grid_desc->config.pdims[1];
+    if (handle->use_col_major_rank_order) {
+      grid_desc->pidx[0] = handle->rank % grid_desc->config.pdims[0];
+      grid_desc->pidx[1] = handle->rank / grid_desc->config.pdims[0];
+    } else {
+      grid_desc->pidx[0] = handle->rank / grid_desc->config.pdims[1];
+      grid_desc->pidx[1] = handle->rank % grid_desc->config.pdims[1];
+    }
 
     cudecompPencilInfo_t pinfo;
     CHECK_CUDECOMP(cudecompGetPencilInfo(handle, grid_desc, &pinfo, options->halo_axis, options->halo_extents,


### PR DESCRIPTION
This PR introduces a new environment variable option, `CUDECOMP_USE_COL_MAJOR_RANK_ORDER`, to enable users to change the default row-major rank assignment over `pdims` to column-major.

This can be useful when users have problems that require process grids like `2 x 8` or `4 x 8` on a system with say, 4 NVLink connected GPUs per node (i.e. a small first dimension that is less than the number of NVLink connected GPUs). With the default row-major rank assignment, ranks are first assigned contiguously over the second dimension. This means that the first dimension, even though it is less than the number of NVLink connected GPUs, will span multiple nodes, resulting in slower internode communication for both the row and column communicators. Instead, if the rank assignment were column-major in this case, the ranks are first assigned across the small first dimension, resulting in a fast column communicator restricted to an NVLink connected group. This new option will enable users to realize this benefit in this type of situation.  