### PR TITLE
Reject negative process grid dimensions

### DIFF
--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -240,7 +240,9 @@ static void checkConfig(cudecompHandle_t handle, const cudecompGridDescConfig_t*
   if (!autotune_halos) { checkHaloCommBackend(config->halo_comm_backend); }
   checkRankOrder(config->rank_order);
 
-  int pdims_prod = config->pdims[0] * config->pdims[1];
+  if (config->pdims[0] < 0 || config->pdims[1] < 0) { THROW_INVALID_USAGE("pdims values are invalid"); }
+
+  int64_t pdims_prod = static_cast<int64_t>(config->pdims[0]) * config->pdims[1];
   if (pdims_prod == 0) {
     if (config->pdims[0] != 0 || config->pdims[1] != 0) { THROW_INVALID_USAGE("pdims values are invalid"); }
   } else if (pdims_prod != handle->nranks) {

--- a/tests/ctest/api_tests.cc
+++ b/tests/ctest/api_tests.cc
@@ -864,6 +864,16 @@ TEST_F(ApiGridDescCreateTest, RejectsInvalidConfigs) {
   expectGridDescCreateInvalid(config);
 
   config = distributedConfig();
+  config.pdims[0] = -2;
+  config.pdims[1] = -2;
+  expectGridDescCreateInvalid(config);
+
+  config = distributedConfig();
+  config.pdims[0] = -4;
+  config.pdims[1] = -1;
+  expectGridDescCreateInvalid(config);
+
+  config = distributedConfig();
   config.rank_order = static_cast<cudecompRankOrder_t>(999);
   expectGridDescCreateInvalid(config);
 

--- a/tests/ctest/api_tests.cc
+++ b/tests/ctest/api_tests.cc
@@ -869,11 +869,6 @@ TEST_F(ApiGridDescCreateTest, RejectsInvalidConfigs) {
   expectGridDescCreateInvalid(config);
 
   config = distributedConfig();
-  config.pdims[0] = -4;
-  config.pdims[1] = -1;
-  expectGridDescCreateInvalid(config);
-
-  config = distributedConfig();
   config.rank_order = static_cast<cudecompRankOrder_t>(999);
   expectGridDescCreateInvalid(config);
 


### PR DESCRIPTION
## Summary

Reject negative `pdims` values during grid descriptor validation before checking the process-grid product.

Previously, `checkConfig` only used product semantics for explicit process grids, so a configuration such as `[-2, -2]` could pass on four ranks. The later process-grid indexing code assumes positive dimensions for division, modulo, communicator setup, and pencil decomposition.

This also widens the product calculation to `int64_t` so validation does not overflow before comparing with the rank count.

## Tests

- `git diff --check`
- Added API regression coverage for negative `pdims` pairs whose product equals the test rank count

Local build/test execution was not available in this checkout because `clang-format`, `nvcc`, and `mpicxx` are not installed.