### PR TITLE
Allow null halo periods for non-periodic halos.

### DIFF
--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -598,7 +598,8 @@ cudecompResult_t cudecompUpdateHalosX(cudecompHandle_t handle, cudecompGridDesc_
  * i-th global domain axis. Symmetric halos are assumed (e.g. a value of one in halo_extents means there are 2 halo
  * elements, one element on each side)
  * @param[in] halo_periods An array of three booleans to define halo periodicity of the input data, in global order.
- * If the i-th entry in this array is true, the domain is treated periodically along the i-th global domain axis.
+ * If the i-th entry in this array is true, the domain is treated periodically along the i-th global domain axis. A NULL
+ * pointer can be provided if none of the domain axes are periodic.
  * @param[in] dim Which pencil dimension (global indexed) to perform the halo update
  * @param[in] padding An array of three integers to define padding of the input data, in global order. The i-th entry
  * in this array should contain the number of elements to treat as padding in the i-th global domain axis. If the input
@@ -624,7 +625,8 @@ cudecompResult_t cudecompUpdateHalosY(cudecompHandle_t handle, cudecompGridDesc_
  * i-th global domain axis. Symmetric halos are assumed (e.g. a value of one in halo_extents means there are 2 halo
  * elements, one element on each side)
  * @param[in] halo_periods An array of three booleans to define halo periodicity of the input data, in global order.
- * If the i-th entry in this array is true, the domain is treated periodically along the i-th global domain axis.
+ * If the i-th entry in this array is true, the domain is treated periodically along the i-th global domain axis. A NULL
+ * pointer can be provided if none of the domain axes are periodic.
  * @param[in] dim Which pencil dimension (global indexed) to perform the halo update
  * @param[in] padding An array of three integers to define padding of the input data, in global order. The i-th entry
  * in this array should contain the number of elements to treat as padding in the i-th global domain axis. If the input

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -1647,7 +1647,6 @@ cudecompResult_t cudecompUpdateHalosX(cudecompHandle_t handle, cudecompGridDesc_
       // No halos, quick return.
       return CUDECOMP_RESULT_SUCCESS;
     }
-    if (!halo_periods) { THROW_INVALID_USAGE("halo_periods argument cannot be null"); }
     if (!input) { THROW_INVALID_USAGE("input argument cannot be null"); }
     if (!work) { THROW_INVALID_USAGE("work argument cannot be null"); }
     if (dim < 0 || dim > 2) { THROW_INVALID_USAGE("dim argument out of range"); }
@@ -1690,7 +1689,6 @@ cudecompResult_t cudecompUpdateHalosY(cudecompHandle_t handle, cudecompGridDesc_
       // No halos, quick return.
       return CUDECOMP_RESULT_SUCCESS;
     }
-    if (!halo_periods) { THROW_INVALID_USAGE("halo_periods argument cannot be null"); }
     if (!input) { THROW_INVALID_USAGE("input argument cannot be null"); }
     if (!work) { THROW_INVALID_USAGE("work argument cannot be null"); }
     if (dim < 0 || dim > 2) { THROW_INVALID_USAGE("dim argument out of range"); }
@@ -1733,7 +1731,6 @@ cudecompResult_t cudecompUpdateHalosZ(cudecompHandle_t handle, cudecompGridDesc_
       // No halos, quick return.
       return CUDECOMP_RESULT_SUCCESS;
     }
-    if (!halo_periods) { THROW_INVALID_USAGE("halo_periods argument cannot be null"); }
     if (!input) { THROW_INVALID_USAGE("input argument cannot be null"); }
     if (!work) { THROW_INVALID_USAGE("work argument cannot be null"); }
     if (dim < 0 || dim > 2) { THROW_INVALID_USAGE("dim argument out of range"); }

--- a/tests/ctest/api_tests.cc
+++ b/tests/ctest/api_tests.cc
@@ -1229,9 +1229,6 @@ TEST_F(ApiHaloTest, RejectsInvalidArguments) {
             cudecompUpdateHalosX(handle_, grid_desc, valid_pointer, valid_pointer, CUDECOMP_FLOAT, nullptr,
                                  kHaloPeriods.data(), 0, nullptr, 0));
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
-            cudecompUpdateHalosX(handle_, grid_desc, valid_pointer, valid_pointer, CUDECOMP_FLOAT, kHaloExtents.data(),
-                                 nullptr, 0, nullptr, 0));
-  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
             cudecompUpdateHalosX(handle_, grid_desc, nullptr, valid_pointer, CUDECOMP_FLOAT, kHaloExtents.data(),
                                  kHaloPeriods.data(), 0, nullptr, 0));
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,


### PR DESCRIPTION
The C++ API documentation for the `cudecompUpdateHalos*` functions has inconsistent statements about if the `halo_periods` argument can be `NULL` to default to non-periodic halos. This PR updates the documentation to consistently state that a `NULL` argument is allowed and defaults to non-periodic halos. It also updates the implementation and tests accordingly. 