### PR TITLE
Avoid NVSHMEM device header parsing in non-RDC CUDA translation units.

### DIFF
--- a/include/internal/cudecomp_kernels.cuh
+++ b/include/internal/cudecomp_kernels.cuh
@@ -22,11 +22,22 @@
 #include <cstddef>
 #include <cstdint>
 
+// Keep NVSHMEM device headers out of non-RDC CUDA translation units.
+#if defined(ENABLE_NVSHMEM) && defined(CUDECOMP_NVSHMEM_HOST_ONLY) && !defined(NVSHMEM_HOSTLIB_ONLY)
+#define CUDECOMP_UNDEF_NVSHMEM_HOSTLIB_ONLY
+#define NVSHMEM_HOSTLIB_ONLY
+#endif
+
 #ifdef ENABLE_NVSHMEM
 #include <nvshmem.h>
 #endif
 
 #include "internal/cudecomp_kernels.h"
+
+#ifdef CUDECOMP_UNDEF_NVSHMEM_HOSTLIB_ONLY
+#undef NVSHMEM_HOSTLIB_ONLY
+#undef CUDECOMP_UNDEF_NVSHMEM_HOSTLIB_ONLY
+#endif
 
 #define CUDECOMP_CUDA_NTHREADS (128)
 #define CUDECOMP_UNROLL_FACTOR (4)
@@ -36,7 +47,7 @@
 
 namespace cudecomp {
 
-#ifdef ENABLE_NVSHMEM
+#if defined(ENABLE_NVSHMEM) && !defined(CUDECOMP_NVSHMEM_HOST_ONLY)
 template <typename T>
 __launch_bounds__(CUDECOMP_CUDA_NTHREADS) __global__
     void cudecomp_nvshmem_alltoallv_k(cudecompNvshmemA2AParams<T> params) {

--- a/src/cudecomp_kernels.cu
+++ b/src/cudecomp_kernels.cu
@@ -18,7 +18,11 @@
 #include <cuda/std/complex>
 
 #include "internal/checks.h"
+
+// This non-RDC translation unit only instantiates generic CUDA kernels.
+#define CUDECOMP_NVSHMEM_HOST_ONLY
 #include "internal/cudecomp_kernels.cuh"
+#undef CUDECOMP_NVSHMEM_HOST_ONLY
 
 namespace cudecomp {
 


### PR DESCRIPTION
Recent versions of NVSHMEM (3.6+, included in NVHPC 26.5) break cuDecomp builds due to changes in device API handing in `nvshmem.h` when included in a file not compiled with RDC. This updates the non-RDC `cudecomp_kernels.cu` path to include NVSHMEM in host-library-only mode. Newer NVSHMEM headers no longer provide the non-RDC fallback device state declarations that older NVSHMEM releases did, so parsing the full device API from a non-RDC translation unit triggers a cascade of compile errors.

The fix adds a cuDecomp-local `CUDECOMP_NVSHMEM_HOST_ONLY` macro around the `cudecomp_kernels.cuh` include in `cudecomp_kernels.cu`. When active, `cudecomp_kernels.cuh` temporarily defines `NVSHMEM_HOSTLIB_ONLY` while including NVSHMEM and related cuDecomp headers, and skips the NVSHMEM device kernel templates. The RDC translation unit remains unchanged and still sees the full NVSHMEM device API.