### PR TITLE
Propagate NVSHMEM compile definitions to ctest build.

### DIFF
--- a/tests/ctest/CMakeLists.txt
+++ b/tests/ctest/CMakeLists.txt
@@ -61,6 +61,16 @@ target_include_directories(cudecomp_test_support
   ${NVHPC_CUDA_INCLUDE_DIR}
   ${NCCL_INCLUDE_DIR}
 )
+if (CUDECOMP_ENABLE_NVSHMEM)
+  target_compile_definitions(cudecomp_test_support
+    PUBLIC
+    ENABLE_NVSHMEM
+  )
+  target_include_directories(cudecomp_test_support
+    PUBLIC
+    ${NVSHMEM_INCLUDE_DIR}
+  )
+endif()
 target_link_libraries(cudecomp_test_support
   PUBLIC
   MPI::MPI_CXX


### PR DESCRIPTION
Some of the CTests fixtures manipulate internal cuDecomp structs. This PR ensures that the `ENABLE_NVSHMEM` compiler defintion is propagated to the tests builds when NVSHMEM is enabled so these structs are appropriately sized. 