### PR TITLE
Update build CI to trigger on comment. Free up additional runner disk space at start of workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,29 @@
 name: "Build"
 
 on:
-  pull_request:
-    branches: [ main ]
+  issue_comment:
+    types: [created]
 
 jobs:
+  trigger-comment:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Post trigger comment"
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const workflowUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `🚀 Build workflow triggered! [View run](${workflowUrl})`
+          });
+
   build:
+    needs: trigger-comment
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
     strategy:
       matrix:
         include:
@@ -22,8 +40,27 @@ jobs:
       image: ${{ matrix.image }}
     
     steps:
-    - name: "Checkout code"
+    - name: "Free disk space"
+      run: |
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+
+    - name: "Retrieve PR info"
+      uses: actions/github-script@v7
+      id: pr-info
+      with:
+        script: |
+          const pr = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          });
+          core.setOutput('sha', pr.data.head.sha);
+
+    - name: "Checkout PR code"
       uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.pr-info.outputs.sha }}
 
     - name: "Full build with NVSHMEM"
       run: |
@@ -38,3 +75,26 @@ jobs:
         cd build-no-nvshmem
         cmake ..
         make -j$(nproc)
+
+  result-comment:
+    needs: build
+    if: always() && github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Post result comment"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflowUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
+            const success = '${{ needs.build.result }}' === 'success';
+
+            const message = success
+              ? `✅ Build workflow passed! [View run](${workflowUrl})`
+              : `❌ Build workflow failed! [View run](${workflowUrl})`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trigger-comment:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build')
     runs-on: ubuntu-latest
     steps:
     - name: "Post trigger comment"
@@ -23,7 +23,7 @@ jobs:
 
   build:
     needs: trigger-comment
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build')
     strategy:
       matrix:
         include:
@@ -78,7 +78,7 @@ jobs:
 
   result-comment:
     needs: build
-    if: always() && github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
+    if: always() && github.event.issue.pull_request && contains(github.event.comment.body, '/build')
     runs-on: ubuntu-latest
     steps:
       - name: "Post result comment"


### PR DESCRIPTION
This PR updates the build CI with some functionality I implemented for another project. In particular, it limits the build CI testing to trigger on a PR comment rather than run every PR commit. Additionally, it adds an additional workflow step to clear out some of the GitHub runner disk space to reduce out of space related failures. 