### PR TITLE
Fixes and improvements to NCCL user buffer registration feature.

### DIFF
--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -69,7 +69,7 @@ struct cudecompHandle {
   cudecomp::ncclComm nccl_comm;       // NCCL communicator (global)
   cudecomp::ncclComm nccl_local_comm; // NCCL communicator (intra-node, or intra-clique on MNNVL systems)
   bool nccl_enable_ubr = false;       // Flag to control NCCL user buffer registration usage
-  std::unordered_map<void*, std::vector<std::pair<ncclComm_t, void*>>>
+  std::unordered_map<void*, std::vector<std::pair<cudecomp::ncclComm, void*>>>
       nccl_ubr_handles; // map of allocated buffer address to NCCL registration handle(s)
 
   std::vector<cudaStream_t> streams; // internal streams for concurrent scheduling

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -1268,14 +1268,20 @@ cudecompResult_t cudecompMalloc(cudecompHandle_t handle, cudecompGridDesc_t grid
           haloBackendRequiresNccl(grid_desc->config.halo_comm_backend)) {
 
         if (handle->nccl_enable_ubr) {
-          void* nccl_ubr_handle;
-          if (grid_desc->nccl_comm) {
-            CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_comm, *buffer, buffer_size_bytes, &nccl_ubr_handle));
-            handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(*grid_desc->nccl_comm, nccl_ubr_handle));
-          }
-          if (grid_desc->nccl_local_comm) {
-            CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_local_comm, *buffer, buffer_size_bytes, &nccl_ubr_handle));
-            handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(*grid_desc->nccl_local_comm, nccl_ubr_handle));
+          try {
+            void* nccl_ubr_handle;
+            if (grid_desc->nccl_comm) {
+              CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_comm, *buffer, buffer_size_bytes, &nccl_ubr_handle));
+              handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(*grid_desc->nccl_comm, nccl_ubr_handle));
+            }
+            if (grid_desc->nccl_local_comm) {
+              CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_local_comm, *buffer, buffer_size_bytes, &nccl_ubr_handle));
+              handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(*grid_desc->nccl_local_comm, nccl_ubr_handle));
+            }
+          } catch (...) {
+            cudecompFree(handle, grid_desc, *buffer);
+            *buffer = nullptr;
+            throw;
           }
         }
       }

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -1195,6 +1195,8 @@ cudecompResult_t cudecompMalloc(cudecompHandle_t handle, cudecompGridDesc_t grid
   try {
     checkHandle(handle);
     checkGridDesc(grid_desc);
+    if (!buffer) { THROW_INVALID_USAGE("buffer argument cannot be null"); }
+    if (buffer_size_bytes == 0) { THROW_INVALID_USAGE("buffer size cannot be zero"); }
 
     if (transposeBackendRequiresNvshmem(grid_desc->config.transpose_comm_backend) ||
         haloBackendRequiresNvshmem(grid_desc->config.halo_comm_backend)) {
@@ -1294,15 +1296,11 @@ cudecompResult_t cudecompFree(cudecompHandle_t handle, cudecompGridDesc_t grid_d
     checkGridDesc(grid_desc);
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
-    if (transposeBackendRequiresNccl(grid_desc->config.transpose_comm_backend) ||
-        haloBackendRequiresNccl(grid_desc->config.halo_comm_backend)) {
-
-      if (handle->nccl_ubr_handles.count(buffer) != 0) {
-        for (const auto& entry : handle->nccl_ubr_handles[buffer]) {
-          CHECK_NCCL(ncclCommDeregister(entry.first, entry.second));
-        }
-        handle->nccl_ubr_handles.erase(buffer);
+    if (handle->nccl_ubr_handles.count(buffer) != 0) {
+      for (const auto& entry : handle->nccl_ubr_handles[buffer]) {
+        CHECK_NCCL(ncclCommDeregister(entry.first, entry.second));
       }
+      handle->nccl_ubr_handles.erase(buffer);
     }
 #endif
 

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -1268,11 +1268,11 @@ cudecompResult_t cudecompMalloc(cudecompHandle_t handle, cudecompGridDesc_t grid
         if (handle->nccl_enable_ubr) {
           void* nccl_ubr_handle;
           if (grid_desc->nccl_comm) {
-            CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_comm, buffer, buffer_size_bytes, &nccl_ubr_handle));
+            CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_comm, *buffer, buffer_size_bytes, &nccl_ubr_handle));
             handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(*grid_desc->nccl_comm, nccl_ubr_handle));
           }
           if (grid_desc->nccl_local_comm) {
-            CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_local_comm, buffer, buffer_size_bytes, &nccl_ubr_handle));
+            CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_local_comm, *buffer, buffer_size_bytes, &nccl_ubr_handle));
             handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(*grid_desc->nccl_local_comm, nccl_ubr_handle));
           }
         }

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -579,6 +579,15 @@ cudecompResult_t cudecompFinalize(cudecompHandle_t handle) {
   try {
     checkHandle(handle);
 
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
+    for (auto& entry : handle->nccl_ubr_handles) {
+      for (const auto& ubr_handle : entry.second) {
+        CHECK_NCCL(ncclCommDeregister(*ubr_handle.first, ubr_handle.second));
+      }
+    }
+    handle->nccl_ubr_handles.clear();
+#endif
+
     handle->nccl_comm.reset();
     handle->nccl_local_comm.reset();
 
@@ -1272,11 +1281,11 @@ cudecompResult_t cudecompMalloc(cudecompHandle_t handle, cudecompGridDesc_t grid
             void* nccl_ubr_handle;
             if (grid_desc->nccl_comm) {
               CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_comm, *buffer, buffer_size_bytes, &nccl_ubr_handle));
-              handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(*grid_desc->nccl_comm, nccl_ubr_handle));
+              handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(grid_desc->nccl_comm, nccl_ubr_handle));
             }
             if (grid_desc->nccl_local_comm) {
               CHECK_NCCL(ncclCommRegister(*grid_desc->nccl_local_comm, *buffer, buffer_size_bytes, &nccl_ubr_handle));
-              handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(*grid_desc->nccl_local_comm, nccl_ubr_handle));
+              handle->nccl_ubr_handles[*buffer].push_back(std::make_pair(grid_desc->nccl_local_comm, nccl_ubr_handle));
             }
           } catch (...) {
             cudecompFree(handle, grid_desc, *buffer);
@@ -1304,7 +1313,7 @@ cudecompResult_t cudecompFree(cudecompHandle_t handle, cudecompGridDesc_t grid_d
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
     if (handle->nccl_ubr_handles.count(buffer) != 0) {
       for (const auto& entry : handle->nccl_ubr_handles[buffer]) {
-        CHECK_NCCL(ncclCommDeregister(entry.first, entry.second));
+        CHECK_NCCL(ncclCommDeregister(*entry.first, entry.second));
       }
       handle->nccl_ubr_handles.erase(buffer);
     }


### PR DESCRIPTION
This PR fixes a long-standing issue with the NCCL user buffer registration feature (enabled via `CUDECOMP_ENABLE_NCCL_UBR`) and makes several improvements to registration handling/cleanup.

The main fix is that the calls to `ncclCommRegister` within `cudecompMalloc` have always incorrectly registered the wrong memory address. In particular, the registration calls were passed `buffer`, which in the context of `cudecompMalloc` is a pointer to thee allocation pointer (e.g., `void **`), but it should have been passed `*buffer`.  Critically, this means `CUDECOMP_ENABLE_NCCL_UBR` has essentially been a no-op up to now. Users who previously tried this feature and did not see a performance impact should consider giving it another try after this patch lands.

Outside this main fix, this PR also adds some code to improve registration clean up within `cudecompFree` and `cudecompFinalize`.