### PR TITLE
Use native NVSHMEM synchronization APIs in NVSHMEM backends

### DIFF
--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -472,7 +472,9 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
           int dst_rank = dst_ranks[i];
           if (src_rank != self_rank) {
             nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[src_rank], NVSHMEM_CMP_EQ,
-                                                 comm_info.nvshmem_signal_counts[src_rank], stream);
+                                                 comm_info.nvshmem_signal_counts[src_rank], pl_stream);
+            CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], pl_stream));
+            CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[dst_rank], 0));
           }
         }
       }

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -148,7 +148,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     if (nvshmem_ptr(recv_buff, dst_rank_global)) {
 
       if (comm_info.ngroups == 1 && handle->device_p2p_ce_count == 1 &&
-          count % CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ == 0) {
+          count != 0 && count % CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ == 0) {
         // For single group, single P2P CE (e.g. NVSwitch), synchronize NVSHMEM team every
         // CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ transfers This helps reduce CE contention due to accumulation of
         // jitter.
@@ -472,9 +472,7 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
           int dst_rank = dst_ranks[i];
           if (src_rank != self_rank) {
             nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[src_rank], NVSHMEM_CMP_EQ,
-                                                 comm_info.nvshmem_signal_counts[src_rank], pl_stream);
-            CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], pl_stream));
-            CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[dst_rank], 0));
+                                                 comm_info.nvshmem_signal_counts[src_rank], stream);
           }
         }
       }

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -146,8 +146,8 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     int dst_rank_global = getGlobalRank(handle, grid_desc, comm_axis, dst_rank);
     if (nvshmem_ptr(recv_buff, dst_rank_global)) {
 
-      if (comm_info.ngroups == 1 && handle->device_p2p_ce_count == 1 &&
-          count != 0 && count % CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ == 0) {
+      if (comm_info.ngroups == 1 && handle->device_p2p_ce_count == 1 && count != 0 &&
+          count % CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ == 0) {
         // For single group, single P2P CE (e.g. NVSwitch), synchronize NVSHMEM team every
         // CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ transfers This helps reduce CE contention due to accumulation of
         // jitter.
@@ -394,8 +394,7 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
   case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL: {
 #ifdef ENABLE_NVSHMEM
     if (nvshmem_ptr(send_buff, handle->rank) && nvshmem_ptr(recv_buff, handle->rank)) {
-      auto& comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info
-                                                         : grid_desc->col_comm_info;
+      auto& comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info : grid_desc->col_comm_info;
       auto pl_stream = handle->streams[0];
       auto aux_stream = handle->streams[handle->device_p2p_ce_count];
       int self_rank = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.rank : grid_desc->col_comm_info.rank;
@@ -421,11 +420,11 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
           CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank], 0));
 
           comm_info.nvshmem_signal_counts[src_rank]++;
-          nvshmemx_putmem_signal_nbi_on_stream(
-              recv_buff + recv_offsets_nvshmem[dst_rank], send_buff + send_offsets[dst_rank],
-              send_counts[dst_rank] * sizeof(T),
-              &comm_info.nvshmem_signals[comm_info.rank], comm_info.nvshmem_signal_counts[src_rank], NVSHMEM_SIGNAL_SET,
-              dst_rank_global, pl_stream);
+          nvshmemx_putmem_signal_nbi_on_stream(recv_buff + recv_offsets_nvshmem[dst_rank],
+                                               send_buff + send_offsets[dst_rank], send_counts[dst_rank] * sizeof(T),
+                                               &comm_info.nvshmem_signals[comm_info.rank],
+                                               comm_info.nvshmem_signal_counts[src_rank], NVSHMEM_SIGNAL_SET,
+                                               dst_rank_global, pl_stream);
 
           need_quiet = true;
         }
@@ -442,12 +441,10 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
         CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank], 0));
 
         comm_info.nvshmem_signal_counts[src_rank]++;
