### PR TITLE
Expand exception handling in C API to catch generic exceptions.

### DIFF
--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <numeric>
 #include <set>
@@ -165,6 +166,35 @@ static void checkHandle(cudecompHandle_t handle) {
 static void checkGridDesc(cudecompGridDesc_t grid_desc) {
   if (!grid_desc || !grid_desc->initialized) { THROW_INVALID_USAGE("invalid grid descriptor"); }
 }
+
+static cudecompResult_t handleException(const BaseException& e) {
+  std::cerr << e.what();
+  return e.getResult();
+}
+
+static cudecompResult_t handleUnexpectedException(const std::exception& e) {
+  std::cerr << "CUDECOMP:ERROR: Internal error. (" << e.what() << ")\n";
+  return CUDECOMP_RESULT_INTERNAL_ERROR;
+}
+
+static cudecompResult_t handleUnexpectedException() {
+  std::cerr << "CUDECOMP:ERROR: Internal error. (unknown exception)\n";
+  return CUDECOMP_RESULT_INTERNAL_ERROR;
+}
+
+#define CUDECOMP_CATCH_C_API_ERRORS(...)                                                                               \
+  catch (const cudecomp::BaseException& e) {                                                                           \
+    __VA_ARGS__;                                                                                                       \
+    return handleException(e);                                                                                         \
+  }                                                                                                                    \
+  catch (const std::exception& e) {                                                                                    \
+    __VA_ARGS__;                                                                                                       \
+    return handleUnexpectedException(e);                                                                               \
+  }                                                                                                                    \
+  catch (...) {                                                                                                        \
+    __VA_ARGS__;                                                                                                       \
+    return handleUnexpectedException();                                                                                \
+  }
 
 static void checkConfig(cudecompHandle_t handle, const cudecompGridDescConfig_t* config, bool autotune_transpose,
                         bool autotune_halos) {
@@ -573,11 +603,7 @@ cudecompResult_t cudecompInit(cudecompHandle_t* handle_in, MPI_Comm mpi_comm) {
 
     *handle_in = handle;
 
-  } catch (const BaseException& e) {
-    if (handle) { delete handle; }
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS(if (handle) { delete handle; })
   return CUDECOMP_RESULT_SUCCESS;
 };
 
@@ -622,16 +648,16 @@ cudecompResult_t cudecompFinalize(cudecompHandle_t handle) {
 
     cudecomp_initialized = false;
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
 cudecompResult_t cudecompInit_F(cudecompHandle_t* handle_in, MPI_Fint mpi_comm_f) {
-  MPI_Comm mpi_comm = MPI_Comm_f2c(mpi_comm_f);
-  return cudecompInit(handle_in, mpi_comm);
+  using namespace cudecomp;
+  try {
+    MPI_Comm mpi_comm = MPI_Comm_f2c(mpi_comm_f);
+    return cudecompInit(handle_in, mpi_comm);
+  } CUDECOMP_CATCH_C_API_ERRORS()
 }
 
 cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDesc_t* grid_desc_in,
@@ -642,6 +668,7 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
   cudecompGridDesc_t grid_desc = nullptr;
   try {
     checkHandle(handle);
+    if (!grid_desc_in) { THROW_INVALID_USAGE("grid_desc argument cannot be null"); }
     if (!config) { THROW_INVALID_USAGE("config argument cannot be null"); }
 
     // Check some autotuning options
@@ -874,17 +901,14 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
       }
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    if (grid_desc) { delete grid_desc; }
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS(if (grid_desc) { delete grid_desc; })
   return CUDECOMP_RESULT_SUCCESS;
 }
 
 cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDesc_t grid_desc) {
   using namespace cudecomp;
   try {
+    checkHandle(handle);
     checkGridDesc(grid_desc);
 
     if (grid_desc->row_comm_info.mpi_comm != MPI_COMM_NULL) {
@@ -971,10 +995,7 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
     delete grid_desc;
     grid_desc = nullptr;
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1005,10 +1026,7 @@ cudecompResult_t cudecompGridDescConfigSetDefaults(cudecompGridDescConfig_t* con
     // Halo Options
     config->halo_comm_backend = CUDECOMP_HALO_COMM_MPI;
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1049,10 +1067,7 @@ cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAuto
       options->halo_padding[i] = 0;
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1111,10 +1126,7 @@ cudecompResult_t cudecompGetPencilInfo(cudecompHandle_t handle, cudecompGridDesc
       pencil_info->size *= pencil_info->shape[ord];
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1143,10 +1155,7 @@ cudecompResult_t cudecompGetGridDescConfig(cudecompHandle_t handle, cudecompGrid
       }
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1169,10 +1178,7 @@ cudecompResult_t cudecompGetTransposeWorkspaceSize(cudecompHandle_t handle, cude
 
     *workspace_size = std::max({wsize_xy, wsize_yx, wsize_yz, wsize_zy});
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1198,10 +1204,7 @@ cudecompResult_t cudecompGetHaloWorkspaceSize(cudecompHandle_t handle, cudecompG
         4 * alignCountToBytes(shape_g[0] * shape_g[1] * pinfo.halo_extents[2], CUDECOMP_WORKSPACE_ALIGN_BYTES);
 
     *workspace_size = std::max({halo_size_x, halo_size_y, halo_size_z});
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1304,10 +1307,7 @@ cudecompResult_t cudecompMalloc(cudecompHandle_t handle, cudecompGridDesc_t grid
 #endif
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1359,10 +1359,7 @@ cudecompResult_t cudecompFree(cudecompHandle_t handle, cudecompGridDesc_t grid_d
         if (buffer) { CHECK_CUDA(cudaFree(buffer)); }
       }
     }
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1403,10 +1400,7 @@ cudecompResult_t cudecompGetDataTypeSize(cudecompDataType_t dtype, int64_t* dtyp
     case CUDECOMP_DOUBLE_COMPLEX: *dtype_size = 16; break;
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1448,10 +1442,7 @@ cudecompResult_t cudecompGetShiftedRank(cudecompHandle_t handle, cudecompGridDes
       *shifted_rank = global_peer;
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1491,10 +1482,7 @@ cudecompResult_t cudecompTransposeXToY(cudecompHandle_t handle, cudecompGridDesc
                             output_halo_extents, input_padding, output_padding, stream);
       break;
     }
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1534,10 +1522,7 @@ cudecompResult_t cudecompTransposeYToZ(cudecompHandle_t handle, cudecompGridDesc
                             output_halo_extents, input_padding, output_padding, stream);
       break;
     }
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1577,10 +1562,7 @@ cudecompResult_t cudecompTransposeZToY(cudecompHandle_t handle, cudecompGridDesc
                             output_halo_extents, input_padding, output_padding, stream);
       break;
     }
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1620,10 +1602,7 @@ cudecompResult_t cudecompTransposeYToX(cudecompHandle_t handle, cudecompGridDesc
                             output_halo_extents, input_padding, output_padding, stream);
       break;
     }
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1666,10 +1645,7 @@ cudecompResult_t cudecompUpdateHalosX(cudecompHandle_t handle, cudecompGridDesc_
       break;
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1712,10 +1688,7 @@ cudecompResult_t cudecompUpdateHalosY(cudecompHandle_t handle, cudecompGridDesc_
       break;
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1758,9 +1731,8 @@ cudecompResult_t cudecompUpdateHalosZ(cudecompHandle_t handle, cudecompGridDesc_
       break;
     }
 
-  } catch (const cudecomp::BaseException& e) {
-    std::cerr << e.what();
-    return e.getResult();
-  }
+  } CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
+
+#undef CUDECOMP_CATCH_C_API_ERRORS

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -602,8 +602,8 @@ cudecompResult_t cudecompInit(cudecompHandle_t* handle_in, MPI_Comm mpi_comm) {
     cudecomp_initialized = true;
 
     *handle_in = handle;
-
-  } CUDECOMP_CATCH_C_API_ERRORS(if (handle) { delete handle; })
+  }
+  CUDECOMP_CATCH_C_API_ERRORS(if (handle) { delete handle; })
   return CUDECOMP_RESULT_SUCCESS;
 };
 
@@ -647,8 +647,8 @@ cudecompResult_t cudecompFinalize(cudecompHandle_t handle) {
     delete handle;
 
     cudecomp_initialized = false;
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -657,7 +657,8 @@ cudecompResult_t cudecompInit_F(cudecompHandle_t* handle_in, MPI_Fint mpi_comm_f
   try {
     MPI_Comm mpi_comm = MPI_Comm_f2c(mpi_comm_f);
     return cudecompInit(handle_in, mpi_comm);
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
 }
 
 cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDesc_t* grid_desc_in,
@@ -900,8 +901,8 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
         }
       }
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS(if (grid_desc) { delete grid_desc; })
+  }
+  CUDECOMP_CATCH_C_API_ERRORS(if (grid_desc) { delete grid_desc; })
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -994,8 +995,8 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
 
     delete grid_desc;
     grid_desc = nullptr;
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1025,8 +1026,8 @@ cudecompResult_t cudecompGridDescConfigSetDefaults(cudecompGridDescConfig_t* con
 
     // Halo Options
     config->halo_comm_backend = CUDECOMP_HALO_COMM_MPI;
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1066,8 +1067,8 @@ cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAuto
       options->halo_periods[i] = false;
       options->halo_padding[i] = 0;
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1125,8 +1126,8 @@ cudecompResult_t cudecompGetPencilInfo(cudecompHandle_t handle, cudecompGridDesc
       }
       pencil_info->size *= pencil_info->shape[ord];
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1154,8 +1155,8 @@ cudecompResult_t cudecompGetGridDescConfig(cudecompHandle_t handle, cudecompGrid
         }
       }
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1177,8 +1178,8 @@ cudecompResult_t cudecompGetTransposeWorkspaceSize(cudecompHandle_t handle, cude
     int64_t wsize_zy = alignCountToBytes(max_pencil_size_z, CUDECOMP_WORKSPACE_ALIGN_BYTES) + max_pencil_size_y;
 
     *workspace_size = std::max({wsize_xy, wsize_yx, wsize_yz, wsize_zy});
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1204,7 +1205,8 @@ cudecompResult_t cudecompGetHaloWorkspaceSize(cudecompHandle_t handle, cudecompG
         4 * alignCountToBytes(shape_g[0] * shape_g[1] * pinfo.halo_extents[2], CUDECOMP_WORKSPACE_ALIGN_BYTES);
 
     *workspace_size = std::max({halo_size_x, halo_size_y, halo_size_z});
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1306,8 +1308,8 @@ cudecompResult_t cudecompMalloc(cudecompHandle_t handle, cudecompGridDesc_t grid
       }
 #endif
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1359,7 +1361,8 @@ cudecompResult_t cudecompFree(cudecompHandle_t handle, cudecompGridDesc_t grid_d
         if (buffer) { CHECK_CUDA(cudaFree(buffer)); }
       }
     }
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1399,8 +1402,8 @@ cudecompResult_t cudecompGetDataTypeSize(cudecompDataType_t dtype, int64_t* dtyp
     case CUDECOMP_FLOAT_COMPLEX: *dtype_size = 8; break;
     case CUDECOMP_DOUBLE_COMPLEX: *dtype_size = 16; break;
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1441,8 +1444,8 @@ cudecompResult_t cudecompGetShiftedRank(cudecompHandle_t handle, cudecompGridDes
       int global_peer = getGlobalRank(handle, grid_desc, comm_axis, comm_peer);
       *shifted_rank = global_peer;
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1482,7 +1485,8 @@ cudecompResult_t cudecompTransposeXToY(cudecompHandle_t handle, cudecompGridDesc
                             output_halo_extents, input_padding, output_padding, stream);
       break;
     }
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1522,7 +1526,8 @@ cudecompResult_t cudecompTransposeYToZ(cudecompHandle_t handle, cudecompGridDesc
                             output_halo_extents, input_padding, output_padding, stream);
       break;
     }
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1562,7 +1567,8 @@ cudecompResult_t cudecompTransposeZToY(cudecompHandle_t handle, cudecompGridDesc
                             output_halo_extents, input_padding, output_padding, stream);
       break;
     }
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1602,7 +1608,8 @@ cudecompResult_t cudecompTransposeYToX(cudecompHandle_t handle, cudecompGridDesc
                             output_halo_extents, input_padding, output_padding, stream);
       break;
     }
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1644,8 +1651,8 @@ cudecompResult_t cudecompUpdateHalosX(cudecompHandle_t handle, cudecompGridDesc_
                            padding, stream);
       break;
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1687,8 +1694,8 @@ cudecompResult_t cudecompUpdateHalosY(cudecompHandle_t handle, cudecompGridDesc_
                            padding, stream);
       break;
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
@@ -1730,8 +1737,8 @@ cudecompResult_t cudecompUpdateHalosZ(cudecompHandle_t handle, cudecompGridDesc_
                            padding, stream);
       break;
     }
-
-  } CUDECOMP_CATCH_C_API_ERRORS()
+  }
+  CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
This PR improves the existing exception handling in cuDecomp. Up to now, cuDecomp would only catch and handle cuDecomp specific exceptions and allow generic C++ exceptions to pass uncaught which isn't ideal. After this change, generic exceptions are caught and reported as internal errors. This PR also includes some small remaining missing input argument validation in some of the functions.