### PR TITLE
Fix basic usage pencil initialization

### DIFF
--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -395,7 +395,7 @@ access pattern as the flattened array example above:
 
     int64_t l = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if (l > pinfo.size) return;
+    if (l >= pinfo.size) return;
 
     int i = l % pinfo.shape[0];
     int j = l / pinfo.shape[0] % pinfo.shape[1];
@@ -410,7 +410,7 @@ access pattern as the flattened array example above:
     gx[pinfo.order[1]] -=  pinfo.halo_extents[pinfo.order[1]];
     gx[pinfo.order[2]] -=  pinfo.halo_extents[pinfo.order[2]];
 
-    data[i] = gx[0] + gx[1] + gx[2];
+    data[l] = gx[0] + gx[1] + gx[2];
 
   }
 

--- a/examples/cc/basic_usage/basic_usage.cu
+++ b/examples/cc/basic_usage/basic_usage.cu
@@ -70,7 +70,7 @@ __global__ void initialize_pencil(double* data, cudecompPencilInfo_t pinfo) {
 
   int64_t l = blockIdx.x * blockDim.x + threadIdx.x;
 
-  if (l > pinfo.size) return;
+  if (l >= pinfo.size) return;
 
   int i = l % pinfo.shape[0];
   int j = l / pinfo.shape[0] % pinfo.shape[1];
@@ -85,7 +85,7 @@ __global__ void initialize_pencil(double* data, cudecompPencilInfo_t pinfo) {
   gx[pinfo.order[1]] -= pinfo.halo_extents[pinfo.order[1]];
   gx[pinfo.order[2]] -= pinfo.halo_extents[pinfo.order[2]];
 
-  data[i] = gx[0] + gx[1] + gx[2];
+  data[l] = gx[0] + gx[1] + gx[2];
 }
 
 int main(int argc, char** argv) {

--- a/examples/cc/basic_usage/basic_usage_autotune.cu
+++ b/examples/cc/basic_usage/basic_usage_autotune.cu
@@ -70,7 +70,7 @@ __global__ void initialize_pencil(double* data, cudecompPencilInfo_t pinfo) {
 
   int64_t l = blockIdx.x * blockDim.x + threadIdx.x;
 
-  if (l > pinfo.size) return;
+  if (l >= pinfo.size) return;
 
   int i = l % pinfo.shape[0];
   int j = l / pinfo.shape[0] % pinfo.shape[1];
@@ -85,7 +85,7 @@ __global__ void initialize_pencil(double* data, cudecompPencilInfo_t pinfo) {
   gx[pinfo.order[1]] -= pinfo.halo_extents[pinfo.order[1]];
   gx[pinfo.order[2]] -= pinfo.halo_extents[pinfo.order[2]];
 
-  data[i] = gx[0] + gx[1] + gx[2];
+  data[l] = gx[0] + gx[1] + gx[2];
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

This fixes the CUDA `initialize_pencil` example kernel used by the basic usage examples.

The kernel computes a flattened pencil element index as `l`, but wrote initialized values through `data[i]`. That means threads with the same first-dimension coordinate race on the same buffer slots, while most of the pencil allocation is left untouched.

This PR updates the device initialization path to store through `data[l]`, matching the host-side flattened loop already shown in the example. It also tightens the guard to `l >= pinfo.size` so the extra threads from the rounded-up launch do not write past the valid pencil range. The documentation snippet is updated to match the source examples.

## Validation

- `git diff --check`
- Searched the touched example/docs scope to confirm the old `data[i]` store and `l > pinfo.size` guard are gone

I could not build or run the CUDA/MPI example locally because this machine does not have `nvcc` or `mpicxx` installed.