-        nvshmemx_putmem_signal_on_stream(
-            recv_buff + recv_offsets_nvshmem[dst_rank], send_buff + send_offsets[dst_rank],
-            send_counts[dst_rank] * sizeof(T),
-            &comm_info.nvshmem_signals[comm_info.rank], comm_info.nvshmem_signal_counts[src_rank], NVSHMEM_SIGNAL_SET,
-            dst_rank_global, pl_stream);
-
+        nvshmemx_putmem_signal_on_stream(recv_buff + recv_offsets_nvshmem[dst_rank], send_buff + send_offsets[dst_rank],
+                                         send_counts[dst_rank] * sizeof(T), &comm_info.nvshmem_signals[comm_info.rank],
+                                         comm_info.nvshmem_signal_counts[src_rank], NVSHMEM_SIGNAL_SET, dst_rank_global,
+                                         pl_stream);
       }
 
       if (need_quiet) { nvshmemx_quiet_on_stream(pl_stream); }

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -419,11 +419,10 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
 
           CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank], 0));
 
-          comm_info.nvshmem_signal_counts[src_rank]++;
           nvshmemx_putmem_signal_nbi_on_stream(recv_buff + recv_offsets_nvshmem[dst_rank],
                                                send_buff + send_offsets[dst_rank], send_counts[dst_rank] * sizeof(T),
                                                &comm_info.nvshmem_signals[comm_info.rank],
-                                               comm_info.nvshmem_signal_counts[src_rank], NVSHMEM_SIGNAL_SET,
+                                               1, NVSHMEM_SIGNAL_SET,
                                                dst_rank_global, pl_stream);
 
           need_quiet = true;
@@ -440,10 +439,9 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
 
         CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank], 0));
 
-        comm_info.nvshmem_signal_counts[src_rank]++;
         nvshmemx_putmem_signal_on_stream(recv_buff + recv_offsets_nvshmem[dst_rank], send_buff + send_offsets[dst_rank],
                                          send_counts[dst_rank] * sizeof(T), &comm_info.nvshmem_signals[comm_info.rank],
-                                         comm_info.nvshmem_signal_counts[src_rank], NVSHMEM_SIGNAL_SET, dst_rank_global,
+                                         1, NVSHMEM_SIGNAL_SET, dst_rank_global,
                                          pl_stream);
       }
 
@@ -453,7 +451,7 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
         int dst_rank = dst_ranks[i];
         if (src_rank != self_rank) {
           nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[src_rank], NVSHMEM_CMP_EQ,
-                                               comm_info.nvshmem_signal_counts[src_rank], pl_stream);
+                                               1, pl_stream);
           CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], pl_stream));
           CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[dst_rank], 0));
         }

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -112,7 +112,6 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   cudecompNvshmemA2AParams<T> params;
 
   // Inter-group transfers (non-blocking)
-  bool need_quiet = false;
   params.send_buff = send_buff;
   params.recv_buff = recv_buff;
   int count = 0;
@@ -132,13 +131,11 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
       params.ntransfers = count;
       cudecomp_nvshmem_alltoallv(params, stream);
       count = 0;
-      need_quiet = true;
     }
   }
   if (count != 0) {
     params.ntransfers = count;
     cudecomp_nvshmem_alltoallv(params, stream);
-    need_quiet = true;
   }
 
   // Intra-group transfers (blocking, scheduled after non-blocking inter-group transfers for concurrency)
@@ -184,8 +181,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[0], 0));
   }
 
-  if (need_quiet) { nvshmemx_quiet_on_stream(stream); }
-  nvshmemx_team_sync_on_stream(team, stream);
+  nvshmemx_barrier_on_stream(team, stream);
 }
 #endif
 
@@ -407,7 +403,6 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
       // Enforce sync dependency between transpose operations
       CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->nvshmem_sync_event));
 
-      bool barrier = false;
       bool need_quiet = false;
 
       // Inter-group transfers and self-copy (non-blocking)
@@ -432,7 +427,6 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
               &comm_info.nvshmem_signals[comm_info.rank], comm_info.nvshmem_signal_counts[src_rank], NVSHMEM_SIGNAL_SET,
               dst_rank_global, pl_stream);
 
-          barrier = true;
           need_quiet = true;
         }
       }
