### PR TITLE
Fix pipelined transpose empty rank skips

### DIFF
--- a/include/internal/comm_routines.h
+++ b/include/internal/comm_routines.h
@@ -445,6 +445,7 @@ cudecompAlltoallPipelined(const cudecompHandle_t& handle, const cudecompGridDesc
                           cudecompTransposePerformanceSample* current_sample = nullptr) {
 
   // If there are no transfers to complete, quick return
+  if (src_ranks.empty()) { return; }
   if (send_counts.size() == 0 && recv_counts.size() == 0) { return; }
 
   std::ostringstream os;


### PR DESCRIPTION
## Summary
- Return early from pipelined all-to-all when there are no source ranks, avoiding performance-report access to an empty rank list after paired pipelined transfers clear the vectors.

## Validation
- `git diff --check`