### PR TITLE
Update build CI to free runner disk space prior to container pull.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: "Build"
 
 on:
   issue_comment:
-    types: [created]
+    types: [ created ]
 
 jobs:
   trigger-comment:
@@ -36,8 +36,6 @@ jobs:
     
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    container:
-      image: ${{ matrix.image }}
     
     steps:
     - name: "Free disk space"
@@ -64,17 +62,21 @@ jobs:
 
     - name: "Full build with NVSHMEM"
       run: |
-        mkdir -p build-nvshmem
-        cd build-nvshmem
-        cmake -DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1 ..
-        make -j$(nproc)
+        docker run --rm -v $PWD:/workspace -w /workspace ${{ matrix.image }} bash -c '
+          mkdir -p build-nvshmem
+          cd build-nvshmem
+          cmake -DCUDECOMP_ENABLE_NVSHMEM=1 -DCUDECOMP_BUILD_EXTRAS=1 ..
+          make -j$(nproc)
+        '
 
     - name: "Library only build without NVSHMEM"
       run: |
-        mkdir -p build-no-nvshmem
-        cd build-no-nvshmem
-        cmake ..
-        make -j$(nproc)
+        docker run --rm -v $PWD:/workspace -w /workspace ${{ matrix.image }} bash -c '
+          mkdir -p build-no-nvshmem
+          cd build-no-nvshmem
+          cmake ..
+          make -j$(nproc)
+        '
 
   result-comment:
     needs: build


### PR DESCRIPTION
#87 did not quite work as expected, as the job step to free runner disk space ran after the container was pulled (and also erroneously inside the container). This PR replaces the `container` tag usage in the workflow with explicit `docker run` commands to ensure the container pull happens after disk space is freed up.

Annoyingly, the `issue_comment` workflow trigger only works for workflow files committed to `main` (see: https://github.com/orgs/community/discussions/59389), so I merged that PR to test the comment workflow trigger before discovering this other issue. Apologies for the churn.