@@ -454,20 +448,17 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
             &comm_info.nvshmem_signals[comm_info.rank], comm_info.nvshmem_signal_counts[src_rank], NVSHMEM_SIGNAL_SET,
             dst_rank_global, pl_stream);
 
-        barrier = true;
       }
 
-      if (barrier) {
-        if (need_quiet) { nvshmemx_quiet_on_stream(pl_stream); }
-        for (int i = 0; i < src_ranks.size(); ++i) {
-          int src_rank = src_ranks[i];
-          int dst_rank = dst_ranks[i];
-          if (src_rank != self_rank) {
-            nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[src_rank], NVSHMEM_CMP_EQ,
-                                                 comm_info.nvshmem_signal_counts[src_rank], pl_stream);
-            CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], pl_stream));
-            CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[dst_rank], 0));
-          }
+      if (need_quiet) { nvshmemx_quiet_on_stream(pl_stream); }
+      for (int i = 0; i < src_ranks.size(); ++i) {
+        int src_rank = src_ranks[i];
+        int dst_rank = dst_ranks[i];
+        if (src_rank != self_rank) {
+          nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[src_rank], NVSHMEM_CMP_EQ,
+                                               comm_info.nvshmem_signal_counts[src_rank], pl_stream);
+          CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], pl_stream));
+          CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[dst_rank], 0));
         }
       }
       break;

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -98,14 +98,10 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   auto& comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info : grid_desc->col_comm_info;
   auto team = comm_info.nvshmem_team;
   int self_rank = comm_info.rank;
-
   auto aux_stream = handle->streams[handle->device_p2p_ce_count];
 
-  // Sync between transpose operations
-  CHECK_CUDA(cudaStreamWaitEvent(aux_stream, grid_desc->nvshmem_sync_event));
-  nvshmemx_team_sync_on_stream(team, aux_stream);
-  CHECK_CUDA(cudaEventRecord(grid_desc->events[0], aux_stream));
-  CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[0]));
+  // Enforce sync dependency between transpose operations
+  CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->nvshmem_sync_event));
 
   // Event dependency on external stream for intra-group transfers
   CHECK_CUDA(cudaEventRecord(grid_desc->events[0], stream));
@@ -365,7 +361,7 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
                           const std::vector<comm_count_t>& recv_offsets,
                           const std::vector<comm_count_t>& recv_offsets_nvshmem, cudecompCommAxis comm_axis,
                           const std::vector<int>& src_ranks, const std::vector<int>& dst_ranks, cudaStream_t stream,
-                          bool& synced, cudecompTransposePerformanceSample* current_sample = nullptr) {
+                          cudecompTransposePerformanceSample* current_sample = nullptr) {
 
   // If there are no transfers to complete, quick return
   if (send_counts.size() == 0 && recv_counts.size() == 0) { return; }
@@ -402,13 +398,14 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
   case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL: {
 #ifdef ENABLE_NVSHMEM
     if (nvshmem_ptr(send_buff, handle->rank) && nvshmem_ptr(recv_buff, handle->rank)) {
-      auto team = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.nvshmem_team
-                                                   : grid_desc->col_comm_info.nvshmem_team;
       auto& comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info
                                                          : grid_desc->col_comm_info;
       auto pl_stream = handle->streams[0];
       auto aux_stream = handle->streams[handle->device_p2p_ce_count];
       int self_rank = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info.rank : grid_desc->col_comm_info.rank;
+
+      // Enforce sync dependency between transpose operations
+      CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->nvshmem_sync_event));
 
       bool barrier = false;
       bool need_quiet = false;
@@ -427,16 +424,6 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
           if (nvshmem_ptr(recv_buff, dst_rank_global)) { continue; }
 
           CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank], 0));
-          if (!synced) {
-            // Sync between transpose operations
-            CHECK_CUDA(cudaStreamWaitEvent(aux_stream, grid_desc->nvshmem_sync_event));
-            nvshmemx_team_sync_on_stream(team, aux_stream);
-            CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], aux_stream));
-            CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank]));
-            // Only need to sync on the first remote operation of an alltoall sequence to ensure reads on other ranks
-            // from previous communication have completed.
-            synced = true;
-          }
 
           comm_info.nvshmem_signal_counts[src_rank]++;
           nvshmemx_putmem_signal_nbi_on_stream(
@@ -459,16 +446,6 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
         if (!nvshmem_ptr(recv_buff, dst_rank_global) || src_rank == self_rank) { continue; }
 
         CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank], 0));
