### PR TITLE
Fix benign typo in cudecompUpdateHaloZ Fortran interface.

### DIFF
--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -987,7 +987,7 @@ contains
     if (present(padding)) padding_ = padding
     res = cudecompUpdateHalosZ_C(handle, grid_desc, &
           input, work, dtype, halo_extents, halo_periods_c, &
-          dim - 1, padding, stream_)
+          dim - 1, padding_, stream_)
   end function cudecompUpdateHalosZ
 
   ! Helper function to copy string


### PR DESCRIPTION
The `cudecompUpdateHaloZ` Fortran interface function erroneously passes the optional `padding` variable directly into the C API rather than the local `padding_` variable that is conditionally populated if `padding` is present, as is done in the other halo update interfaces. This is a benign issue as `padding` will be `nullptr` if not present, resulting in the appropriate non-padded behavior in the C API. This PR just cleans up the inconsistency.