### PR TITLE
Minor general fixes.

### DIFF
--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -249,6 +249,8 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
               (need_nccl) ? CUDECOMP_TRANSPOSE_COMM_NCCL : CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
           cudecompResult_t ret = cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work), work_sz);
           grid_desc->config.transpose_comm_backend = tmp;
+          // Check after restoring the temporary backend used to select the allocation path.
+          CHECK_CUDECOMP(ret);
         }
 #endif
       } else {
@@ -708,6 +710,8 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
           grid_desc->config.halo_comm_backend = (need_nccl) ? CUDECOMP_HALO_COMM_NCCL : CUDECOMP_HALO_COMM_MPI;
           cudecompResult_t ret = cudecompMalloc(handle, grid_desc, reinterpret_cast<void**>(&work), work_sz);
           grid_desc->config.halo_comm_backend = tmp;
+          // Check after restoring the temporary backend used to select the allocation path.
+          CHECK_CUDECOMP(ret);
         }
 #endif
       } else {

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -440,6 +440,7 @@ cudecompResult_t cudecompInit(cudecompHandle_t* handle_in, MPI_Comm mpi_comm) {
   using namespace cudecomp;
   cudecompHandle_t handle = nullptr;
   try {
+    if (!handle_in) { THROW_INVALID_USAGE("handle argument cannot be null"); }
     if (cudecomp_initialized) {
       THROW_INVALID_USAGE("cuDecomp already initialized and multiple handles are not supported.");
     }
@@ -577,7 +578,6 @@ cudecompResult_t cudecompFinalize(cudecompHandle_t handle) {
 
     CHECK_NVML(nvmlShutdown());
 
-    handle = nullptr;
     delete handle;
 
     cudecomp_initialized = false;

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -590,15 +590,8 @@ cudecompResult_t cudecompFinalize(cudecompHandle_t handle) {
 }
 
 cudecompResult_t cudecompInit_F(cudecompHandle_t* handle_in, MPI_Fint mpi_comm_f) {
-  using namespace cudecomp;
-  try {
-    MPI_Comm mpi_comm = MPI_Comm_f2c(mpi_comm_f);
-    cudecompInit(handle_in, mpi_comm);
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
-  return CUDECOMP_RESULT_SUCCESS;
+  MPI_Comm mpi_comm = MPI_Comm_f2c(mpi_comm_f);
+  return cudecompInit(handle_in, mpi_comm);
 }
 
 cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDesc_t* grid_desc_in,


### PR DESCRIPTION
This PR fixes some minor general issues in cuDecomp:
- Adds `nullptr` check on input handle argument to `cudecompInit`.
- Fixes handle memory leak in `cudecompFinalize`
- Fixes `cudecompInit` return value in Fortran if an error occurs
- Adds some missing error checks around `cudecompMalloc` calls during autotuning 