-        if (!synced) {
-          // Sync between transpose operations
-          CHECK_CUDA(cudaStreamWaitEvent(aux_stream, grid_desc->nvshmem_sync_event));
-          nvshmemx_team_sync_on_stream(team, aux_stream);
-          CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], aux_stream));
-          CHECK_CUDA(cudaStreamWaitEvent(pl_stream, grid_desc->events[dst_rank]));
-          // Only need to sync on the first remote operation of an alltoall sequence to ensure reads on other ranks
-          // from previous communication have completed.
-          synced = true;
-        }
 
         comm_info.nvshmem_signal_counts[src_rank]++;
         nvshmemx_putmem_signal_on_stream(

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -421,8 +421,7 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
 
           nvshmemx_putmem_signal_nbi_on_stream(recv_buff + recv_offsets_nvshmem[dst_rank],
                                                send_buff + send_offsets[dst_rank], send_counts[dst_rank] * sizeof(T),
-                                               &comm_info.nvshmem_signals[comm_info.rank],
-                                               1, NVSHMEM_SIGNAL_SET,
+                                               &comm_info.nvshmem_signals[comm_info.rank], 1, NVSHMEM_SIGNAL_SET,
                                                dst_rank_global, pl_stream);
 
           need_quiet = true;
@@ -441,8 +440,7 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
 
         nvshmemx_putmem_signal_on_stream(recv_buff + recv_offsets_nvshmem[dst_rank], send_buff + send_offsets[dst_rank],
                                          send_counts[dst_rank] * sizeof(T), &comm_info.nvshmem_signals[comm_info.rank],
-                                         1, NVSHMEM_SIGNAL_SET, dst_rank_global,
-                                         pl_stream);
+                                         1, NVSHMEM_SIGNAL_SET, dst_rank_global, pl_stream);
       }
 
       if (need_quiet) { nvshmemx_quiet_on_stream(pl_stream); }
@@ -450,8 +448,7 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
         int src_rank = src_ranks[i];
         int dst_rank = dst_ranks[i];
         if (src_rank != self_rank) {
-          nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[src_rank], NVSHMEM_CMP_EQ,
-                                               1, pl_stream);
+          nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[src_rank], NVSHMEM_CMP_EQ, 1, pl_stream);
           CHECK_CUDA(cudaEventRecord(grid_desc->events[dst_rank], pl_stream));
           CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[dst_rank], 0));
         }

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -127,6 +127,8 @@ struct cudecompCommInfo {
 
 #ifdef ENABLE_NVSHMEM
   nvshmem_team_t nvshmem_team = NVSHMEM_TEAM_INVALID;
+  uint64_t* nvshmem_signals = nullptr;
+  std::vector<uint64_t> nvshmem_signal_counts;
 #endif
 };
 

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -128,7 +128,6 @@ struct cudecompCommInfo {
 #ifdef ENABLE_NVSHMEM
   nvshmem_team_t nvshmem_team = NVSHMEM_TEAM_INVALID;
   uint64_t* nvshmem_signals = nullptr;
-  std::vector<uint64_t> nvshmem_signal_counts;
 #endif
 };
 

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -248,6 +248,9 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       auto aux_stream = handle->streams[handle->device_p2p_ce_count];
       CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, stream));
       CHECK_CUDA(cudaStreamWaitEvent(aux_stream, grid_desc->nvshmem_sync_event));
+      // Zero out signal buffer for this team here.
+      CHECK_CUDA(
+          cudaMemsetAsync(comm_info.nvshmem_signals, 0, comm_info.nranks * sizeof(uint64_t), aux_stream));
       nvshmemx_team_sync_on_stream(team, aux_stream);
       CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, aux_stream));
       // Delay final stream wait dependency to alltoall to ensure sync runs concurrently with initial transpose/pack

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -236,6 +236,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   T* o2 = work + pinfo_a.size;
   T* o3 = output;
 
