### PR TITLE
Fix potential deadlock during NCCL local communicator creation.

### DIFF
--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -655,12 +655,14 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
           setCommInfo(handle, grid_desc, col_comm, CUDECOMP_COMM_COL);
 
           // Create local NCCL communicator if row or column communicator uses it
-          int need_local_nccl_comm = static_cast<int>((grid_desc->row_comm_info.ngroups == 1 && grid_desc->row_comm_info.nranks > 1) ||
-                                                      (grid_desc->col_comm_info.ngroups == 1 && grid_desc->col_comm_info.nranks > 1));
+          int need_local_nccl_comm =
+              static_cast<int>((grid_desc->row_comm_info.ngroups == 1 && grid_desc->row_comm_info.nranks > 1) ||
+                               (grid_desc->col_comm_info.ngroups == 1 && grid_desc->col_comm_info.nranks > 1));
 
           // Local comm can include ranks in other rows/columns, need additional check for those cases.
           CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &need_local_nccl_comm, 1, MPI_INT, MPI_LOR,
-                                  handle->mpi_clique_comm != MPI_COMM_NULL ? handle->mpi_clique_comm : handle->mpi_local_comm));
+                                  handle->mpi_clique_comm != MPI_COMM_NULL ? handle->mpi_clique_comm
+                                                                           : handle->mpi_local_comm));
 
           if (need_local_nccl_comm) {
             handle->nccl_local_comm = ncclCommFromMPIComm(


### PR DESCRIPTION
It was discovered that for grid configurations that distribute intra-node GPUs unevenly across row and column communicators, the library can deadlock when creating a node-local NCCL communicator. The issue is that the decision to create a NCCL local communicator is based on only the row and column communicator a particular rank is in, but the communicator creation involves all ranks on a node. If some but not all ranks on a node determine they need to create a NCCL local communicator, this deadlocks. 

This only impacts cases where a user explicitly sets a processor decomposition that results in an uneven distribution of intra-node GPUs (e.g using a 4x3 process grid on a 4 GPU per node system). For cases that autotune the grid and end up in this situation, the local NCCL communicator is created unconditionally before autotuning and there is no deadlock issue.  

This PR fixes the problem by making the NCCL local communicator decision consistent across nodes.