### PR TITLE
Allow GPU oversubscription in test programs.

### DIFF
--- a/tests/cc/halo_test.cc
+++ b/tests/cc/halo_test.cc
@@ -510,7 +510,13 @@ int main(int argc, char** argv) {
   MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &local_comm);
   int local_rank;
   MPI_Comm_rank(local_comm, &local_rank);
-  CHECK_CUDA_EXIT(cudaSetDevice(local_rank));
+  int num_devices = 0;
+  CHECK_CUDA_EXIT(cudaGetDeviceCount(&num_devices));
+  if (num_devices <= 0) {
+    fprintf(stderr, "No CUDA devices available.\n");
+    exit(EXIT_FAILURE);
+  }
+  CHECK_CUDA_EXIT(cudaSetDevice(local_rank % num_devices));
 
   // Check if test file was provided
   std::string testfile;

--- a/tests/cc/transpose_test.cc
+++ b/tests/cc/transpose_test.cc
@@ -574,7 +574,13 @@ int main(int argc, char** argv) {
   MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &local_comm);
   int local_rank;
   MPI_Comm_rank(local_comm, &local_rank);
-  CHECK_CUDA_EXIT(cudaSetDevice(local_rank));
+  int num_devices = 0;
+  CHECK_CUDA_EXIT(cudaGetDeviceCount(&num_devices));
+  if (num_devices <= 0) {
+    fprintf(stderr, "No CUDA devices available.\n");
+    exit(EXIT_FAILURE);
+  }
+  CHECK_CUDA_EXIT(cudaSetDevice(local_rank % num_devices));
 
   // Check if test file was provided
   std::string testfile;

--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -529,7 +529,7 @@ program main
 
   integer :: i, idx
   real(real64) :: t0
-  integer :: local_rank, ierr
+  integer :: local_rank, ierr, num_devices
   integer :: local_comm
   integer :: res, retcode
   logical :: using_testfile
@@ -546,7 +546,12 @@ program main
 
   call MPI_Comm_split_Type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, local_comm, ierr)
   call MPI_Comm_rank(local_comm, local_rank, ierr)
-  CHECK_CUDA_EXIT(cudaSetDevice(local_rank))
+  CHECK_CUDA_EXIT(cudaGetDeviceCount(num_devices))
+  if (num_devices <= 0) then
+    print*, 'No CUDA devices available.'
+    call exit(1)
+  endif
+  CHECK_CUDA_EXIT(cudaSetDevice(mod(local_rank, num_devices)))
 
   using_testfile = .false.
   do i = 1, command_argument_count()

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -554,7 +554,7 @@ program main
 
   integer :: i, idx
   real(real64) :: t0
-  integer :: local_rank, ierr
+  integer :: local_rank, ierr, num_devices
   integer :: local_comm
   integer :: res, retcode
   logical :: using_testfile
@@ -571,7 +571,12 @@ program main
 
   call MPI_Comm_split_Type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, local_comm, ierr)
   call MPI_Comm_rank(local_comm, local_rank, ierr)
-  CHECK_CUDA_EXIT(cudaSetDevice(local_rank))
+  CHECK_CUDA_EXIT(cudaGetDeviceCount(num_devices))
+  if (num_devices <= 0) then
+    print*, 'No CUDA devices available.'
+    call exit(1)
+  endif
+  CHECK_CUDA_EXIT(cudaSetDevice(mod(local_rank, num_devices)))
 
   using_testfile = .false.
   do i = 1, command_argument_count()


### PR DESCRIPTION
The recent NCCL 2.30 release includes experimental support for [multiple ranks per GPU](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-multi-rank-gpu-enable), removing the final blocker to allowing simple multi-rank cuDecomp testing on single GPU systems. This PR updates the test programs to allow GPU oversubscription for this use case. 