### PR TITLE
Correctly propagate C++17 standard flags to NVCC compilation with older CMake versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 17)
+
+if (CMAKE_VERSION VERSION_LESS "3.18")
+  # Workaround with older CMake versions to propagate C++17 standard flags
+  set(CMAKE_CUDA_FLAGS "-std=c++17")
+endif()
+
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
A user reported compilation issues for cuDecomp using the most recent NVHPC release (25.9) against CUDA 13.0. The root cause of their issue was a combination of an older GCC (earlier than GCC-10) and older CMake version (earlier than 3.18).

#72 bumped the required C++ standard to 17 to address deprecation warnings from `libcu++` about C++14, which became a true compilation error in the `libcu++` version packaged with CUDA 13. It turns out that CMake versions older than 3.18 do not propagate the C++17 flags (via `CMAKE_CXX_STANDARD=17`)  to `.cu` file compilation, likely because `CMAKE_CUDA_STANDARD` does not support C++17 until CMake 3.18 ([ref](https://cmake.org/cmake/help/latest/prop_tgt/CUDA_STANDARD.html)). This doesn't matter if the GCC compiler is 10 or newer, as C++17 is the default standard applied and works in lieu of CMake providing the C++17 flags to `nvcc`, but breaks when the GCC is older and the default standard is pre-C++17.

To address this, I am manually adding `-std=c++17` to `CMAKE_CUDA_FLAGS` for CMake versions prior to 3.18. While I could make the CMake minimum version 3.18, this would break builds on Ubuntu 20.04 which defaults to CMake 3.16.