### PR TITLE
Add CUDECOMP_DISABLE_MNNVL debug option.

### DIFF
--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -211,6 +211,7 @@ static void gatherGlobalMPIInfo(cudecompHandle_t& handle) {
   bool disable_mnnvl = checkEnvVar("CUDECOMP_DISABLE_MNNVL");
 
   if (nvmlHasFabricSupport() && !disable_mnnvl) {
+    handle->rank_to_mnnvl_info.resize(handle->nranks);
 
     // Gather MNNVL information (clusterUuid, cliqueId) by rank
     CHECK_NVML(nvmlDeviceGetGpuFabricInfoV(nvml_dev, &fabricInfo));


### PR DESCRIPTION
There have been several occasions recently where I've needed/desired to test cuDecomp on a multi-node NVLink (MNNVL) equipped system but wanted to disable internode NVLink traffic. While cuDecomp itself does not control whether network traffic is routed over MNNVL, it does make scheduling decisions based on the MNNVL topology if it detects it is present. 

This PR introduces a debug env var `CUDECOMP_DISABLE_MNNVL` which disables this MNNVL topology detection for testing. This env var is not meant for general use and as such, is not documented. 