### PR TITLE
Fix erroneous MPI_Bcast sizing in autotune.cc and remove O1 optimization cap.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,6 @@ endif()
 string(REPLACE "compilers/bin/nvc++" "cmake" NVHPC_CMAKE_DIR ${NVHPC_CXX_BIN})
 set(CMAKE_PREFIX_PATH ${NVHPC_CMAKE_DIR})
 
-# Limit optimization levels of CPU code compilation
-set(CMAKE_CXX_FLAGS_RELEASE "-O1 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O1 -g -DNDEBUG")
-set(CMAKE_Fortran_FLAGS_RELEASE "-O1 -DNDEBUG")
-# Note: Removing "-g" flag from Fortran RelWithDebInfo to enable mixed compilation with cc100 and older compute capabilities
-set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O1 -DNDEBUG")
-
 if (CUDECOMP_BUILD_FORTRAN)
   set(LANGS CXX CUDA Fortran)
 else()
@@ -49,6 +42,12 @@ else()
 endif()
 
 project(cudecomp LANGUAGES ${LANGS})
+
+if (CUDECOMP_BUILD_FORTRAN)
+  # Remove debug information to enable mixed Fortran compilation with cc100 and older compute capabilities.
+  string(REGEX REPLACE "(^| )-g(opt)?($| )" "\\3" CMAKE_Fortran_FLAGS_RELWITHDEBINFO
+                       "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}")
+endif()
 
 # Set up CUDA compute capabilities by CUDA version. Users can override defaults with CUDECOMP_CUDA_CC_LIST
 if (NOT CUDECOMP_CUDA_CC_LIST)

--- a/src/autotune.cc
+++ b/src/autotune.cc
@@ -588,7 +588,7 @@ void autotuneTransposeBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_d
 
   // Set handle to best option (broadcast from rank 0 for consistency)
   CHECK_MPI(MPI_Bcast(&comm_backend_best, sizeof(cudecompTransposeCommBackend_t), MPI_CHAR, 0, handle->mpi_comm));
-  CHECK_MPI(MPI_Bcast(pdims_best, 2 * sizeof(int), MPI_INT, 0, handle->mpi_comm));
+  CHECK_MPI(MPI_Bcast(pdims_best, 2, MPI_INT, 0, handle->mpi_comm));
 
   grid_desc->config.transpose_comm_backend = comm_backend_best;
   grid_desc->config.pdims[0] = pdims_best[0];
@@ -966,7 +966,7 @@ void autotuneHaloBackend(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
 
   // Set handle to best option (broadcast from rank 0 for consistency)
   CHECK_MPI(MPI_Bcast(&comm_backend_best, sizeof(cudecompHaloCommBackend_t), MPI_CHAR, 0, handle->mpi_comm));
-  CHECK_MPI(MPI_Bcast(pdims_best, 2 * sizeof(int), MPI_INT, 0, handle->mpi_comm));
+  CHECK_MPI(MPI_Bcast(pdims_best, 2, MPI_INT, 0, handle->mpi_comm));
 
   grid_desc->config.halo_comm_backend = comm_backend_best;
   grid_desc->config.pdims[0] = pdims_best[0];


### PR DESCRIPTION
This PR removes a legacy -O1 optimization cap applied to host code compilation. This limitation was driven by historic issues with `autotune.cc` segfaulting at higher optimizations levels. Codex determined it was due to erroneous counts used in an `MPI_Bcast` operation in this file, causing an out-of-bounds stack write. At -O1, the stack arrangement made this benign which is why that workaround always worked. This PR finally fixes the issue and enables higher optimization.