+#ifdef ENABLE_NVSHMEM
   if (transposeBackendRequiresNvshmem(grid_desc->config.transpose_comm_backend)) {
     auto max_pencil_size_a = getGlobalMaxPencilSize(handle, grid_desc, ax_a);
     o2 = work + max_pencil_size_a;
@@ -252,6 +253,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       // Delay final stream wait dependency to alltoall to ensure sync runs concurrently with initial transpose/pack
     }
   }
+#endif
 
   cudecompTransposePerformanceSample* current_sample = nullptr;
   if (handle->performance_report_enable) {

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -239,8 +239,18 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
   if (transposeBackendRequiresNvshmem(grid_desc->config.transpose_comm_backend)) {
     auto max_pencil_size_a = getGlobalMaxPencilSize(handle, grid_desc, ax_a);
     o2 = work + max_pencil_size_a;
-    // Record event at start of transpose op for NVSHMEM team synchronization
-    CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, stream));
+
+    // NVSHMEM team synchronization between transpose operations
+    if (splits_a.size() != 1) {
+      auto& comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info : grid_desc->col_comm_info;
+      auto team = comm_info.nvshmem_team;
+      auto aux_stream = handle->streams[handle->device_p2p_ce_count];
+      CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, stream));
+      CHECK_CUDA(cudaStreamWaitEvent(aux_stream, grid_desc->nvshmem_sync_event));
+      nvshmemx_team_sync_on_stream(team, aux_stream);
+      CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, aux_stream));
+      // Delay final stream wait dependency to alltoall to ensure sync runs concurrently with initial transpose/pack
+    }
   }
 
   cudecompTransposePerformanceSample* current_sample = nullptr;
@@ -604,7 +614,6 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       }
 
       if (pipelined) {
-        bool nvshmem_synced = false;
         for (int j = 0; j < splits_b.size(); ++j) {
           int src_rank, dst_rank;
           getAlltoallPeerRanks(grid_desc, comm_axis, j, src_rank, dst_rank);
@@ -634,7 +643,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
           if (o2 != o1) {
             cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced,
+                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream,
                                       current_sample);
           }
 
@@ -699,7 +708,6 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
         if (i > 0) { strides_out[i] = strides_out[i - 1] * extents_h[i - 1]; }
       }
 
-      bool nvshmem_synced = false;
       for (int j = 0; j < splits_b.size(); ++j) {
         int src_rank, dst_rank;
         getAlltoallPeerRanks(grid_desc, comm_axis, j, src_rank, dst_rank);
@@ -730,7 +738,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
           if (o2 != o1) {
             cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced,
+                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream,
                                       current_sample);
           }
         }
@@ -755,7 +763,6 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
     }
   } else {
     // Unpack
-    bool nvshmem_synced = false;
     int memcpy_count = 0;
     cudecompBatchedD2DMemcpy3DParams<T> memcpy_params;
     for (int j = 0; j < splits_a.size(); ++j) {
@@ -788,7 +795,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
         if (o2 != o1) {
           cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                    recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, nvshmem_synced,
+                                    recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream,
                                     current_sample);
         }
       }

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -643,8 +643,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
           if (o2 != o1) {
             cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream,
-                                      current_sample);
+                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, current_sample);
           }
 
           if (o2 != o3) {
@@ -738,8 +737,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
           if (o2 != o1) {
             cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream,
-                                      current_sample);
+                                      recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, current_sample);
           }
         }
 
@@ -795,8 +793,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
 
         if (o2 != o1) {
           cudecompAlltoallPipelined(handle, grid_desc, o1, send_counts, send_offsets, o2, recv_counts, recv_offsets,
-                                    recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream,
-                                    current_sample);
+                                    recv_offsets_nvshmem, comm_axis, src_ranks, dst_ranks, stream, current_sample);
         }
       }
 

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -249,8 +249,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
       CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, stream));
       CHECK_CUDA(cudaStreamWaitEvent(aux_stream, grid_desc->nvshmem_sync_event));
       // Zero out signal buffer for this team here.
