### PR TITLE
Remove outdated transpose_axis_contiguous override during grid descriptor creation.

### DIFF
--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -767,8 +767,6 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
       }
     }
 
-    grid_desc->config.transpose_axis_contiguous[0] = false; // For x-axis, always set to false.
-
     if (grid_desc->config.gdims_dist[0] > grid_desc->config.gdims[0] ||
         grid_desc->config.gdims_dist[1] > grid_desc->config.gdims[1] ||
         grid_desc->config.gdims_dist[2] > grid_desc->config.gdims[2]) {


### PR DESCRIPTION
This PR removes an old override of `transpose_axis_contiguous[0]` to `false` that was made obsolete by the introduction of `transpose_mem_order` in #49. Previously, this flag setting was used to route the transpose through a more performant pack/unpack path but after #49, all these decisions are based on `transpose_mem_order`, and this config mutation doesn't actually do anything (other than potentially modify a user provided config). 