### PR TITLE
Add new NVSHMEM transpose communication backend with SM-based P2P copies.

### DIFF
--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -48,7 +48,7 @@ typedef enum {
   CUDECOMP_TRANSPOSE_COMM_NCCL = 4,       ///< NCCL backend
   CUDECOMP_TRANSPOSE_COMM_NCCL_PL = 5,    ///< NCCL backend with pipelining
   CUDECOMP_TRANSPOSE_COMM_NVSHMEM = 6,    ///< NVSHMEM backend
-  CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL = 7,  ///< NVSHMEM backend with pipelining
+  CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL = 7, ///< NVSHMEM backend with pipelining
   CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM = 8  ///< NVSHMEM backend using SM-based P2P transfers
 } cudecompTransposeCommBackend_t;
 

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -48,7 +48,8 @@ typedef enum {
   CUDECOMP_TRANSPOSE_COMM_NCCL = 4,       ///< NCCL backend
   CUDECOMP_TRANSPOSE_COMM_NCCL_PL = 5,    ///< NCCL backend with pipelining
   CUDECOMP_TRANSPOSE_COMM_NVSHMEM = 6,    ///< NVSHMEM backend
-  CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL = 7  ///< NVSHMEM backend with pipelining
+  CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL = 7,  ///< NVSHMEM backend with pipelining
+  CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM = 8  ///< NVSHMEM backend using SM-based P2P transfers
 } cudecompTransposeCommBackend_t;
 
 /**

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -141,7 +141,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 
   // Intra-group transfers (blocking, scheduled after non-blocking inter-group transfers for concurrency)
   count = 0;
-  for (int i = 1; i < send_counts.size(); ++i) {
+  for (int i = (use_sm ? 0 : 1); i < send_counts.size(); ++i) {
     int src_rank, dst_rank;
     getAlltoallPeerRanks(grid_desc, comm_axis, i, src_rank, dst_rank);
     int dst_rank_global = getGlobalRank(handle, grid_desc, comm_axis, dst_rank);
@@ -171,30 +171,40 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
                                   handle->streams[count % handle->device_p2p_ce_count]);
         count++;
       } else {
-        params.send_offsets[count] = send_offsets[dst_rank];
-        params.recv_offsets[count] = recv_offsets[dst_rank];
-        params.send_counts[count] = send_counts[dst_rank];
-        params.peer_ranks[count] = dst_rank_global;
-        count++;
+        if (dst_rank == self_rank) {
+          // Record self-copy entries in params but do not add to remote transfer count.
+          params.has_self = true;
+          params.self_send_offset = send_offsets[self_rank];
+          params.self_recv_offset = recv_offsets[self_rank];
+          params.self_count = send_counts[self_rank];
+        } else {
+          params.send_offsets[count] = send_offsets[dst_rank];
+          params.recv_offsets[count] = recv_offsets[dst_rank];
+          params.send_counts[count] = send_counts[dst_rank];
+          params.peer_ranks[count] = dst_rank_global;
+          count++;
+        }
 
         if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
           params.ntransfers = count;
           cudecomp_nvshmem_alltoallv_p2p(params, handle->streams[0]);
+          params.has_self = false;
           count = 0;
         }
       }
     }
   }
 
-  if (use_sm && count != 0) {
-    params.ntransfers = count;
-    cudecomp_nvshmem_alltoallv_p2p(params, handle->streams[0]);
+  if (use_sm) {
+    if (count != 0 || params.has_self) {
+      params.ntransfers = count;
+      cudecomp_nvshmem_alltoallv_p2p(params, handle->streams[0]);
+    }
+  } else {
+    // Self-copy with cudaMemcpy
+    CHECK_CUDA(cudaMemcpyAsync(recv_buff + recv_offsets[self_rank], send_buff + send_offsets[self_rank],
+                               send_counts[self_rank] * sizeof(T), cudaMemcpyDeviceToDevice, stream));
   }
-
-  // Self-copy with cudaMemcpy
-  auto self_stream = use_sm ? handle->streams[0] : stream;
-  CHECK_CUDA(cudaMemcpyAsync(recv_buff + recv_offsets[self_rank], send_buff + send_offsets[self_rank],
-                             send_counts[self_rank] * sizeof(T), cudaMemcpyDeviceToDevice, self_stream));
 
   // Event dependency on internal streams for completion of intra-group transfers
   for (int i = 0; i < handle->device_p2p_ce_count; ++i) {

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -115,7 +115,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   bool need_barrier = false;
   bool need_quiet = false;
   cudecompNvshmemA2AParams<T> params;
-  params.block_counters = comm_info.nvshmem_block_counters;
+  params.block_counters = grid_desc->nvshmem_block_counters;
 
   // Inter-group transfers (non-blocking)
   params.send_buff = send_buff;

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -90,12 +90,12 @@ static inline void checkMpiInt32Limit(int64_t val, cudecompHaloCommBackend_t bac
 #ifdef ENABLE_NVSHMEM
 #define CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ 8 // max number of intra-group transfers to schedule between team syncs
 template <typename T>
-static void
-nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_desc, T* send_buff,
-                 const std::vector<comm_count_t>& send_counts, const std::vector<comm_count_t>& send_offsets,
-                 T* recv_buff, const std::vector<comm_count_t>& recv_counts,
-                 const std::vector<comm_count_t>& recv_offsets, cudecompCommAxis comm_axis, bool use_sm,
-                 cudaStream_t stream) {
+static void nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_desc, T* send_buff,
+                             const std::vector<comm_count_t>& send_counts,
+                             const std::vector<comm_count_t>& send_offsets, T* recv_buff,
+                             const std::vector<comm_count_t>& recv_counts,
+                             const std::vector<comm_count_t>& recv_offsets, cudecompCommAxis comm_axis, bool use_sm,
+                             cudaStream_t stream) {
   auto& comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info : grid_desc->col_comm_info;
   auto team = comm_info.nvshmem_team;
   int self_rank = comm_info.rank;
@@ -221,9 +221,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     }
   }
 
-  if (need_barrier) {
-    nvshmemx_barrier_on_stream(team, stream);
-  }
+  if (need_barrier) { nvshmemx_barrier_on_stream(team, stream); }
 }
 #endif
 
@@ -260,7 +258,8 @@ static void cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridD
 #ifdef ENABLE_NVSHMEM
     if (nvshmem_ptr(send_buff, handle->rank) && nvshmem_ptr(recv_buff, handle->rank)) {
       nvshmemAlltoallV(handle, grid_desc, send_buff, send_counts, send_offsets, recv_buff, recv_counts,
-                       recv_offsets_nvshmem, comm_axis, grid_desc->config.transpose_comm_backend == CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM, stream);
+                       recv_offsets_nvshmem, comm_axis,
+                       grid_desc->config.transpose_comm_backend == CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM, stream);
       break;
     } else {
       THROW_INVALID_USAGE("NVSHMEM communication backends require workspace allocated via cudecompMalloc.");

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -192,8 +192,9 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   }
 
   // Self-copy with cudaMemcpy
+  auto self_stream = use_sm ? handle->streams[0] : stream;
   CHECK_CUDA(cudaMemcpyAsync(recv_buff + recv_offsets[self_rank], send_buff + send_offsets[self_rank],
-                             send_counts[self_rank] * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+                             send_counts[self_rank] * sizeof(T), cudaMemcpyDeviceToDevice, self_stream));
 
   // Event dependency on internal streams for completion of intra-group transfers
   for (int i = 0; i < handle->device_p2p_ce_count; ++i) {

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -138,13 +138,13 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 
     if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
       params.ntransfers = count;
-      cudecomp_nvshmem_alltoallv(params, &comm_info.nvshmem_signals[0], stream);
+      cudecomp_nvshmem_alltoallv(params, use_sm ? &comm_info.nvshmem_signals[0] : nullptr, stream);
       count = 0;
     }
   }
   if (count != 0) {
     params.ntransfers = count;
-    cudecomp_nvshmem_alltoallv(params, &comm_info.nvshmem_signals[0], stream);
+    cudecomp_nvshmem_alltoallv(params, use_sm ? &comm_info.nvshmem_signals[0] : nullptr, stream);
   }
 
   // Intra-group transfers (blocking, scheduled after non-blocking inter-group transfers for concurrency)

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -94,7 +94,8 @@ static void
 nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_desc, T* send_buff,
                  const std::vector<comm_count_t>& send_counts, const std::vector<comm_count_t>& send_offsets,
                  T* recv_buff, const std::vector<comm_count_t>& recv_counts,
-                 const std::vector<comm_count_t>& recv_offsets, cudecompCommAxis comm_axis, cudaStream_t stream) {
+                 const std::vector<comm_count_t>& recv_offsets, cudecompCommAxis comm_axis, bool use_sm,
+                 cudaStream_t stream) {
   auto& comm_info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info : grid_desc->col_comm_info;
   auto team = comm_info.nvshmem_team;
   int self_rank = comm_info.rank;
@@ -146,29 +147,48 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     int dst_rank_global = getGlobalRank(handle, grid_desc, comm_axis, dst_rank);
     if (nvshmem_ptr(recv_buff, dst_rank_global)) {
 
-      if (comm_info.ngroups == 1 && handle->device_p2p_ce_count == 1 && count != 0 &&
-          count % CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ == 0) {
-        // For single group, single P2P CE (e.g. NVSwitch), synchronize NVSHMEM team every
-        // CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ transfers This helps reduce CE contention due to accumulation of
-        // jitter.
-        for (int i = 0; i < handle->device_p2p_ce_count; ++i) {
-          CHECK_CUDA(cudaEventRecord(grid_desc->events[0], handle->streams[i]));
-          CHECK_CUDA(cudaStreamWaitEvent(aux_stream, grid_desc->events[0], 0));
+      if (!use_sm) {
+        if (comm_info.ngroups == 1 && handle->device_p2p_ce_count == 1 && count != 0 &&
+            count % CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ == 0) {
+          // For single group, single P2P CE (e.g. NVSwitch), synchronize NVSHMEM team every
+          // CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ transfers This helps reduce CE contention due to accumulation of
+          // jitter.
+          for (int i = 0; i < handle->device_p2p_ce_count; ++i) {
+            CHECK_CUDA(cudaEventRecord(grid_desc->events[0], handle->streams[i]));
+            CHECK_CUDA(cudaStreamWaitEvent(aux_stream, grid_desc->events[0], 0));
+          }
+
+          nvshmemx_team_sync_on_stream(team, aux_stream);
+
+          CHECK_CUDA(cudaEventRecord(grid_desc->events[0], aux_stream));
+          for (int i = 0; i < handle->device_p2p_ce_count; ++i) {
+            CHECK_CUDA(cudaStreamWaitEvent(handle->streams[i], grid_desc->events[0], 0));
+          }
         }
 
-        nvshmemx_team_sync_on_stream(team, aux_stream);
+        nvshmemx_putmem_on_stream(recv_buff + recv_offsets[dst_rank], send_buff + send_offsets[dst_rank],
+                                  send_counts[dst_rank] * sizeof(T), dst_rank_global,
+                                  handle->streams[count % handle->device_p2p_ce_count]);
+        count++;
+      } else {
+        params.send_offsets[count] = send_offsets[dst_rank];
+        params.recv_offsets[count] = recv_offsets[dst_rank];
+        params.send_counts[count] = send_counts[dst_rank];
+        params.peer_ranks[count] = dst_rank_global;
+        count++;
 
-        CHECK_CUDA(cudaEventRecord(grid_desc->events[0], aux_stream));
-        for (int i = 0; i < handle->device_p2p_ce_count; ++i) {
-          CHECK_CUDA(cudaStreamWaitEvent(handle->streams[i], grid_desc->events[0], 0));
+        if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
+          params.ntransfers = count;
+          cudecomp_nvshmem_alltoallv_p2p(params, handle->streams[0]);
+          count = 0;
         }
       }
-
-      nvshmemx_putmem_on_stream(recv_buff + recv_offsets[dst_rank], send_buff + send_offsets[dst_rank],
-                                send_counts[dst_rank] * sizeof(T), dst_rank_global,
-                                handle->streams[count % handle->device_p2p_ce_count]);
-      count++;
     }
+  }
+
+  if (use_sm && count != 0) {
+    params.ntransfers = count;
+    cudecomp_nvshmem_alltoallv_p2p(params, handle->streams[0]);
   }
 
   // Self-copy with cudaMemcpy
@@ -213,11 +233,12 @@ static void cudecompAlltoall(const cudecompHandle_t& handle, const cudecompGridD
 
   std::vector<MPI_Request> reqs;
   switch (grid_desc->config.transpose_comm_backend) {
-  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM: {
+  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM:
+  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM: {
 #ifdef ENABLE_NVSHMEM
     if (nvshmem_ptr(send_buff, handle->rank) && nvshmem_ptr(recv_buff, handle->rank)) {
       nvshmemAlltoallV(handle, grid_desc, send_buff, send_counts, send_offsets, recv_buff, recv_counts,
-                       recv_offsets_nvshmem, comm_axis, stream);
+                       recv_offsets_nvshmem, comm_axis, grid_desc->config.transpose_comm_backend == CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM, stream);
       break;
     } else {
       THROW_INVALID_USAGE("NVSHMEM communication backends require workspace allocated via cudecompMalloc.");

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -115,7 +115,10 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   bool need_barrier = false;
   bool need_quiet = false;
   cudecompNvshmemA2AParams<T> params;
-  params.block_counters = grid_desc->nvshmem_block_counters;
+  cudecompNvshmemP2PParams<T> p2p_params;
+  p2p_params.send_buff = send_buff;
+  p2p_params.recv_buff = recv_buff;
+  p2p_params.block_counters = grid_desc->nvshmem_block_counters;
 
   // Inter-group transfers (non-blocking)
   params.send_buff = send_buff;
@@ -180,15 +183,15 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
                                   handle->streams[count % handle->device_p2p_ce_count]);
         count++;
       } else {
-        params.send_offsets[count] = send_offsets[dst_rank];
-        params.recv_offsets[count] = recv_offsets[dst_rank];
-        params.send_counts[count] = send_counts[dst_rank];
-        params.peer_ranks[count] = dst_rank_global;
+        p2p_params.send_offsets[count] = send_offsets[dst_rank];
+        p2p_params.recv_offsets[count] = recv_offsets[dst_rank];
+        p2p_params.send_counts[count] = send_counts[dst_rank];
+        p2p_params.peer_ranks[count] = dst_rank_global;
         count++;
 
-        if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
-          params.ntransfers = count;
-          cudecomp_nvshmem_alltoallv_p2p(handle, params, &comm_info.nvshmem_signals[0], stream);
+        if (count == CUDECOMP_NVSHMEM_P2P_PARAM_CAPACITY) {
+          p2p_params.ntransfers = count;
+          cudecomp_nvshmem_alltoallv_p2p(handle, p2p_params, &comm_info.nvshmem_signals[0], stream);
           count = 0;
         }
       }
@@ -197,8 +200,8 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 
   if (use_sm) {
     if (count != 0) {
-      params.ntransfers = count;
-      cudecomp_nvshmem_alltoallv_p2p(handle, params, &comm_info.nvshmem_signals[0], stream);
+      p2p_params.ntransfers = count;
+      cudecomp_nvshmem_alltoallv_p2p(handle, p2p_params, &comm_info.nvshmem_signals[0], stream);
     }
 
     if (need_quiet) { nvshmemx_quiet_on_stream(stream); }

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -188,7 +188,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 
         if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
           params.ntransfers = count;
-          cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], stream);
+          cudecomp_nvshmem_alltoallv_p2p(handle, params, &comm_info.nvshmem_signals[0], stream);
           count = 0;
         }
       }
@@ -198,7 +198,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   if (use_sm) {
     if (count != 0) {
       params.ntransfers = count;
-      cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], stream);
+      cudecomp_nvshmem_alltoallv_p2p(handle, params, &comm_info.nvshmem_signals[0], stream);
     }
 
     if (need_quiet) { nvshmemx_quiet_on_stream(stream); }

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -177,25 +177,16 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
                                   handle->streams[count % handle->device_p2p_ce_count]);
         count++;
       } else {
-        if (dst_rank == self_rank) {
-          // Record self-copy entries in params but do not add to remote transfer count.
-          params.has_self = true;
-          params.self_send_offset = send_offsets[self_rank];
-          params.self_recv_offset = recv_offsets[self_rank];
-          params.self_count = send_counts[self_rank];
-        } else {
-          params.send_offsets[count] = send_offsets[dst_rank];
-          params.recv_offsets[count] = recv_offsets[dst_rank];
-          params.send_counts[count] = send_counts[dst_rank];
-          params.peer_ranks[count] = dst_rank_global;
-          count++;
-        }
+        params.send_offsets[count] = send_offsets[dst_rank];
+        params.recv_offsets[count] = recv_offsets[dst_rank];
+        params.send_counts[count] = send_counts[dst_rank];
+        params.peer_ranks[count] = dst_rank_global;
+        count++;
 
         if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
           params.ntransfers = count;
           total_sm_transfers += count;
           cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], handle->streams[0]);
-          params.has_self = false;
           count = 0;
         }
       }
@@ -203,7 +194,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   }
 
   if (use_sm) {
-    if (count != 0 || params.has_self) {
+    if (count != 0) {
       params.ntransfers = count;
       total_sm_transfers += count;
       cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], handle->streams[0]);

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -105,12 +105,15 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->nvshmem_sync_event));
 
   // Event dependency on external stream for intra-group transfers
-  CHECK_CUDA(cudaEventRecord(grid_desc->events[0], stream));
-  for (int i = 0; i < handle->device_p2p_ce_count; ++i) {
-    CHECK_CUDA(cudaStreamWaitEvent(handle->streams[i], grid_desc->events[0], 0));
+  if (!use_sm) {
+    CHECK_CUDA(cudaEventRecord(grid_desc->events[0], stream));
+    for (int i = 0; i < handle->device_p2p_ce_count; ++i) {
+      CHECK_CUDA(cudaStreamWaitEvent(handle->streams[i], grid_desc->events[0], 0));
+    }
   }
 
   bool need_barrier = false;
+  bool need_quiet = false;
   cudecompNvshmemA2AParams<T> params;
   params.block_counters = comm_info.nvshmem_block_counters;
 
@@ -118,7 +121,6 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   params.send_buff = send_buff;
   params.recv_buff = recv_buff;
 
-  int total_sm_transfers = 0;
   int count = 0;
   for (int i = 1; i < send_counts.size(); ++i) {
     int src_rank, dst_rank;
@@ -126,7 +128,8 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     int dst_rank_global = getGlobalRank(handle, grid_desc, comm_axis, dst_rank);
     if (nvshmem_ptr(recv_buff, dst_rank_global)) { continue; }
 
-    need_barrier = true;
+    if (!use_sm) need_barrier = true;
+    need_quiet = true;
     params.send_offsets[count] = send_offsets[dst_rank];
     params.recv_offsets[count] = recv_offsets[dst_rank];
     params.send_counts[count] = send_counts[dst_rank];
@@ -135,13 +138,13 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 
     if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
       params.ntransfers = count;
-      cudecomp_nvshmem_alltoallv(params, stream);
+      cudecomp_nvshmem_alltoallv(params, &comm_info.nvshmem_signals[0], stream);
       count = 0;
     }
   }
   if (count != 0) {
     params.ntransfers = count;
-    cudecomp_nvshmem_alltoallv(params, stream);
+    cudecomp_nvshmem_alltoallv(params, &comm_info.nvshmem_signals[0], stream);
   }
 
   // Intra-group transfers (blocking, scheduled after non-blocking inter-group transfers for concurrency)
@@ -185,8 +188,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 
         if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
           params.ntransfers = count;
-          total_sm_transfers += count;
-          cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], handle->streams[0]);
+          cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], stream);
           count = 0;
         }
       }
@@ -196,22 +198,24 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   if (use_sm) {
     if (count != 0) {
       params.ntransfers = count;
-      total_sm_transfers += count;
-      cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], handle->streams[0]);
+      cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], stream);
     }
 
+    if (need_quiet) { nvshmemx_quiet_on_stream(stream); }
     nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[0], NVSHMEM_CMP_EQ,
-                                         static_cast<uint64_t>(total_sm_transfers), handle->streams[0]);
+                                         static_cast<uint64_t>(comm_info.nranks), stream);
   } else {
     // Self-copy with cudaMemcpy
     CHECK_CUDA(cudaMemcpyAsync(recv_buff + recv_offsets[self_rank], send_buff + send_offsets[self_rank],
                                send_counts[self_rank] * sizeof(T), cudaMemcpyDeviceToDevice, stream));
   }
 
-  // Event dependency on internal streams for completion of intra-group transfers
-  for (int i = 0; i < handle->device_p2p_ce_count; ++i) {
-    CHECK_CUDA(cudaEventRecord(grid_desc->events[0], handle->streams[i]));
-    CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[0], 0));
+  // Event dependency on internal streams for completion of intra-group transfers (not needed for SM path)
+  if (!use_sm) {
+    for (int i = 0; i < handle->device_p2p_ce_count; ++i) {
+      CHECK_CUDA(cudaEventRecord(grid_desc->events[0], handle->streams[i]));
+      CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[0], 0));
+    }
   }
 
   if (need_barrier) {

--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -110,11 +110,15 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     CHECK_CUDA(cudaStreamWaitEvent(handle->streams[i], grid_desc->events[0], 0));
   }
 
+  bool need_barrier = false;
   cudecompNvshmemA2AParams<T> params;
+  params.block_counters = comm_info.nvshmem_block_counters;
 
   // Inter-group transfers (non-blocking)
   params.send_buff = send_buff;
   params.recv_buff = recv_buff;
+
+  int total_sm_transfers = 0;
   int count = 0;
   for (int i = 1; i < send_counts.size(); ++i) {
     int src_rank, dst_rank;
@@ -122,6 +126,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     int dst_rank_global = getGlobalRank(handle, grid_desc, comm_axis, dst_rank);
     if (nvshmem_ptr(recv_buff, dst_rank_global)) { continue; }
 
+    need_barrier = true;
     params.send_offsets[count] = send_offsets[dst_rank];
     params.recv_offsets[count] = recv_offsets[dst_rank];
     params.send_counts[count] = send_counts[dst_rank];
@@ -148,6 +153,7 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     if (nvshmem_ptr(recv_buff, dst_rank_global)) {
 
       if (!use_sm) {
+        need_barrier = true;
         if (comm_info.ngroups == 1 && handle->device_p2p_ce_count == 1 && count != 0 &&
             count % CUDECOMP_NVSHMEM_INTRAGROUP_SYNC_FREQ == 0) {
           // For single group, single P2P CE (e.g. NVSwitch), synchronize NVSHMEM team every
@@ -187,7 +193,8 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
 
         if (count == CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY) {
           params.ntransfers = count;
-          cudecomp_nvshmem_alltoallv_p2p(params, handle->streams[0]);
+          total_sm_transfers += count;
+          cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], handle->streams[0]);
           params.has_self = false;
           count = 0;
         }
@@ -198,8 +205,12 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
   if (use_sm) {
     if (count != 0 || params.has_self) {
       params.ntransfers = count;
-      cudecomp_nvshmem_alltoallv_p2p(params, handle->streams[0]);
+      total_sm_transfers += count;
+      cudecomp_nvshmem_alltoallv_p2p(params, &comm_info.nvshmem_signals[0], handle->streams[0]);
     }
+
+    nvshmemx_signal_wait_until_on_stream(&comm_info.nvshmem_signals[0], NVSHMEM_CMP_EQ,
+                                         static_cast<uint64_t>(total_sm_transfers), handle->streams[0]);
   } else {
     // Self-copy with cudaMemcpy
     CHECK_CUDA(cudaMemcpyAsync(recv_buff + recv_offsets[self_rank], send_buff + send_offsets[self_rank],
@@ -212,7 +223,9 @@ nvshmemAlltoallV(const cudecompHandle_t& handle, const cudecompGridDesc_t& grid_
     CHECK_CUDA(cudaStreamWaitEvent(stream, grid_desc->events[0], 0));
   }
 
-  nvshmemx_barrier_on_stream(team, stream);
+  if (need_barrier) {
+    nvshmemx_barrier_on_stream(team, stream);
+  }
 }
 #endif
 

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -381,8 +381,8 @@ static inline void getAlltoallPeerRanks(cudecompGridDesc_t grid_desc, cudecompCo
 
   const auto& info = (comm_axis == CUDECOMP_COMM_ROW) ? grid_desc->row_comm_info : grid_desc->col_comm_info;
 
-  // Quick return for single rank case
-  if (info.nranks == 1) {
+  // Return self for single rank case or when iter is zero
+  if (info.nranks == 1 || iter == 0) {
     src_rank = info.rank;
     dst_rank = info.rank;
     return;

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -129,7 +129,6 @@ struct cudecompCommInfo {
 #ifdef ENABLE_NVSHMEM
   nvshmem_team_t nvshmem_team = NVSHMEM_TEAM_INVALID;
   uint64_t* nvshmem_signals = nullptr;
-  int* nvshmem_block_counters = nullptr; // device memory counters for SM alltoallv last-block detection
 #endif
 
   bool mnnvl_active = false; // flag to indicate whether communicator has MNNVL connections
@@ -183,6 +182,10 @@ struct cudecompGridDesc {
 
   std::vector<cudaEvent_t> events{nullptr}; // CUDA events used for scheduling
   cudaEvent_t nvshmem_sync_event = nullptr; // NVSHMEM event used for synchronization
+
+#ifdef ENABLE_NVSHMEM
+  int* nvshmem_block_counters = nullptr; // device memory counters for SM alltoallv last-block detection
+#endif
 
   cudecomp::graphCache graph_cache; // CUDA graph cache
 

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -292,7 +292,8 @@ static inline bool haloBackendRequiresNccl(cudecompHaloCommBackend_t comm_backen
 }
 
 static inline bool transposeBackendRequiresNvshmem(cudecompTransposeCommBackend_t comm_backend) {
-  return (comm_backend == CUDECOMP_TRANSPOSE_COMM_NVSHMEM || comm_backend == CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL);
+  return (comm_backend == CUDECOMP_TRANSPOSE_COMM_NVSHMEM || comm_backend == CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL ||
+          comm_backend == CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM);
 }
 
 static inline bool haloBackendRequiresNvshmem(cudecompHaloCommBackend_t comm_backend) {

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -129,6 +129,7 @@ struct cudecompCommInfo {
 #ifdef ENABLE_NVSHMEM
   nvshmem_team_t nvshmem_team = NVSHMEM_TEAM_INVALID;
   uint64_t* nvshmem_signals = nullptr;
+  int* nvshmem_block_counters = nullptr; // device memory counters for SM alltoallv last-block detection
 #endif
 
   bool mnnvl_active = false; // flag to indicate whether communicator has MNNVL connections

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -114,6 +114,8 @@ struct cudecompHandle {
 
   // Miscellaneous
   int32_t device_p2p_ce_count = 0;       // number of P2P CEs available
+  int32_t device_num_sms = 0;            // number of SMs on the device
+  int32_t device_max_threads_per_sm = 0; // maximum threads per SM
   bool use_col_major_rank_order = false; // Flag to control whether to use column-major rank order
 };
 

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -31,6 +31,7 @@
 #define CUDECOMP_MIN_BLOCKS_PER_SM (16)
 
 #define CUDECOMP_NVSHMEM_NTHREADS (1024)
+#define CUDECOMP_NVSHMEM_MAX_SMS (32)
 
 namespace cudecomp {
 
@@ -86,20 +87,6 @@ __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
       if (atomicAdd(&params.block_counters[peer_rank], 1) + 1 == blocks_per_copy) {
         params.block_counters[peer_rank] = 0;
         nvshmemx_signal_op(sig_addr, 1, NVSHMEM_SIGNAL_ADD, peer_rank);
-      }
-    }
-  }
-
-  // Self-copy: runs after remote puts are issued, using all blocks for full HBM bandwidth.
-  if (params.has_self) {
-    size_t nelems_per_block = (params.self_count + gridDim.x - 1) / gridDim.x;
-    size_t block_offset = (size_t)bid * nelems_per_block;
-    if (block_offset < params.self_count) {
-      size_t block_count = min(nelems_per_block, params.self_count - block_offset);
-      T* src = send_buff + params.self_send_offset + block_offset;
-      T* dst = recv_buff + params.self_recv_offset + block_offset;
-      for (size_t j = threadIdx.x; j < block_count; j += blockDim.x) {
-        dst[j] = src[j];
       }
     }
   }

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -169,7 +169,8 @@ __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
 }
 
 template <typename T>
-void cudecomp_batched_d2d_memcpy_3d_nd_dispatch(const cudecompBatchedD2DMemcpy3DParams<T>& params,
+void cudecomp_batched_d2d_memcpy_3d_nd_dispatch(cudecompHandle_t handle,
+                                                const cudecompBatchedD2DMemcpy3DParams<T>& params,
                                                 cudaStream_t stream) {
   size_t N = params.extents[0][0] * params.extents[1][0] * params.extents[2][0];
 
@@ -200,12 +201,7 @@ void cudecomp_batched_d2d_memcpy_3d_nd_dispatch(const cudecompBatchedD2DMemcpy3D
   int blocks_per_copy_unroll = (blocks_per_copy + CUDECOMP_UNROLL_FACTOR - 1) / CUDECOMP_UNROLL_FACTOR;
   size_t total_blocks_unroll = params.ncopies * blocks_per_copy_unroll;
 
-  // Clamp minimum number of blocks from unrolling
-  int dev, num_sms;
-  CHECK_CUDA(cudaGetDevice(&dev));
-  CHECK_CUDA(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev));
-
-  if (total_blocks_unroll > CUDECOMP_MIN_BLOCKS_PER_SM * num_sms) { blocks_per_copy = blocks_per_copy_unroll; }
+  if (total_blocks_unroll > CUDECOMP_MIN_BLOCKS_PER_SM * handle->device_num_sms) { blocks_per_copy = blocks_per_copy_unroll; }
 
   switch (src_nd) {
   case 1:

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -38,7 +38,7 @@ namespace cudecomp {
 #ifdef ENABLE_NVSHMEM
 template <typename T>
 __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
-    void cudecomp_nvshmem_alltoallv_k(cudecompNvshmemA2AParams<T> params) {
+    void cudecomp_nvshmem_alltoallv_k(cudecompNvshmemA2AParams<T> params, uint64_t* sig_addr) {
 
   const int tid = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid >= params.ntransfers) return;
@@ -50,7 +50,8 @@ __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
   size_t recv_offset = params.recv_offsets[tid];
   size_t send_count = params.send_counts[tid];
 
-  nvshmem_putmem_nbi(recv_buff + recv_offset, send_buff + send_offset, send_count * sizeof(T), peer_rank);
+  nvshmem_putmem_signal_nbi(recv_buff + recv_offset, send_buff + send_offset, send_count * sizeof(T), sig_addr, 1,
+                            NVSHMEM_SIGNAL_ADD, peer_rank);
 }
 
 template <typename T>

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -18,6 +18,8 @@
 #ifndef CUDECOMP_KERNELS_CUH
 #define CUDECOMP_KERNELS_CUH
 
+#include <algorithm>
+
 #ifdef ENABLE_NVSHMEM
 #include <nvshmem.h>
 #endif
@@ -27,6 +29,8 @@
 #define CUDECOMP_CUDA_NTHREADS (128)
 #define CUDECOMP_UNROLL_FACTOR (4)
 #define CUDECOMP_MIN_BLOCKS_PER_SM (16)
+
+#define CUDECOMP_NVSHMEM_NTHREADS (512)
 
 namespace cudecomp {
 
@@ -46,6 +50,34 @@ __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
   size_t send_count = params.send_counts[tid];
 
   nvshmem_putmem_nbi(recv_buff + recv_offset, send_buff + send_offset, send_count * sizeof(T), peer_rank);
+}
+
+template <typename T>
+__launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
+    void cudecomp_nvshmem_alltoallv_p2p_k(cudecompNvshmemA2AParams<T> params) {
+
+  T* send_buff = params.send_buff;
+  T* recv_buff = params.recv_buff;
+  int bid = blockIdx.x;
+
+  for (int i = 0; i < params.ntransfers; ++i) {
+    // Assign blocks across copies
+    int copyid = (bid + i) % params.ntransfers;
+    int peer_rank = params.peer_ranks[copyid];
+    size_t send_offset = params.send_offsets[copyid];
+    size_t recv_offset = params.recv_offsets[copyid];
+    size_t send_count = params.send_counts[copyid];
+
+    size_t nelems_per_block = (send_count + gridDim.x  - 1) / gridDim.x;
+    if (nelems_per_block * bid < send_count) {
+      size_t block_offset = bid * nelems_per_block;
+      size_t block_count = min(nelems_per_block, send_count - block_offset);
+      nvshmemx_putmem_nbi_block(recv_buff + recv_offset + block_offset,
+                                send_buff + send_offset + block_offset,
+                                block_count * sizeof(T),
+                                peer_rank);
+    }
+  }
 }
 #endif
 

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -30,7 +30,7 @@
 #define CUDECOMP_UNROLL_FACTOR (4)
 #define CUDECOMP_MIN_BLOCKS_PER_SM (16)
 
-#define CUDECOMP_NVSHMEM_NTHREADS (512)
+#define CUDECOMP_NVSHMEM_NTHREADS (1024)
 
 namespace cudecomp {
 
@@ -76,6 +76,20 @@ __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
                                 send_buff + send_offset + block_offset,
                                 block_count * sizeof(T),
                                 peer_rank);
+    }
+  }
+
+  // Self-copy: runs after remote puts are issued, using all blocks for full HBM bandwidth.
+  if (params.has_self) {
+    size_t nelems_per_block = (params.self_count + gridDim.x - 1) / gridDim.x;
+    size_t block_offset = (size_t)bid * nelems_per_block;
+    if (block_offset < params.self_count) {
+      size_t block_count = min(nelems_per_block, params.self_count - block_offset);
+      T* src = send_buff + params.self_send_offset + block_offset;
+      T* dst = recv_buff + params.self_recv_offset + block_offset;
+      for (size_t j = threadIdx.x; j < block_count; j += blockDim.x) {
+        dst[j] = src[j];
+      }
     }
   }
 }

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -31,7 +31,6 @@
 #define CUDECOMP_MIN_BLOCKS_PER_SM (16)
 
 #define CUDECOMP_NVSHMEM_NTHREADS (1024)
-#define CUDECOMP_NVSHMEM_MAX_SMS (32)
 
 namespace cudecomp {
 
@@ -73,7 +72,7 @@ __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
 
 template <typename T>
 __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
-    void cudecomp_nvshmem_alltoallv_p2p_k(cudecompNvshmemA2AParams<T> params, uint64_t *sig_addr) {
+    void cudecomp_nvshmem_alltoallv_p2p_k(cudecompNvshmemP2PParams<T> params, uint64_t *sig_addr) {
 
   T* send_buff = params.send_buff;
   T* recv_buff = params.recv_buff;

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -38,7 +38,24 @@ namespace cudecomp {
 #ifdef ENABLE_NVSHMEM
 template <typename T>
 __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
-    void cudecomp_nvshmem_alltoallv_k(cudecompNvshmemA2AParams<T> params, uint64_t* sig_addr) {
+    void cudecomp_nvshmem_alltoallv_k(cudecompNvshmemA2AParams<T> params) {
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid >= params.ntransfers) return;
+
+  int peer_rank = params.peer_ranks[tid];
+  T* send_buff = params.send_buff;
+  T* recv_buff = params.recv_buff;
+  size_t send_offset = params.send_offsets[tid];
+  size_t recv_offset = params.recv_offsets[tid];
+  size_t send_count = params.send_counts[tid];
+
+  nvshmem_putmem_nbi(recv_buff + recv_offset, send_buff + send_offset, send_count * sizeof(T), peer_rank);
+}
+
+template <typename T>
+__launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
+    void cudecomp_nvshmem_alltoallv_signal_k(cudecompNvshmemA2AParams<T> params, uint64_t* sig_addr) {
 
   const int tid = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid >= params.ntransfers) return;

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -54,11 +54,12 @@ __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
 
 template <typename T>
 __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
-    void cudecomp_nvshmem_alltoallv_p2p_k(cudecompNvshmemA2AParams<T> params) {
+    void cudecomp_nvshmem_alltoallv_p2p_k(cudecompNvshmemA2AParams<T> params, uint64_t *sig_addr) {
 
   T* send_buff = params.send_buff;
   T* recv_buff = params.recv_buff;
   int bid = blockIdx.x;
+  int blocks_per_copy = gridDim.x;
 
   for (int i = 0; i < params.ntransfers; ++i) {
     // Assign blocks across copies
@@ -72,11 +73,22 @@ __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
     if (nelems_per_block * bid < send_count) {
       size_t block_offset = bid * nelems_per_block;
       size_t block_count = min(nelems_per_block, send_count - block_offset);
-      nvshmemx_putmem_nbi_block(recv_buff + recv_offset + block_offset,
-                                send_buff + send_offset + block_offset,
-                                block_count * sizeof(T),
-                                peer_rank);
+      nvshmemx_putmem_block(recv_buff + recv_offset + block_offset,
+                            send_buff + send_offset + block_offset,
+                            block_count * sizeof(T),
+                            peer_rank);
     }
+
+    // Last block to finish this copy signals the destination PE.
+    nvshmem_fence();
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      if (atomicAdd(&params.block_counters[peer_rank], 1) + 1 == blocks_per_copy) {
+        params.block_counters[peer_rank] = 0;
+        nvshmemx_signal_op(sig_addr, 1, NVSHMEM_SIGNAL_ADD, peer_rank);
+      }
+    }
+    __syncthreads();
   }
 
   // Self-copy: runs after remote puts are issued, using all blocks for full HBM bandwidth.

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -59,19 +59,19 @@ __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
   T* send_buff = params.send_buff;
   T* recv_buff = params.recv_buff;
   int bid = blockIdx.x;
-  int blocks_per_copy = gridDim.x;
 
-  for (int i = 0; i < params.ntransfers; ++i) {
-    // Assign blocks across copies
-    int copyid = (bid + i) % params.ntransfers;
+  if (params.ntransfers > 0) {
+    int blocks_per_copy = gridDim.x / params.ntransfers;
+    int copyid = bid / blocks_per_copy;
+    int block_within_copy = bid % blocks_per_copy;
     int peer_rank = params.peer_ranks[copyid];
     size_t send_offset = params.send_offsets[copyid];
     size_t recv_offset = params.recv_offsets[copyid];
     size_t send_count = params.send_counts[copyid];
 
-    size_t nelems_per_block = (send_count + gridDim.x  - 1) / gridDim.x;
-    if (nelems_per_block * bid < send_count) {
-      size_t block_offset = bid * nelems_per_block;
+    size_t nelems_per_block = (send_count + blocks_per_copy - 1) / blocks_per_copy;
+    size_t block_offset = (size_t)block_within_copy * nelems_per_block;
+    if (block_offset < send_count) {
       size_t block_count = min(nelems_per_block, send_count - block_offset);
       nvshmemx_putmem_block(recv_buff + recv_offset + block_offset,
                             send_buff + send_offset + block_offset,
@@ -88,7 +88,6 @@ __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
         nvshmemx_signal_op(sig_addr, 1, NVSHMEM_SIGNAL_ADD, peer_rank);
       }
     }
-    __syncthreads();
   }
 
   // Self-copy: runs after remote puts are issued, using all blocks for full HBM bandwidth.

--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -72,7 +72,7 @@ __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
 
 template <typename T>
 __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
-    void cudecomp_nvshmem_alltoallv_p2p_k(cudecompNvshmemP2PParams<T> params, uint64_t *sig_addr) {
+    void cudecomp_nvshmem_alltoallv_p2p_k(cudecompNvshmemP2PParams<T> params, uint64_t* sig_addr) {
 
   T* send_buff = params.send_buff;
   T* recv_buff = params.recv_buff;
@@ -91,10 +91,8 @@ __launch_bounds__(CUDECOMP_NVSHMEM_NTHREADS) __global__
     size_t block_offset = (size_t)block_within_copy * nelems_per_block;
     if (block_offset < send_count) {
       size_t block_count = min(nelems_per_block, send_count - block_offset);
-      nvshmemx_putmem_block(recv_buff + recv_offset + block_offset,
-                            send_buff + send_offset + block_offset,
-                            block_count * sizeof(T),
-                            peer_rank);
+      nvshmemx_putmem_block(recv_buff + recv_offset + block_offset, send_buff + send_offset + block_offset,
+                            block_count * sizeof(T), peer_rank);
     }
 
     // Last block to finish this copy signals the destination PE.
@@ -200,7 +198,9 @@ void cudecomp_batched_d2d_memcpy_3d_nd_dispatch(cudecompHandle_t handle,
   int blocks_per_copy_unroll = (blocks_per_copy + CUDECOMP_UNROLL_FACTOR - 1) / CUDECOMP_UNROLL_FACTOR;
   size_t total_blocks_unroll = params.ncopies * blocks_per_copy_unroll;
 
-  if (total_blocks_unroll > CUDECOMP_MIN_BLOCKS_PER_SM * handle->device_num_sms) { blocks_per_copy = blocks_per_copy_unroll; }
+  if (total_blocks_unroll > CUDECOMP_MIN_BLOCKS_PER_SM * handle->device_num_sms) {
+    blocks_per_copy = blocks_per_copy_unroll;
+  }
 
   switch (src_nd) {
   case 1:

--- a/include/internal/cudecomp_kernels.h
+++ b/include/internal/cudecomp_kernels.h
@@ -35,10 +35,11 @@ template <typename T> struct cudecompNvshmemA2AParams {
   int* block_counters;
 };
 
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, uint64_t* sig_addr,
+                                cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr,
                                 cudaStream_t stream);
 
 void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream);

--- a/include/internal/cudecomp_kernels.h
+++ b/include/internal/cudecomp_kernels.h
@@ -30,13 +30,9 @@ template <typename T> struct cudecompNvshmemA2AParams {
   size_t send_offsets[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   size_t recv_offsets[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   size_t send_counts[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
-  size_t self_send_offset;
-  size_t self_recv_offset;
-  size_t self_count;
   int peer_ranks[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   int ntransfers;
   int* block_counters;
-  bool has_self;
 };
 
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream);

--- a/include/internal/cudecomp_kernels.h
+++ b/include/internal/cudecomp_kernels.h
@@ -35,6 +35,7 @@ template <typename T> struct cudecompNvshmemA2AParams {
   size_t self_count;
   int peer_ranks[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   int ntransfers;
+  int* block_counters;
   bool has_self;
 };
 
@@ -44,10 +45,10 @@ void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::comple
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
                                 cudaStream_t stream);
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr, cudaStream_t stream);
 #endif
 
 #define CUDECOMP_BATCHED_D2D_3D_PARAM_CAPACITY 56

--- a/include/internal/cudecomp_kernels.h
+++ b/include/internal/cudecomp_kernels.h
@@ -20,6 +20,8 @@
 
 #include <cuda/std/complex>
 
+#include "internal/common.h"
+
 namespace cudecomp {
 
 #ifdef ENABLE_NVSHMEM
@@ -42,10 +44,16 @@ void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::comple
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr,
                                 cudaStream_t stream);
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, uint64_t* sig_addr, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<float>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<double>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
+                                    const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
+                                    const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream);
 #endif
 
 #define CUDECOMP_BATCHED_D2D_3D_PARAM_CAPACITY 56
@@ -58,11 +66,15 @@ template <typename T> struct cudecompBatchedD2DMemcpy3DParams {
   int ncopies;
 };
 
-void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<float>& params, cudaStream_t stream);
-void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<double>& params, cudaStream_t stream);
-void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<float>>& params,
+void cudecomp_batched_d2d_memcpy_3d(cudecompHandle_t handle, cudecompBatchedD2DMemcpy3DParams<float>& params,
                                     cudaStream_t stream);
-void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<double>>& params,
+void cudecomp_batched_d2d_memcpy_3d(cudecompHandle_t handle, cudecompBatchedD2DMemcpy3DParams<double>& params,
+                                    cudaStream_t stream);
+void cudecomp_batched_d2d_memcpy_3d(cudecompHandle_t handle,
+                                    cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<float>>& params,
+                                    cudaStream_t stream);
+void cudecomp_batched_d2d_memcpy_3d(cudecompHandle_t handle,
+                                    cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<double>>& params,
                                     cudaStream_t stream);
 
 } // namespace cudecomp

--- a/include/internal/cudecomp_kernels.h
+++ b/include/internal/cudecomp_kernels.h
@@ -25,13 +25,13 @@ namespace cudecomp {
 #ifdef ENABLE_NVSHMEM
 #define CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY 96
 template <typename T> struct cudecompNvshmemA2AParams {
-  int ntransfers;
   T* send_buff = nullptr;
   T* recv_buff = nullptr;
   size_t send_offsets[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   size_t recv_offsets[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   size_t send_counts[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   int peer_ranks[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
+  int ntransfers;
 };
 
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream);
@@ -39,16 +39,21 @@ void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, 
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, cudaStream_t stream);
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
                                 cudaStream_t stream);
+
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, cudaStream_t stream);
 #endif
 
 #define CUDECOMP_BATCHED_D2D_3D_PARAM_CAPACITY 56
 template <typename T> struct cudecompBatchedD2DMemcpy3DParams {
-  int ncopies;
   T* src[CUDECOMP_BATCHED_D2D_3D_PARAM_CAPACITY];
   T* dest[CUDECOMP_BATCHED_D2D_3D_PARAM_CAPACITY];
   size_t src_strides[2][CUDECOMP_BATCHED_D2D_3D_PARAM_CAPACITY];  // [depth stride, row stride] col_stride=1 assumed
   size_t dest_strides[2][CUDECOMP_BATCHED_D2D_3D_PARAM_CAPACITY]; // [depth stride, row stride] col_stride=1 assumed
   size_t extents[3][CUDECOMP_BATCHED_D2D_3D_PARAM_CAPACITY];      // [depth, height, width]
+  int ncopies;
 };
 
 void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<float>& params, cudaStream_t stream);

--- a/include/internal/cudecomp_kernels.h
+++ b/include/internal/cudecomp_kernels.h
@@ -30,8 +30,12 @@ template <typename T> struct cudecompNvshmemA2AParams {
   size_t send_offsets[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   size_t recv_offsets[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   size_t send_counts[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
+  size_t self_send_offset;
+  size_t self_recv_offset;
+  size_t self_count;
   int peer_ranks[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   int ntransfers;
+  bool has_self;
 };
 
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream);

--- a/include/internal/cudecomp_kernels.h
+++ b/include/internal/cudecomp_kernels.h
@@ -53,7 +53,8 @@ template <typename T> struct cudecompNvshmemP2PParams {
 };
 
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr,
+                                cudaStream_t stream);
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, uint64_t* sig_addr,
                                 cudaStream_t stream);
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr,

--- a/include/internal/cudecomp_kernels.h
+++ b/include/internal/cudecomp_kernels.h
@@ -25,7 +25,9 @@
 namespace cudecomp {
 
 #ifdef ENABLE_NVSHMEM
-#define CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY 96
+
+// Capacity for the inter-group alltoallv kernel.
+#define CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY (96)
 template <typename T> struct cudecompNvshmemA2AParams {
   T* send_buff = nullptr;
   T* recv_buff = nullptr;
@@ -34,7 +36,20 @@ template <typename T> struct cudecompNvshmemA2AParams {
   size_t send_counts[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   int peer_ranks[CUDECOMP_NVSHMEM_A2A_PARAM_CAPACITY];
   int ntransfers;
-  int* block_counters;
+};
+
+// Capacity for the intra-group SM P2P kernel.
+#define CUDECOMP_NVSHMEM_MAX_SMS (32)
+#define CUDECOMP_NVSHMEM_P2P_PARAM_CAPACITY (CUDECOMP_NVSHMEM_MAX_SMS * 2)
+template <typename T> struct cudecompNvshmemP2PParams {
+  T* send_buff = nullptr;
+  T* recv_buff = nullptr;
+  int* block_counters = nullptr;
+  size_t send_offsets[CUDECOMP_NVSHMEM_P2P_PARAM_CAPACITY];
+  size_t recv_offsets[CUDECOMP_NVSHMEM_P2P_PARAM_CAPACITY];
+  size_t send_counts[CUDECOMP_NVSHMEM_P2P_PARAM_CAPACITY];
+  int peer_ranks[CUDECOMP_NVSHMEM_P2P_PARAM_CAPACITY];
+  int ntransfers;
 };
 
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream);
@@ -44,15 +59,15 @@ void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::comple
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr,
                                 cudaStream_t stream);
 
-void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<float>& params,
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemP2PParams<float>& params,
                                     uint64_t* sig_addr, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<double>& params,
-                                    uint64_t* sig_addr, cudaStream_t stream);
-void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
-                                    const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemP2PParams<double>& params,
                                     uint64_t* sig_addr, cudaStream_t stream);
 void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
-                                    const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+                                    const cudecompNvshmemP2PParams<cuda::std::complex<float>>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
+                                    const cudecompNvshmemP2PParams<cuda::std::complex<double>>& params,
                                     uint64_t* sig_addr, cudaStream_t stream);
 #endif
 

--- a/include/internal/halo.h
+++ b/include/internal/halo.h
@@ -183,7 +183,7 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     }
 
     memcpy_params.ncopies = 2;
-    cudecomp_batched_d2d_memcpy_3d(memcpy_params, stream);
+    cudecomp_batched_d2d_memcpy_3d(handle, memcpy_params, stream);
   } break;
 
   case 1: {
@@ -218,7 +218,7 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
     }
 
     memcpy_params.ncopies = 2;
-    cudecomp_batched_d2d_memcpy_3d(memcpy_params, stream);
+    cudecomp_batched_d2d_memcpy_3d(handle, memcpy_params, stream);
 
     std::array<comm_count_t, 2> counts{static_cast<comm_count_t>(halo_size), static_cast<comm_count_t>(halo_size)};
     std::array<size_t, 2> offsets{};
@@ -266,7 +266,7 @@ void cudecompUpdateHalos_(int ax, const cudecompHandle_t handle, const cudecompG
       memcpy_params.ncopies = 2;
     }
 
-    cudecomp_batched_d2d_memcpy_3d(memcpy_params, stream);
+    cudecomp_batched_d2d_memcpy_3d(handle, memcpy_params, stream);
   } break;
 
   case 2: {

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -579,7 +579,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
           memcpy_count++;
           if (memcpy_count == memcpy_limit || j == splits_a.size()) {
             memcpy_params.ncopies = memcpy_count;
-            cudecomp_batched_d2d_memcpy_3d(memcpy_params, graph_stream);
+            cudecomp_batched_d2d_memcpy_3d(handle, memcpy_params, graph_stream);
             memcpy_count = 0;
           }
 #if CUDART_VERSION >= 11010
@@ -873,7 +873,7 @@ static void cudecompTranspose_(int ax, int dir, const cudecompHandle_t handle, c
         memcpy_count++;
         if (memcpy_count == memcpy_limit || j == splits_a.size() - 1) {
           memcpy_params.ncopies = memcpy_count;
-          cudecomp_batched_d2d_memcpy_3d(memcpy_params, stream);
+          cudecomp_batched_d2d_memcpy_3d(handle, memcpy_params, stream);
           memcpy_count = 0;
         }
       }

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -105,6 +105,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
     if (!options->disable_nvshmem_backends) {
       comm_backend_list.push_back(CUDECOMP_TRANSPOSE_COMM_NVSHMEM);
       comm_backend_list.push_back(CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL);
+      comm_backend_list.push_back(CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM);
       need_nvshmem = true;
     }
 #endif

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -280,10 +280,18 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->row_comm_info.nvshmem_block_counters,
+                            grid_desc->row_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_block_counters, 0,
+                            grid_desc->row_comm_info.nranks * sizeof(int)));
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->col_comm_info.nvshmem_block_counters,
+                            grid_desc->col_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_block_counters, 0,
+                            grid_desc->col_comm_info.nranks * sizeof(int)));
 #endif
     }
 
@@ -462,6 +470,8 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
       nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
       nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
+      CHECK_CUDA(cudaFree(grid_desc->row_comm_info.nvshmem_block_counters));
+      CHECK_CUDA(cudaFree(grid_desc->col_comm_info.nvshmem_block_counters));
       grid_desc->row_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
       grid_desc->col_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
 #endif
@@ -706,10 +716,18 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->row_comm_info.nvshmem_block_counters,
+                            grid_desc->row_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_block_counters, 0,
+                            grid_desc->row_comm_info.nranks * sizeof(int)));
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->col_comm_info.nvshmem_block_counters,
+                            grid_desc->col_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_block_counters, 0,
+                            grid_desc->col_comm_info.nranks * sizeof(int)));
 #endif
     }
 
@@ -825,6 +843,8 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
       nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
       nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
+      CHECK_CUDA(cudaFree(grid_desc->row_comm_info.nvshmem_block_counters));
+      CHECK_CUDA(cudaFree(grid_desc->col_comm_info.nvshmem_block_counters));
       grid_desc->row_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
       grid_desc->col_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
 #endif

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -280,18 +280,12 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
-      CHECK_CUDA(cudaMalloc(&grid_desc->row_comm_info.nvshmem_block_counters,
-                            grid_desc->row_comm_info.nranks * sizeof(int)));
-      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_block_counters, 0,
-                            grid_desc->row_comm_info.nranks * sizeof(int)));
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
-      CHECK_CUDA(cudaMalloc(&grid_desc->col_comm_info.nvshmem_block_counters,
-                            grid_desc->col_comm_info.nranks * sizeof(int)));
-      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_block_counters, 0,
-                            grid_desc->col_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->nvshmem_block_counters, handle->nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->nvshmem_block_counters, 0, handle->nranks * sizeof(int)));
 #endif
     }
 
@@ -470,8 +464,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
       nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
       nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
       nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
-      CHECK_CUDA(cudaFree(grid_desc->row_comm_info.nvshmem_block_counters));
-      CHECK_CUDA(cudaFree(grid_desc->col_comm_info.nvshmem_block_counters));
+      CHECK_CUDA(cudaFree(grid_desc->nvshmem_block_counters));
       grid_desc->row_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
       grid_desc->col_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
 #endif
@@ -716,18 +709,12 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
-      CHECK_CUDA(cudaMalloc(&grid_desc->row_comm_info.nvshmem_block_counters,
-                            grid_desc->row_comm_info.nranks * sizeof(int)));
-      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_block_counters, 0,
-                            grid_desc->row_comm_info.nranks * sizeof(int)));
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
-      CHECK_CUDA(cudaMalloc(&grid_desc->col_comm_info.nvshmem_block_counters,
-                            grid_desc->col_comm_info.nranks * sizeof(int)));
-      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_block_counters, 0,
-                            grid_desc->col_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->nvshmem_block_counters, handle->nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->nvshmem_block_counters, 0, handle->nranks * sizeof(int)));
 #endif
     }
 
@@ -843,8 +830,7 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
       nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
       nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
       nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
-      CHECK_CUDA(cudaFree(grid_desc->row_comm_info.nvshmem_block_counters));
-      CHECK_CUDA(cudaFree(grid_desc->col_comm_info.nvshmem_block_counters));
+      CHECK_CUDA(cudaFree(grid_desc->nvshmem_block_counters));
       grid_desc->row_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
       grid_desc->col_comm_info.nvshmem_team = NVSHMEM_TEAM_INVALID;
 #endif

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -102,11 +102,13 @@ static void checkTransposeCommBackend(cudecompTransposeCommBackend_t comm_backen
   case CUDECOMP_TRANSPOSE_COMM_MPI_A2A:
 #ifdef ENABLE_NVSHMEM
   case CUDECOMP_TRANSPOSE_COMM_NVSHMEM:
-  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL: return;
+  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL:
+  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM: return;
 #else
     return;
   case CUDECOMP_TRANSPOSE_COMM_NVSHMEM:
-  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL: THROW_NOT_SUPPORTED("transpose communication type unsupported");
+  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL:
+  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM: THROW_NOT_SUPPORTED("transpose communication type unsupported");
 #endif
 
   default: THROW_INVALID_USAGE("unknown transpose communication type");
@@ -1338,6 +1340,7 @@ const char* cudecompTransposeCommBackendToString(cudecompTransposeCommBackend_t 
   case CUDECOMP_TRANSPOSE_COMM_MPI_A2A: return "MPI_A2A";
   case CUDECOMP_TRANSPOSE_COMM_NVSHMEM: return "NVSHMEM";
   case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL: return "NVSHMEM (pipelined)";
+  case CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM: return "NVSHMEM_SM";
   default: return "ERROR";
   }
 }

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -789,10 +789,18 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->row_comm_info.nvshmem_block_counters,
+                            grid_desc->row_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_block_counters, 0,
+                            grid_desc->row_comm_info.nranks * sizeof(int)));
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->col_comm_info.nvshmem_block_counters,
+                            grid_desc->col_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_block_counters, 0,
+                            grid_desc->col_comm_info.nranks * sizeof(int)));
       handle->n_grid_descs_using_nvshmem++;
     } else {
       // Finalize nvshmem to reclaim symmetric heap memory if not used
@@ -921,10 +929,12 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
       if (grid_desc->row_comm_info.nvshmem_team != NVSHMEM_TEAM_INVALID) {
         nvshmem_team_destroy(grid_desc->row_comm_info.nvshmem_team);
         nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
+        CHECK_CUDA(cudaFree(grid_desc->row_comm_info.nvshmem_block_counters));
       }
       if (grid_desc->col_comm_info.nvshmem_team != NVSHMEM_TEAM_INVALID) {
         nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
         nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
+        CHECK_CUDA(cudaFree(grid_desc->col_comm_info.nvshmem_block_counters));
       }
       handle->n_grid_descs_using_nvshmem--;
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -789,18 +789,12 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
           (uint64_t*)nvshmem_malloc(grid_desc->row_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->row_comm_info.nvshmem_signals, 0, grid_desc->row_comm_info.nranks * sizeof(uint64_t)));
-      CHECK_CUDA(cudaMalloc(&grid_desc->row_comm_info.nvshmem_block_counters,
-                            grid_desc->row_comm_info.nranks * sizeof(int)));
-      CHECK_CUDA(cudaMemset(grid_desc->row_comm_info.nvshmem_block_counters, 0,
-                            grid_desc->row_comm_info.nranks * sizeof(int)));
       grid_desc->col_comm_info.nvshmem_signals =
           (uint64_t*)nvshmem_malloc(grid_desc->col_comm_info.nranks * sizeof(uint64_t));
       CHECK_CUDA(
           cudaMemset(grid_desc->col_comm_info.nvshmem_signals, 0, grid_desc->col_comm_info.nranks * sizeof(uint64_t)));
-      CHECK_CUDA(cudaMalloc(&grid_desc->col_comm_info.nvshmem_block_counters,
-                            grid_desc->col_comm_info.nranks * sizeof(int)));
-      CHECK_CUDA(cudaMemset(grid_desc->col_comm_info.nvshmem_block_counters, 0,
-                            grid_desc->col_comm_info.nranks * sizeof(int)));
+      CHECK_CUDA(cudaMalloc(&grid_desc->nvshmem_block_counters, handle->nranks * sizeof(int)));
+      CHECK_CUDA(cudaMemset(grid_desc->nvshmem_block_counters, 0, handle->nranks * sizeof(int)));
       handle->n_grid_descs_using_nvshmem++;
     } else {
       // Finalize nvshmem to reclaim symmetric heap memory if not used
@@ -929,13 +923,12 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
       if (grid_desc->row_comm_info.nvshmem_team != NVSHMEM_TEAM_INVALID) {
         nvshmem_team_destroy(grid_desc->row_comm_info.nvshmem_team);
         nvshmem_free(grid_desc->row_comm_info.nvshmem_signals);
-        CHECK_CUDA(cudaFree(grid_desc->row_comm_info.nvshmem_block_counters));
       }
       if (grid_desc->col_comm_info.nvshmem_team != NVSHMEM_TEAM_INVALID) {
         nvshmem_team_destroy(grid_desc->col_comm_info.nvshmem_team);
         nvshmem_free(grid_desc->col_comm_info.nvshmem_signals);
-        CHECK_CUDA(cudaFree(grid_desc->col_comm_info.nvshmem_block_counters));
       }
+      CHECK_CUDA(cudaFree(grid_desc->nvshmem_block_counters));
       handle->n_grid_descs_using_nvshmem--;
 
       // Finalize nvshmem to reclaim symmetric heap memory if not used

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -531,6 +531,10 @@ cudecompResult_t cudecompInit(cudecompHandle_t* handle_in, MPI_Comm mpi_comm) {
       handle->device_p2p_ce_count = 2; // Assume 2 P2P CE otherwise (shared D2H/H2D CE)
     }
 
+    // Cache device attributes
+    CHECK_CUDA(cudaDeviceGetAttribute(&handle->device_num_sms, cudaDevAttrMultiProcessorCount, dev));
+    CHECK_CUDA(cudaDeviceGetAttribute(&handle->device_max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
+
     handle->initialized = true;
     cudecomp_initialized = true;
 

--- a/src/cudecomp_kernels.cu
+++ b/src/cudecomp_kernels.cu
@@ -22,19 +22,23 @@
 
 namespace cudecomp {
 
-void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<float>& params, cudaStream_t stream) {
-  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
-}
-void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<double>& params, cudaStream_t stream) {
-  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
-}
-void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<float>>& params,
+void cudecomp_batched_d2d_memcpy_3d(cudecompHandle_t handle, cudecompBatchedD2DMemcpy3DParams<float>& params,
                                     cudaStream_t stream) {
-  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
+  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(handle, params, stream);
 }
-void cudecomp_batched_d2d_memcpy_3d(cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<double>>& params,
+void cudecomp_batched_d2d_memcpy_3d(cudecompHandle_t handle, cudecompBatchedD2DMemcpy3DParams<double>& params,
                                     cudaStream_t stream) {
-  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
+  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(handle, params, stream);
+}
+void cudecomp_batched_d2d_memcpy_3d(cudecompHandle_t handle,
+                                    cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<float>>& params,
+                                    cudaStream_t stream) {
+  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(handle, params, stream);
+}
+void cudecomp_batched_d2d_memcpy_3d(cudecompHandle_t handle,
+                                    cudecompBatchedD2DMemcpy3DParams<cuda::std::complex<double>>& params,
+                                    cudaStream_t stream) {
+  cudecomp_batched_d2d_memcpy_3d_nd_dispatch(handle, params, stream);
 }
 
 } // namespace cudecomp

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -55,34 +55,34 @@ static int nvshmem_p2p_nblocks(int ntransfers) {
   // number of blocks, ensuring even NVLink subscription across peers.
   int max_blocks_per_sm = max_threads_per_sm / CUDECOMP_NVSHMEM_NTHREADS;
   int nblocks_max = max_blocks_per_sm * num_sms;
+  if (ntransfers == 0) return nblocks_max;
   int blocks_per_copy = std::max(1, nblocks_max / ntransfers);
   return blocks_per_copy * ntransfers;
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream) {
+template <typename T>
+static void launch_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<T>& params, cudaStream_t stream) {
   int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
   cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
   CHECK_CUDA_LAUNCH();
 }
 
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream) {
+  launch_nvshmem_alltoallv_p2p(params, stream);
+}
+
 void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream) {
-  int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
-  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
-  CHECK_CUDA_LAUNCH();
+  launch_nvshmem_alltoallv_p2p(params, stream);
 }
 
 void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
                                     cudaStream_t stream) {
-  int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
-  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
-  CHECK_CUDA_LAUNCH();
+  launch_nvshmem_alltoallv_p2p(params, stream);
 }
 
 void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
                                     cudaStream_t stream) {
-  int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
-  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
-  CHECK_CUDA_LAUNCH();
+  launch_nvshmem_alltoallv_p2p(params, stream);
 }
 #endif
 

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -61,28 +61,28 @@ static int nvshmem_p2p_nblocks(int ntransfers) {
 }
 
 template <typename T>
-static void launch_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<T>& params, cudaStream_t stream) {
+static void launch_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<T>& params, uint64_t* sig_addr, cudaStream_t stream) {
   int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
-  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
+  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params, sig_addr);
   CHECK_CUDA_LAUNCH();
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(params, stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream) {
+  launch_nvshmem_alltoallv_p2p(params, sig_addr, stream);
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(params, stream);
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream) {
+  launch_nvshmem_alltoallv_p2p(params, sig_addr, stream);
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, uint64_t* sig_addr,
                                     cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(params, stream);
+  launch_nvshmem_alltoallv_p2p(params, sig_addr, stream);
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr,
                                     cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(params, stream);
+  launch_nvshmem_alltoallv_p2p(params, sig_addr, stream);
 }
 #endif
 

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -23,25 +23,25 @@
 namespace cudecomp {
 
 #ifdef ENABLE_NVSHMEM
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream) {
+  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
   CHECK_CUDA_LAUNCH();
 }
 
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream) {
+  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
   CHECK_CUDA_LAUNCH();
 }
 
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, uint64_t* sig_addr,
                                 cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
   CHECK_CUDA_LAUNCH();
 }
 
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr,
                                 cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
   CHECK_CUDA_LAUNCH();
 }
 

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -64,31 +64,31 @@ static int nvshmem_p2p_nblocks(int ntransfers, cudecompHandle_t handle) {
 }
 
 template <typename T>
-static void launch_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<T>& params,
+static void launch_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemP2PParams<T>& params,
                                          uint64_t* sig_addr, cudaStream_t stream) {
   int nblocks = nvshmem_p2p_nblocks(params.ntransfers, handle);
   cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params, sig_addr);
   CHECK_CUDA_LAUNCH();
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<float>& params,
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemP2PParams<float>& params,
                                     uint64_t* sig_addr, cudaStream_t stream) {
   launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<double>& params,
-                                    uint64_t* sig_addr, cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
-}
-
-void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
-                                    const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemP2PParams<double>& params,
                                     uint64_t* sig_addr, cudaStream_t stream) {
   launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
 }
 
 void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
-                                    const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+                                    const cudecompNvshmemP2PParams<cuda::std::complex<float>>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream) {
+  launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
+}
+
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
+                                    const cudecompNvshmemP2PParams<cuda::std::complex<double>>& params,
                                     uint64_t* sig_addr, cudaStream_t stream) {
   launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
 }

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -23,26 +23,33 @@
 namespace cudecomp {
 
 #ifdef ENABLE_NVSHMEM
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
+template <typename T>
+static void launch_nvshmem_alltoallv(const cudecompNvshmemA2AParams<T>& params, uint64_t* sig_addr,
+                                     cudaStream_t stream) {
+  if (sig_addr) {
+    cudecomp_nvshmem_alltoallv_signal_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
+  } else {
+    cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
+  }
   CHECK_CUDA_LAUNCH();
 }
 
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream) {
+  launch_nvshmem_alltoallv(params, sig_addr, stream);
+}
+
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
-  CHECK_CUDA_LAUNCH();
+  launch_nvshmem_alltoallv(params, sig_addr, stream);
 }
 
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, uint64_t* sig_addr,
                                 cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
-  CHECK_CUDA_LAUNCH();
+  launch_nvshmem_alltoallv(params, sig_addr, stream);
 }
 
 void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr,
                                 cudaStream_t stream) {
-  cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params, sig_addr);
-  CHECK_CUDA_LAUNCH();
+  launch_nvshmem_alltoallv(params, sig_addr, stream);
 }
 
 static int nvshmem_p2p_nblocks(int ntransfers) {

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -52,44 +52,45 @@ void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::comple
   launch_nvshmem_alltoallv(params, sig_addr, stream);
 }
 
-static int nvshmem_p2p_nblocks(int ntransfers) {
-  int dev, num_sms, max_threads_per_sm;
-  CHECK_CUDA(cudaGetDevice(&dev));
-  CHECK_CUDA(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev));
-  CHECK_CUDA(cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
+static int nvshmem_p2p_nblocks(int ntransfers, cudecompHandle_t handle) {
   // Theoretical max blocks per SM based on thread count. Round down to a multiple of ntransfers so
   // that all launched blocks fit in a single resident wave and each copy receives exactly the same
   // number of blocks, ensuring even NVLink subscription across peers.
-  int max_blocks_per_sm = max_threads_per_sm / CUDECOMP_NVSHMEM_NTHREADS;
-  int nblocks_max = max_blocks_per_sm * std::min(num_sms, CUDECOMP_NVSHMEM_MAX_SMS);
+  int max_blocks_per_sm = handle->device_max_threads_per_sm / CUDECOMP_NVSHMEM_NTHREADS;
+  int nblocks_max = max_blocks_per_sm * std::min(handle->device_num_sms, (int32_t)CUDECOMP_NVSHMEM_MAX_SMS);
   if (ntransfers == 0) return nblocks_max;
   int blocks_per_copy = std::max(1, nblocks_max / ntransfers);
   return blocks_per_copy * ntransfers;
 }
 
 template <typename T>
-static void launch_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<T>& params, uint64_t* sig_addr, cudaStream_t stream) {
-  int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
+static void launch_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<T>& params,
+                                         uint64_t* sig_addr, cudaStream_t stream) {
+  int nblocks = nvshmem_p2p_nblocks(params.ntransfers, handle);
   cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params, sig_addr);
   CHECK_CUDA_LAUNCH();
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(params, sig_addr, stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<float>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream) {
+  launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(params, sig_addr, stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle, const cudecompNvshmemA2AParams<double>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream) {
+  launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params, uint64_t* sig_addr,
-                                    cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(params, sig_addr, stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
+                                    const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream) {
+  launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
 }
 
-void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params, uint64_t* sig_addr,
-                                    cudaStream_t stream) {
-  launch_nvshmem_alltoallv_p2p(params, sig_addr, stream);
+void cudecomp_nvshmem_alltoallv_p2p(cudecompHandle_t handle,
+                                    const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+                                    uint64_t* sig_addr, cudaStream_t stream) {
+  launch_nvshmem_alltoallv_p2p(handle, params, sig_addr, stream);
 }
 #endif
 

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -50,11 +50,12 @@ static int nvshmem_p2p_nblocks(int ntransfers) {
   CHECK_CUDA(cudaGetDevice(&dev));
   CHECK_CUDA(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev));
   CHECK_CUDA(cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
-  // Theoretical max blocks per SM based on thread count, then round up to a multiple of ntransfers
-  // so that each copy receives the same number of blocks.
+  // Theoretical max blocks per SM based on thread count. Round down to a multiple of ntransfers so
+  // that all launched blocks fit in a single resident wave and each copy receives exactly the same
+  // number of blocks, ensuring even NVLink subscription across peers.
   int max_blocks_per_sm = max_threads_per_sm / CUDECOMP_NVSHMEM_NTHREADS;
   int nblocks_max = max_blocks_per_sm * num_sms;
-  int blocks_per_copy = (nblocks_max + ntransfers - 1) / ntransfers;
+  int blocks_per_copy = std::max(1, nblocks_max / ntransfers);
   return blocks_per_copy * ntransfers;
 }
 

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -34,11 +34,13 @@ static void launch_nvshmem_alltoallv(const cudecompNvshmemA2AParams<T>& params, 
   CHECK_CUDA_LAUNCH();
 }
 
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr, cudaStream_t stream) {
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<float>& params, uint64_t* sig_addr,
+                                cudaStream_t stream) {
   launch_nvshmem_alltoallv(params, sig_addr, stream);
 }
 
-void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr, cudaStream_t stream) {
+void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<double>& params, uint64_t* sig_addr,
+                                cudaStream_t stream) {
   launch_nvshmem_alltoallv(params, sig_addr, stream);
 }
 

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -44,6 +44,45 @@ void cudecomp_nvshmem_alltoallv(const cudecompNvshmemA2AParams<cuda::std::comple
   cudecomp_nvshmem_alltoallv_k<<<1, CUDECOMP_CUDA_NTHREADS, 0, stream>>>(params);
   CHECK_CUDA_LAUNCH();
 }
+
+static int nvshmem_p2p_nblocks(int ntransfers) {
+  int dev, num_sms, max_threads_per_sm;
+  CHECK_CUDA(cudaGetDevice(&dev));
+  CHECK_CUDA(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev));
+  CHECK_CUDA(cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, dev));
+  // Theoretical max blocks per SM based on thread count, then round up to a multiple of ntransfers
+  // so that each copy receives the same number of blocks.
+  int max_blocks_per_sm = max_threads_per_sm / CUDECOMP_NVSHMEM_NTHREADS;
+  int nblocks_max = max_blocks_per_sm * num_sms;
+  int blocks_per_copy = (nblocks_max + ntransfers - 1) / ntransfers;
+  return blocks_per_copy * ntransfers;
+}
+
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<float>& params, cudaStream_t stream) {
+  int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
+  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
+  CHECK_CUDA_LAUNCH();
+}
+
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<double>& params, cudaStream_t stream) {
+  int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
+  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
+  CHECK_CUDA_LAUNCH();
+}
+
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<float>>& params,
+                                    cudaStream_t stream) {
+  int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
+  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
+  CHECK_CUDA_LAUNCH();
+}
+
+void cudecomp_nvshmem_alltoallv_p2p(const cudecompNvshmemA2AParams<cuda::std::complex<double>>& params,
+                                    cudaStream_t stream) {
+  int nblocks = nvshmem_p2p_nblocks(params.ntransfers);
+  cudecomp_nvshmem_alltoallv_p2p_k<<<nblocks, CUDECOMP_NVSHMEM_NTHREADS, 0, stream>>>(params);
+  CHECK_CUDA_LAUNCH();
+}
 #endif
 
 } // namespace cudecomp

--- a/src/cudecomp_kernels_rdc.cu
+++ b/src/cudecomp_kernels_rdc.cu
@@ -54,7 +54,7 @@ static int nvshmem_p2p_nblocks(int ntransfers) {
   // that all launched blocks fit in a single resident wave and each copy receives exactly the same
   // number of blocks, ensuring even NVLink subscription across peers.
   int max_blocks_per_sm = max_threads_per_sm / CUDECOMP_NVSHMEM_NTHREADS;
-  int nblocks_max = max_blocks_per_sm * num_sms;
+  int nblocks_max = max_blocks_per_sm * std::min(num_sms, CUDECOMP_NVSHMEM_MAX_SMS);
   if (ntransfers == 0) return nblocks_max;
   int blocks_per_copy = std::max(1, nblocks_max / ntransfers);
   return blocks_per_copy * ntransfers;

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -30,6 +30,7 @@ module cudecomp
     enumerator :: CUDECOMP_TRANSPOSE_COMM_NCCL_PL = 5
     enumerator :: CUDECOMP_TRANSPOSE_COMM_NVSHMEM = 6
     enumerator :: CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL = 7
+    enumerator :: CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM = 8
   end enum
 
   ! enum for cuDecomp halo backend options

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -48,8 +48,8 @@ module transpose_CUDECOMP_DOUBLE_COMPLEX_mod
 
   type(cudecompHandle) :: handle
   integer :: rank, nranks
-  type(cudecompGridDesc) :: grid_desc_cache(7)
-  logical :: grid_desc_cache_set(7) = .false.
+  type(cudecompGridDesc) :: grid_desc_cache(8)
+  logical :: grid_desc_cache_set(8) = .false.
   ARRTYPE, pointer, device, contiguous :: work_d(:)
   integer :: work_backend = -1
 
@@ -642,7 +642,7 @@ program main
   endif
 
   ! Free grid descriptors
-  do i = 1, 7
+  do i = 1, 8
     if (grid_desc_cache_set(i)) then
       ! Free workspace with correct grid descriptor
       if (work_backend == i) then

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -18,7 +18,7 @@ transpose_test_base: &transpose_test_base
           'hex' ,'hey', 'hez',
           'pdx', 'pdy', 'pdz']
 
-  backend: [1, 2, 3, 4, 5, 6, 7]
+  backend: [1, 2, 3, 4, 5, 6, 7, 8]
 
   gx: [128]
   gy: [124]


### PR DESCRIPTION
This PR introduces a new transpose communication backend, `CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM`, that uses SM-driven transfers to perform intra-group (NVLink-connected) P2P transfers instead of using copy-engine (CE) driven transfers.

The existing `CUDECOMP_TRANSPOSE_COMM_NVSHMEM` backend issues all intra-group puts via the NVSHMEM host API `nvshmemx_putmem_on_stream`, which dispatches through the CEs. For large transfers, it is often the case that CE-driven transfers achieve higher bandwidth than SM-driven ones, which is why the existing backend was designed that way. However, as per-peer transfer sizes reduce, like in strong scaling or extreme weak scaling scenarios, SM-driven transfers become more competitive. In addition to this, the GPUs on systems equipped with NVSwitch-connectivity between GPUs (e.g., DGX systems, MNNVL systems) can typically only run a single CE-driven P2P transfer at a time, which can be a problem if individual transfer sizes become to small to saturate NVLink on their own. SM-driven transfers can more effectively run NVLink transfers to multiple peers concurrently, providing better total NVLink utilization in these scenarios.

Historically, the NCCL backend of cuDecomp has served the role of the "SM-driven" alltoall backend to fall back on when the CE-driven NVSHMEM backends were suboptimal. This PR provides a new alternative SM-driven backend for cuDecomp to make use of.