### PR TITLE
Address iso_c_binding warning in Fortran Poisson example.

### DIFF
--- a/examples/fortran/poisson/poisson.f90
+++ b/examples/fortran/poisson/poisson.f90
@@ -52,7 +52,8 @@ program main
   real(8), allocatable :: kx(:), ky(:), kz(:)
   real(8), device, allocatable :: kx_d(:), ky_d(:), kz_d(:)
 
-  complex(8), allocatable :: phi(:), ua(:,:,:)
+  complex(8), allocatable, target :: phi(:)
+  complex(8), allocatable :: ua(:,:,:)
   complex(8), device, allocatable :: phi_d(:)
   complex(8), pointer, device, contiguous :: work_d(:)
 


### PR DESCRIPTION
The most recent NVHPC compiler started producing warnings when compiling the Fortran Poisson example:
```
NVFORTRAN-W-0468-Argument to ISO_C_BINDING intrinsic  must have TARGET or POINTER attribute set
```

 This PR adds the required `target` attribute to the `phi` array which is used in the `c_loc` intrinsic.