-      CHECK_CUDA(
-          cudaMemsetAsync(comm_info.nvshmem_signals, 0, comm_info.nranks * sizeof(uint64_t), aux_stream));
+      CHECK_CUDA(cudaMemsetAsync(comm_info.nvshmem_signals, 0, comm_info.nranks * sizeof(uint64_t), aux_stream));
       nvshmemx_team_sync_on_stream(team, aux_stream);
       CHECK_CUDA(cudaEventRecord(grid_desc->nvshmem_sync_event, aux_stream));
       // Delay final stream wait dependency to alltoall to ensure sync runs concurrently with initial transpose/pack

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -275,6 +275,12 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       nvshmem_team_config_t tmp;
       nvshmem_team_split_2d(NVSHMEM_TEAM_WORLD, grid_desc->config.pdims[1], &tmp, 0,
                             &grid_desc->row_comm_info.nvshmem_team, &tmp, 0, &grid_desc->col_comm_info.nvshmem_team);
+      grid_desc->row_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
+      grid_desc->col_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
 #endif
     }
 
@@ -451,6 +457,10 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
 #ifdef ENABLE_NVSHMEM
       nvshmem_team_destroy(grid_desc->row_comm_info.nvshmem_team);
       nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
+      nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
+      nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
+      grid_desc->row_comm_info.nvshmem_signal_counts.clear();
+      grid_desc->col_comm_info.nvshmem_signal_counts.clear();
       grid_desc->row_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
       grid_desc->col_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
 #endif
@@ -691,6 +701,12 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       nvshmem_team_config_t tmp;
       nvshmem_team_split_2d(NVSHMEM_TEAM_WORLD, grid_desc->config.pdims[1], &tmp, 0,
                             &grid_desc->row_comm_info.nvshmem_team, &tmp, 0, &grid_desc->col_comm_info.nvshmem_team);
+      grid_desc->row_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
+      grid_desc->col_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
 #endif
     }
 
@@ -804,6 +820,10 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
 #ifdef ENABLE_NVSHMEM
       nvshmem_team_destroy(grid_desc->row_comm_info.nvshmem_team);
       nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
+      nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
+      nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
+      grid_desc->row_comm_info.nvshmem_signal_counts.clear();
+      grid_desc->col_comm_info.nvshmem_signal_counts.clear();
       grid_desc->row_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
       grid_desc->col_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
 #endif

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -275,11 +275,15 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       nvshmem_team_config_t tmp;
       nvshmem_team_split_2d(NVSHMEM_TEAM_WORLD, grid_desc->config.pdims[1], &tmp, 0,
                             &grid_desc->row_comm_info.nvshmem_team, &tmp, 0, &grid_desc->col_comm_info.nvshmem_team);
-      grid_desc->row_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
-      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->row_comm_info.nvshmem_signals =
+          (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(
+          cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
       grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
-      grid_desc->col_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
-      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->col_comm_info.nvshmem_signals =
+          (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(
+          cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
       grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
 #endif
     }
@@ -701,11 +705,15 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       nvshmem_team_config_t tmp;
       nvshmem_team_split_2d(NVSHMEM_TEAM_WORLD, grid_desc->config.pdims[1], &tmp, 0,
                             &grid_desc->row_comm_info.nvshmem_team, &tmp, 0, &grid_desc->col_comm_info.nvshmem_team);
-      grid_desc->row_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
-      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->row_comm_info.nvshmem_signals =
+          (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(
+          cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
       grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
-      grid_desc->col_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
-      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->col_comm_info.nvshmem_signals =
+          (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(
+          cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
       grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
 #endif
     }

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -279,12 +279,10 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
-      grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
-      grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
 #endif
     }
 
@@ -463,8 +461,6 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
       nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
       nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
-      grid_desc->row_comm_info.nvshmem_signal_counts.clear();
-      grid_desc->col_comm_info.nvshmem_signal_counts.clear();
       grid_desc->row_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
       grid_desc->col_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
 #endif
@@ -709,12 +705,10 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
-      grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
-      grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
 #endif
     }
 
@@ -830,8 +824,6 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
       nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
       nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
-      grid_desc->row_comm_info.nvshmem_signal_counts.clear();
-      grid_desc->col_comm_info.nvshmem_signal_counts.clear();
       grid_desc->row_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
       grid_desc->col_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
 #endif

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -764,6 +764,12 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
       nvshmem_team_config_t tmp;
       nvshmem_team_split_2d(NVSHMEM_TEAM_WORLD, grid_desc->config.pdims[1], &tmp, 0,
                             &grid_desc->row_comm_info.nvshmem_team, &tmp, 0, &grid_desc->col_comm_info.nvshmem_team);
+      grid_desc->row_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
+      grid_desc->col_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
       handle->n_grid_descs_using_nvshmem++;
     } else {
       // Finalize nvshmem to reclaim symmetric heap memory if not used
@@ -891,9 +897,13 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
         haloBackendRequiresNvshmem(grid_desc->config.halo_comm_backend)) {
       if (grid_desc->row_comm_info.nvshmem_team != NVSHMEM_TEAM_INVALID) {
         nvshmem_team_destroy(grid_desc->row_comm_info.nvshmem_team);
+        nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
+        grid_desc->row_comm_info.nvshmem_signal_counts.clear();
       }
       if (grid_desc->col_comm_info.nvshmem_team != NVSHMEM_TEAM_INVALID) {
         nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
+        nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
+        grid_desc->col_comm_info.nvshmem_signal_counts.clear();
       }
       handle->n_grid_descs_using_nvshmem--;
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -768,12 +768,10 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
-      grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
-      grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
       handle->n_grid_descs_using_nvshmem++;
     } else {
       // Finalize nvshmem to reclaim symmetric heap memory if not used
@@ -902,12 +900,10 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
       if (grid_desc->row_comm_info.nvshmem_team != NVSHMEM_TEAM_INVALID) {
         nvshmem_team_destroy(grid_desc->row_comm_info.nvshmem_team);
         nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
-        grid_desc->row_comm_info.nvshmem_signal_counts.clear();
       }
       if (grid_desc->col_comm_info.nvshmem_team != NVSHMEM_TEAM_INVALID) {
         nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
         nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
-        grid_desc->col_comm_info.nvshmem_signal_counts.clear();
       }
       handle->n_grid_descs_using_nvshmem--;
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -764,11 +764,15 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
       nvshmem_team_config_t tmp;
       nvshmem_team_split_2d(NVSHMEM_TEAM_WORLD, grid_desc->config.pdims[1], &tmp, 0,
                             &grid_desc->row_comm_info.nvshmem_team, &tmp, 0, &grid_desc->col_comm_info.nvshmem_team);
-      grid_desc->row_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
-      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->row_comm_info.nvshmem_signals =
+          (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(
+          cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
       grid_desc->row_comm_info.nvshmem_signal_counts.resize(grid_desc->row_comm_info.nranks);
-      grid_desc->col_comm_info.nvshmem_signals = (uint64_t*) nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
-      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      grid_desc->col_comm_info.nvshmem_signals =
+          (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
+      CHECK_CUDA(
+          cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
       grid_desc->col_comm_info.nvshmem_signal_counts.resize(grid_desc->col_comm_info.nranks);
       handle->n_grid_descs_using_nvshmem++;
     } else {


### PR DESCRIPTION
This PR replaces the current use of CPU-based MPI synchronization primitives in the NVSHMEM backends with NVSHMEM native APIs. This has been found to improve performance in many cases, as well as make the NVSHMEM backends CPU-synchronization free.

In particular, the non-pipelined NVSHMEM backend replaces the existing CPU synchronization pattern (quiet -> stream synchronize -> MPI_Barrier) with a call to `nvshmemx_barrier_on_stream`. For the pipelined NVSHMEM backend, the existing barrier synchronization is re-implemented using signal-based APIs, enabling more targeted synchronization between GPU pairs involved in each stage.