### PR TITLE
Harden public struct ABI for future extensions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,22 @@ else()
   set(LANGS CXX CUDA)
 endif()
 
-project(cudecomp LANGUAGES ${LANGS})
+set(CUDECOMP_VERSION_COMPONENTS)
+foreach(COMPONENT MAJOR MINOR PATCH)
+  file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp_version.h CUDECOMP_VERSION_LINE
+       REGEX "^#define CUDECOMP_${COMPONENT} [0-9]+$")
+  if (NOT CUDECOMP_VERSION_LINE)
+    message(FATAL_ERROR "Failed to read CUDECOMP_${COMPONENT} from include/cudecomp_version.h")
+  endif()
+  string(REGEX MATCH "[0-9]+$" CUDECOMP_VERSION_COMPONENT ${CUDECOMP_VERSION_LINE})
+  list(APPEND CUDECOMP_VERSION_COMPONENTS ${CUDECOMP_VERSION_COMPONENT})
+endforeach()
+list(JOIN CUDECOMP_VERSION_COMPONENTS "." CUDECOMP_VERSION)
+
+# Increment only when a release breaks binary compatibility.
+set(CUDECOMP_SOVERSION 0)
+
+project(cudecomp VERSION ${CUDECOMP_VERSION} LANGUAGES ${LANGS})
 
 if (CUDECOMP_BUILD_FORTRAN)
   # Remove debug information to enable mixed Fortran compilation with cc100 and older compute capabilities.
@@ -152,7 +167,12 @@ endif()
 
 # Building cuDecomp shared lib
 add_library(cudecomp SHARED)
-set_target_properties(cudecomp PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set_target_properties(
+  cudecomp
+  PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+             VERSION ${PROJECT_VERSION}
+             SOVERSION ${CUDECOMP_SOVERSION}
+)
 
 # Set NVCC flags for requested compute capability
 if (CMAKE_VERSION VERSION_LESS 3.18)
@@ -254,8 +274,13 @@ if (CUDECOMP_ENABLE_NVSHMEM)
   endif()
 endif()
 
-set_target_properties(cudecomp PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp.h)
+set_target_properties(
+  cudecomp
+  PROPERTIES PUBLIC_HEADER
+             "${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp.h;${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp_version.h"
+)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp.h ${CMAKE_BINARY_DIR}/include/cudecomp.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/cudecomp_version.h ${CMAKE_BINARY_DIR}/include/cudecomp_version.h)
 
 install(
   TARGETS cudecomp
@@ -273,9 +298,14 @@ if (CUDECOMP_BUILD_FORTRAN)
   list(JOIN CUF_GPU_ARG "," CUF_GPU_ARG)
 
   add_library(cudecomp_fort SHARED)
-  set_target_properties(cudecomp_fort PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-  set_target_properties(cudecomp_fort PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include)
-  set_target_properties(cudecomp_fort PROPERTIES LINKER_LANGUAGE Fortran)
+  set_target_properties(
+    cudecomp_fort
+    PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+               Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include
+               LINKER_LANGUAGE Fortran
+               VERSION ${PROJECT_VERSION}
+               SOVERSION ${CUDECOMP_SOVERSION}
+  )
   target_compile_options(cudecomp_fort PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-cpp -cuda -gpu=${CUF_GPU_ARG}>)
   target_sources(
     cudecomp_fort
@@ -290,8 +320,12 @@ if (CUDECOMP_BUILD_FORTRAN)
     TARGETS cudecomp_fort
     LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
    )
-   # Install cuDecomp module
-   install(FILES ${CMAKE_BINARY_DIR}/include/cudecomp.mod DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+   # Install cuDecomp modules
+   install(
+     FILES ${CMAKE_BINARY_DIR}/include/cudecomp.mod
+           ${CMAKE_BINARY_DIR}/include/cudecomp_internal.mod
+     DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+   )
 endif()
 
 if (CUDECOMP_BUILD_TESTS OR CUDECOMP_BUILD_EXTRAS)

--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -44,6 +44,9 @@ ________________________
 
   A data structure defining configuration options for grid descriptor creation.
 
+  Call :f:func:`cudecompGridDescConfigSetDefaults` before first passing an instance to
+  :f:func:`cudecompGridDescCreate`. Public fields may be modified and initialized instances may be copied afterward.
+
   :f integer gdims(3): dimensions of global data grid
   :f integer gdims_dist(3): dimensions of global data grid to use for distribution
   :f integer pdims(2): dimensions of process grid
@@ -64,6 +67,9 @@ _________________________________
 .. f:type:: cudecompGridDescAutotuneOptions
 
   A data structure defining autotuning options for grid descriptor creation.
+
+  Call :f:func:`cudecompGridDescAutotuneOptionsSetDefaults` before first passing an instance to
+  :f:func:`cudecompGridDescCreate`. Public fields may be modified and initialized instances may be copied afterward.
 
   :f integer n_warmup_trials: number of warmup trials to run for each tested configuration during autotuning
   :f integer n_trials: number of timed trials to run for each tested configuration during autotuning

--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -69,7 +69,10 @@ the autotuning process.
 In addition to this modification of :code:`pdims`, an autotuning options structure, :ref:`cudecompGridDescAutotuneOptions_t-ref` must be created,
 populated, and passed as an additional argument to :ref:`cudecompGridDescCreate-ref`.
 
-Create an uninitialized autotune option struct and initialize it to defaults using :ref:`cudecompGridDescAutotuneOptionsSetDefaults-ref`. Initializing this struct to default values is required to ensure no entries are left uninitialized.
+Create an uninitialized autotune options struct and initialize it to defaults using
+:ref:`cudecompGridDescAutotuneOptionsSetDefaults-ref`. This initialization is required before the options are first
+passed to :ref:`cudecompGridDescCreate-ref`. After initialization, its public fields may be modified and the initialized
+structure may be copied.
 
 .. tabs::
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -54,8 +54,10 @@ Creating a grid descriptor
 Next, we need to create a grid descriptor. To do this, we first need to create and populate a grid descriptor
 configuration structure, which provides basic information to the library required to set up the grid descriptor.
 
-We create an uninitialized configuration struct and initialize it to defaults using :ref:`cudecompGridDescConfigSetDefaults-ref`.
-Initializing to default values is required to ensure no entries are left uninitialized.
+We create an uninitialized configuration struct and initialize it to defaults using
+:ref:`cudecompGridDescConfigSetDefaults-ref`. This initialization is required before the configuration is first passed
+to :ref:`cudecompGridDescCreate-ref`. After initialization, its public fields may be modified and the initialized
+structure may be copied.
 
 .. tabs::
 

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -30,9 +30,13 @@
 #include <cuda_runtime.h>
 #include <mpi.h>
 
-#define CUDECOMP_MAJOR 0
-#define CUDECOMP_MINOR 6
-#define CUDECOMP_PATCH 2
+#include "cudecomp_version.h"
+
+/** @cond */
+#define CUDECOMP_GRID_DESC_CONFIG_MAGIC INT32_C(0x434f4e46)
+#define CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_MAGIC INT32_C(0x4155544f)
+#define CUDECOMP_PENCIL_INFO_MAGIC INT32_C(0x50494e46)
+/** @endcond */
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,6 +126,12 @@ typedef struct cudecompGridDesc* cudecompGridDesc_t;
  * @brief A data structure defining configuration options for grid descriptor creation.
  */
 typedef struct {
+  /** @cond */
+  int64_t struct_size;
+  int32_t magic;
+  int32_t version;
+  /** @endcond */
+
   // Grid information
   int32_t gdims[3];               ///< dimensions of global data grid
   int32_t gdims_dist[3];          ///< dimensions of global data grid to use for distribution
@@ -148,6 +158,12 @@ typedef struct {
  * @brief A data structure defining autotuning options for grid descriptor creation.
  */
 typedef struct {
+  /** @cond */
+  int64_t struct_size;
+  int32_t magic;
+  int32_t version;
+  /** @endcond */
+
   // General options
   int32_t n_warmup_trials; ///< number of warmup trials to run for each tested configuration during autotuning
                            ///< (default: 3)
@@ -206,6 +222,12 @@ typedef struct {
  * @brief A data structure containing geometry information about a pencil data buffer.
  */
 typedef struct {
+  /** @cond */
+  int64_t struct_size;
+  int32_t magic;
+  int32_t version;
+  /** @endcond */
+
   int32_t shape[3];        ///< pencil shape (in local order, including halo and padding elements)
   int32_t lo[3];           ///< lower bound coordinates (in local order, excluding halo and padding elements)
   int32_t hi[3];           ///< upper bound coordinates (in local order, excluding halo and padding elements)
@@ -246,6 +268,14 @@ cudecompResult_t cudecompInit_F(cudecompHandle_t* handle, MPI_Fint mpi_comm_f);
 cudecompResult_t cudecompFinalize(cudecompHandle_t handle);
 
 // cudecompGridDesc_t creation/manipulation functions
+/** @cond */
+cudecompResult_t cudecompGridDescCreateVersioned(cudecompHandle_t handle, cudecompGridDesc_t* grid_desc,
+                                                 cudecompGridDescConfig_t* config, int64_t config_struct_size,
+                                                 int32_t config_version,
+                                                 const cudecompGridDescAutotuneOptions_t* options,
+                                                 int64_t options_struct_size, int32_t options_version);
+/** @endcond */
+
 /**
  * @brief Creates a cuDecomp grid descriptor for use with cuDecomp functions.
  * @details This function creates a grid descriptor that cuDecomp requires for most library operations that perform
@@ -253,18 +283,24 @@ cudecompResult_t cudecompFinalize(cudecompHandle_t handle);
  * the global data grid is distributed and other internal resources to facilitate communication.
  * @param[in] handle The initialized cuDecomp library handle
  * @param[out] grid_desc A pointer to an uninitialized cudecompGridDesc_t
- * @param[in,out] config A pointer to a populated cudecompGridDescConfig_t structure. This config structure defines
- * the required attributes of the decomposition. On successful exit, fields in this structure may be updated to reflect
- * autotuning results.
- * @param[in] options A pointer to cudecompGridDescAutotuneOptions_t structure. This options structure is used
- * to control the behavior of the process grid and communication backend autotuning. If autotuning is not desired, a
- * NULL pointer can be passed in for this argument.
+ * @param[in,out] config A pointer to a cudecompGridDescConfig_t structure initialized by
+ * cudecompGridDescConfigSetDefaults(). After initialization, callers may modify its public fields. On successful exit,
+ * fields in this structure may be updated to reflect autotuning results.
+ * @param[in] options A pointer to a cudecompGridDescAutotuneOptions_t structure initialized by
+ * cudecompGridDescAutotuneOptionsSetDefaults(). After initialization, callers may modify its public fields. If
+ * autotuning is not desired, a NULL pointer can be passed in for this argument.
  *
  * @return CUDECOMP_RESULT_SUCCESS on success or error code on failure.
  */
-cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDesc_t* grid_desc,
-                                        cudecompGridDescConfig_t* config,
-                                        const cudecompGridDescAutotuneOptions_t* options);
+static inline cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDesc_t* grid_desc,
+                                                      cudecompGridDescConfig_t* config,
+                                                      const cudecompGridDescAutotuneOptions_t* options) {
+  return cudecompGridDescCreateVersioned(handle, grid_desc, config, (int64_t)sizeof(cudecompGridDescConfig_t),
+                                         CUDECOMP_GRID_DESC_CONFIG_VERSION, options,
+                                         options ? (int64_t)sizeof(cudecompGridDescAutotuneOptions_t) : (int64_t)0,
+                                         options ? CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION : (int32_t)0);
+}
+
 /**
  * @brief Destroys a cuDecomp grid descriptor and frees associated resources.
  * @param[in] handle The initialized cuDecomp library handle
@@ -275,28 +311,54 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
 cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDesc_t grid_desc);
 
 // cudecompGridDescConfig_t creation/manipulation functions
+/** @cond */
+cudecompResult_t cudecompGridDescConfigSetDefaultsVersioned(cudecompGridDescConfig_t* config, int64_t struct_size,
+                                                            int32_t version);
+/** @endcond */
+
 /**
  * @brief Initializes a cudecompGridDescConfig_t structure with default values
- * @details This function initializes entries in a cuDecomp grid descriptor configuration structure to default
- * values.
+ * @details This function initializes entries in a cuDecomp grid descriptor configuration structure to default values.
+ * It must be called before the structure is first passed to cudecompGridDescCreate(). After initialization, callers may
+ * modify public fields or copy the structure.
  * @param[in,out] config A pointer to cudecompGridDescConfig_t structure
  *
  * @return CUDECOMP_RESULT_SUCCESS on success or error code on failure.
  */
-cudecompResult_t cudecompGridDescConfigSetDefaults(cudecompGridDescConfig_t* config);
+static inline cudecompResult_t cudecompGridDescConfigSetDefaults(cudecompGridDescConfig_t* config) {
+  return cudecompGridDescConfigSetDefaultsVersioned(config, (int64_t)sizeof(cudecompGridDescConfig_t),
+                                                    CUDECOMP_GRID_DESC_CONFIG_VERSION);
+}
 
 // cudecompGridDescAutotuneOptions_t creation/manipulation functions
+/** @cond */
+cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaultsVersioned(cudecompGridDescAutotuneOptions_t* options,
+                                                                     int64_t struct_size, int32_t version);
+/** @endcond */
+
 /**
  * @brief Initializes a cudecompGridDescAutotuneOptions_t structure with default values
  * @details This function initializes entries in a cuDecomp grid descriptor autotune options structure to default
- * values.
+ * values. It must be called before the structure is first passed to cudecompGridDescCreate(). After initialization,
+ * callers may modify public fields or copy the structure.
  * @param[in,out] options A pointer to cudecompGridDescAutotuneOptions_t structure
  *
  * @return CUDECOMP_RESULT_SUCCESS on success or error code on failure.
  */
-cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAutotuneOptions_t* options);
+static inline cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAutotuneOptions_t* options) {
+  return cudecompGridDescAutotuneOptionsSetDefaultsVersioned(options,
+                                                             (int64_t)sizeof(cudecompGridDescAutotuneOptions_t),
+                                                             CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION);
+}
 
 // General functions
+/** @cond */
+cudecompResult_t cudecompGetPencilInfoVersioned(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                                cudecompPencilInfo_t* pencil_info, int64_t pencil_info_struct_size,
+                                                int32_t pencil_info_version, int32_t axis, const int32_t halo_extents[],
+                                                const int32_t padding[]);
+/** @endcond */
+
 /**
  * @brief Collects geometry information about assigned pencils, by domain axis
  * @details This function queries information about the pencil assigned to the calling worker for the given axis.
@@ -316,9 +378,12 @@ cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAuto
  *
  * @return CUDECOMP_RESULT_SUCCESS on success or error code on failure.
  */
-cudecompResult_t cudecompGetPencilInfo(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
-                                       cudecompPencilInfo_t* pencil_info, int32_t axis, const int32_t halo_extents[],
-                                       const int32_t padding[]);
+static inline cudecompResult_t cudecompGetPencilInfo(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                                     cudecompPencilInfo_t* pencil_info, int32_t axis,
+                                                     const int32_t halo_extents[], const int32_t padding[]) {
+  return cudecompGetPencilInfoVersioned(handle, grid_desc, pencil_info, (int64_t)sizeof(cudecompPencilInfo_t),
+                                        CUDECOMP_PENCIL_INFO_VERSION, axis, halo_extents, padding);
+}
 
 /**
  * @brief Queries the required transpose workspace size, in elements, for a provided grid descriptor.
@@ -413,6 +478,12 @@ const char* cudecompTransposeCommBackendToString(cudecompTransposeCommBackend_t 
  */
 const char* cudecompHaloCommBackendToString(cudecompHaloCommBackend_t comm_backend);
 
+/** @cond */
+cudecompResult_t cudecompGetGridDescConfigVersioned(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                                    cudecompGridDescConfig_t* config, int64_t struct_size,
+                                                    int32_t version);
+/** @endcond */
+
 /**
  * @brief Queries the configuration used to create a grid descriptor.
  * @param[in] handle The initialized cuDecomp library handle
@@ -421,8 +492,11 @@ const char* cudecompHaloCommBackendToString(cudecompHaloCommBackend_t comm_backe
  *
  * @return CUDECOMP_RESULT_SUCCESS on success or error code on failure.
  */
-cudecompResult_t cudecompGetGridDescConfig(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
-                                           cudecompGridDescConfig_t* config);
+static inline cudecompResult_t cudecompGetGridDescConfig(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                                         cudecompGridDescConfig_t* config) {
+  return cudecompGetGridDescConfigVersioned(handle, grid_desc, config, (int64_t)sizeof(cudecompGridDescConfig_t),
+                                            CUDECOMP_GRID_DESC_CONFIG_VERSION);
+}
 
 /**
  * @brief Function to retrieve the global rank of neighboring processes

--- a/include/cudecomp_version.h
+++ b/include/cudecomp_version.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CUDECOMP_VERSION_H
+#define CUDECOMP_VERSION_H
+
+#define CUDECOMP_MAJOR 0
+#define CUDECOMP_MINOR 6
+#define CUDECOMP_PATCH 2
+
+#define CUDECOMP_GRID_DESC_CONFIG_VERSION 1
+#define CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION 1
+#define CUDECOMP_PENCIL_INFO_VERSION 1
+
+#endif // CUDECOMP_VERSION_H

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -206,6 +206,207 @@ static void checkGridDesc(cudecompHandle_t handle, cudecompGridDesc_t grid_desc)
   if (grid_desc->handle != handle) { THROW_INVALID_USAGE("grid descriptor belongs to a different handle"); }
 }
 
+static int64_t expectedConfigSizeForVersion(int32_t version) {
+  if (version > CUDECOMP_GRID_DESC_CONFIG_VERSION) {
+    THROW_INVALID_USAGE("config was initialized with a newer cuDecomp header than this runtime library supports");
+  }
+
+  switch (version) {
+  case 1: {
+    constexpr int64_t size = 104;
+    static_assert(CUDECOMP_GRID_DESC_CONFIG_VERSION != 1 ||
+                      static_cast<int64_t>(sizeof(cudecompGridDescConfig_t)) == size,
+                  "config version 1 ABI size changed");
+    return size;
+  }
+  default: THROW_INVALID_USAGE("config layout version is unsupported");
+  }
+}
+
+static int64_t expectedConfigPayloadSizeForVersion(int32_t version) {
+  switch (version) {
+  case 1:
+    return static_cast<int64_t>(offsetof(cudecompGridDescConfig_t, halo_comm_backend) +
+                                sizeof(cudecompGridDescConfig_t::halo_comm_backend));
+  default: THROW_INVALID_USAGE("config layout version is unsupported");
+  }
+}
+
+static int64_t expectedAutotuneOptionsSizeForVersion(int32_t version) {
+  if (version > CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION) {
+    THROW_INVALID_USAGE("options were initialized with a newer cuDecomp header than this runtime library supports");
+  }
+
+  switch (version) {
+  case 1: {
+    constexpr int64_t size = 320;
+    static_assert(CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION != 1 ||
+                      static_cast<int64_t>(sizeof(cudecompGridDescAutotuneOptions_t)) == size,
+                  "autotune options version 1 ABI size changed");
+    return size;
+  }
+  default: THROW_INVALID_USAGE("options layout version is unsupported");
+  }
+}
+
+static int64_t expectedAutotuneOptionsPayloadSizeForVersion(int32_t version) {
+  switch (version) {
+  case 1:
+    return static_cast<int64_t>(offsetof(cudecompGridDescAutotuneOptions_t, halo_padding) +
+                                sizeof(cudecompGridDescAutotuneOptions_t::halo_padding));
+  default: THROW_INVALID_USAGE("options layout version is unsupported");
+  }
+}
+
+static int64_t expectedPencilInfoSizeForVersion(int32_t version) {
+  if (version > CUDECOMP_PENCIL_INFO_VERSION) {
+    THROW_INVALID_USAGE("pencil_info was created with a newer cuDecomp header than this runtime library supports");
+  }
+
+  switch (version) {
+  case 1: {
+    constexpr int64_t size = 96;
+    static_assert(CUDECOMP_PENCIL_INFO_VERSION != 1 || static_cast<int64_t>(sizeof(cudecompPencilInfo_t)) == size,
+                  "pencil info version 1 ABI size changed");
+    return size;
+  }
+  default: THROW_INVALID_USAGE("pencil_info layout version is unsupported");
+  }
+}
+
+static int64_t expectedPencilInfoPayloadSizeForVersion(int32_t version) {
+  switch (version) {
+  case 1: return static_cast<int64_t>(offsetof(cudecompPencilInfo_t, size) + sizeof(cudecompPencilInfo_t::size));
+  default: THROW_INVALID_USAGE("pencil_info layout version is unsupported");
+  }
+}
+
+static void checkConfigStruct(const cudecompGridDescConfig_t* config) {
+  if (config->magic != CUDECOMP_GRID_DESC_CONFIG_MAGIC) { THROW_INVALID_USAGE("config magic is invalid"); }
+  if (config->struct_size != expectedConfigSizeForVersion(config->version)) {
+    THROW_INVALID_USAGE("config struct_size does not match its cuDecomp layout version");
+  }
+}
+
+static void checkAutotuneOptionsStruct(const cudecompGridDescAutotuneOptions_t* options) {
+  if (options->magic != CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_MAGIC) { THROW_INVALID_USAGE("options magic is invalid"); }
+  if (options->struct_size != expectedAutotuneOptionsSizeForVersion(options->version)) {
+    THROW_INVALID_USAGE("options struct_size does not match its cuDecomp layout version");
+  }
+}
+
+static void setConfigDefaults(cudecompGridDescConfig_t* config, int64_t struct_size, int32_t version) {
+  cudecompGridDescConfig_t defaults{};
+  for (int i = 0; i < 2; ++i) {
+    defaults.pdims[i] = 0;
+  }
+  for (int i = 0; i < 3; ++i) {
+    defaults.gdims[i] = 0;
+    defaults.gdims_dist[i] = 0;
+  }
+
+  defaults.transpose_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
+  for (int i = 0; i < 3; ++i) {
+    defaults.transpose_axis_contiguous[i] = false;
+    for (int j = 0; j < 3; ++j) {
+      defaults.transpose_mem_order[i][j] = -1;
+    }
+  }
+
+  defaults.rank_order = CUDECOMP_RANK_ORDER_DEFAULT;
+  defaults.halo_comm_backend = CUDECOMP_HALO_COMM_MPI;
+
+  std::memcpy(config, &defaults, static_cast<size_t>(expectedConfigPayloadSizeForVersion(version)));
+  config->struct_size = struct_size;
+  config->magic = CUDECOMP_GRID_DESC_CONFIG_MAGIC;
+  config->version = version;
+}
+
+static void setAutotuneOptionsDefaults(cudecompGridDescAutotuneOptions_t* options, int64_t struct_size,
+                                       int32_t version) {
+  cudecompGridDescAutotuneOptions_t defaults{};
+  defaults.n_warmup_trials = 3;
+  defaults.n_trials = 5;
+  defaults.grid_mode = CUDECOMP_AUTOTUNE_GRID_TRANSPOSE;
+  defaults.dtype = CUDECOMP_DOUBLE;
+  defaults.allow_uneven_decompositions = true;
+  defaults.disable_mpi_backends = false;
+  defaults.disable_nccl_backends = false;
+  defaults.disable_nvshmem_backends = false;
+  defaults.skip_threshold = 0.0;
+
+  defaults.autotune_transpose_backend = false;
+  for (int i = 0; i < 4; ++i) {
+    defaults.transpose_use_inplace_buffers[i] = false;
+    defaults.transpose_op_weights[i] = 1.0;
+    for (int j = 0; j < 3; ++j) {
+      defaults.transpose_input_halo_extents[i][j] = 0;
+      defaults.transpose_output_halo_extents[i][j] = 0;
+      defaults.transpose_input_padding[i][j] = 0;
+      defaults.transpose_output_padding[i][j] = 0;
+    }
+  }
+
+  defaults.autotune_halo_backend = false;
+  defaults.halo_axis = 0;
+  for (int i = 0; i < 3; ++i) {
+    defaults.halo_extents[i] = 0;
+    defaults.halo_periods[i] = false;
+    defaults.halo_padding[i] = 0;
+  }
+
+  std::memcpy(options, &defaults, static_cast<size_t>(expectedAutotuneOptionsPayloadSizeForVersion(version)));
+  options->struct_size = struct_size;
+  options->magic = CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_MAGIC;
+  options->version = version;
+}
+
+static cudecompGridDescConfig_t normalizeConfig(const cudecompGridDescConfig_t* config) {
+  cudecompGridDescConfig_t normalized{};
+  setConfigDefaults(&normalized, static_cast<int64_t>(sizeof(normalized)), CUDECOMP_GRID_DESC_CONFIG_VERSION);
+  std::memcpy(&normalized, config, static_cast<size_t>(expectedConfigPayloadSizeForVersion(config->version)));
+  normalized.struct_size = static_cast<int64_t>(sizeof(normalized));
+  normalized.magic = CUDECOMP_GRID_DESC_CONFIG_MAGIC;
+  normalized.version = CUDECOMP_GRID_DESC_CONFIG_VERSION;
+  return normalized;
+}
+
+static cudecompGridDescAutotuneOptions_t normalizeAutotuneOptions(const cudecompGridDescAutotuneOptions_t* options) {
+  cudecompGridDescAutotuneOptions_t normalized{};
+  setAutotuneOptionsDefaults(&normalized, static_cast<int64_t>(sizeof(normalized)),
+                             CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION);
+  std::memcpy(&normalized, options,
+              static_cast<size_t>(expectedAutotuneOptionsPayloadSizeForVersion(options->version)));
+  normalized.struct_size = static_cast<int64_t>(sizeof(normalized));
+  normalized.magic = CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_MAGIC;
+  normalized.version = CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION;
+  return normalized;
+}
+
+static void copyConfigToCaller(cudecompGridDescConfig_t* config, int64_t struct_size, int32_t version,
+                               const cudecompGridDescConfig_t& source) {
+  const int64_t config_size = expectedConfigSizeForVersion(version);
+  if (struct_size != config_size) {
+    THROW_INVALID_USAGE("config struct_size does not match its cuDecomp layout version");
+  }
+  std::memcpy(config, &source, static_cast<size_t>(expectedConfigPayloadSizeForVersion(version)));
+  config->struct_size = struct_size;
+  config->magic = CUDECOMP_GRID_DESC_CONFIG_MAGIC;
+  config->version = version;
+}
+
+static void copyPencilInfoToCaller(cudecompPencilInfo_t* pencil_info, int64_t struct_size, int32_t version,
+                                   const cudecompPencilInfo_t& source) {
+  const int64_t pencil_info_size = expectedPencilInfoSizeForVersion(version);
+  if (struct_size != pencil_info_size) {
+    THROW_INVALID_USAGE("pencil_info struct_size does not match its cuDecomp layout version");
+  }
+  std::memcpy(pencil_info, &source, static_cast<size_t>(expectedPencilInfoPayloadSizeForVersion(version)));
+  pencil_info->struct_size = struct_size;
+  pencil_info->magic = CUDECOMP_PENCIL_INFO_MAGIC;
+  pencil_info->version = version;
+}
+
 static cudecompResult_t handleException(const BaseException& e) {
   std::cerr << e.what();
   return e.getResult();
@@ -828,9 +1029,11 @@ cudecompResult_t cudecompInit_F(cudecompHandle_t* handle_in, MPI_Fint mpi_comm_f
   CUDECOMP_CATCH_C_API_ERRORS()
 }
 
-cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDesc_t* grid_desc_in,
-                                        cudecompGridDescConfig_t* config,
-                                        const cudecompGridDescAutotuneOptions_t* options) {
+cudecompResult_t cudecompGridDescCreateVersioned(cudecompHandle_t handle, cudecompGridDesc_t* grid_desc_in,
+                                                 cudecompGridDescConfig_t* config, int64_t config_struct_size,
+                                                 int32_t config_version,
+                                                 const cudecompGridDescAutotuneOptions_t* options,
+                                                 int64_t options_struct_size, int32_t options_version) {
 
   using namespace cudecomp;
   cudecompGridDesc_t grid_desc = nullptr;
@@ -842,6 +1045,30 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
     checkHandle(handle);
     if (!grid_desc_in) { THROW_INVALID_USAGE("grid_desc argument cannot be null"); }
     if (!config) { THROW_INVALID_USAGE("config argument cannot be null"); }
+    if (config_struct_size != expectedConfigSizeForVersion(config_version)) {
+      THROW_INVALID_USAGE("config struct_size does not match its cuDecomp layout version");
+    }
+    checkConfigStruct(config);
+    if (config->struct_size != config_struct_size || config->version != config_version) {
+      THROW_INVALID_USAGE("config metadata does not match the requested cuDecomp layout version");
+    }
+    cudecompGridDescConfig_t* caller_config = config;
+    const int64_t caller_config_size = config_struct_size;
+    const int32_t caller_config_version = config_version;
+    cudecompGridDescConfig_t normalized_config = normalizeConfig(config);
+    config = &normalized_config;
+    cudecompGridDescAutotuneOptions_t normalized_options;
+    if (options) {
+      if (options_struct_size != expectedAutotuneOptionsSizeForVersion(options_version)) {
+        THROW_INVALID_USAGE("options struct_size does not match its cuDecomp layout version");
+      }
+      checkAutotuneOptionsStruct(options);
+      if (options->struct_size != options_struct_size || options->version != options_version) {
+        THROW_INVALID_USAGE("options metadata does not match the requested cuDecomp layout version");
+      }
+      normalized_options = normalizeAutotuneOptions(options);
+      options = &normalized_options;
+    }
 
     // Check some autotuning options
     bool autotune_transpose_backend = false;
@@ -1017,7 +1244,8 @@ cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, cudecompGridDes
     releaseUnusedHandleResources(handle);
 
     *grid_desc_in = grid_desc;
-    *config = grid_desc->config;
+    copyConfigToCaller(caller_config, caller_config_size, caller_config_version, grid_desc->config);
+    config = caller_config;
 
     // If gdims_dist was not set, return config with default values
     if (!grid_desc->gdims_dist_set) {
@@ -1057,88 +1285,51 @@ cudecompResult_t cudecompGridDescDestroy(cudecompHandle_t handle, cudecompGridDe
   return CUDECOMP_RESULT_SUCCESS;
 }
 
-cudecompResult_t cudecompGridDescConfigSetDefaults(cudecompGridDescConfig_t* config) {
+cudecompResult_t cudecompGridDescConfigSetDefaultsVersioned(cudecompGridDescConfig_t* config, int64_t struct_size,
+                                                            int32_t version) {
   using namespace cudecomp;
   try {
     if (!config) { THROW_INVALID_USAGE("config argument cannot be null"); }
-
-    // Grid Information
-    for (int i = 0; i < 2; ++i) {
-      config->pdims[i] = 0;
+    if (struct_size != expectedConfigSizeForVersion(version)) {
+      THROW_INVALID_USAGE("config struct_size does not match its cuDecomp layout version");
     }
-    for (int i = 0; i < 3; ++i) {
-      config->gdims[i] = 0;
-      config->gdims_dist[i] = 0;
-    }
-    config->rank_order = CUDECOMP_RANK_ORDER_DEFAULT;
-
-    // Transpose Options
-    config->transpose_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P;
-    for (int i = 0; i < 3; ++i) {
-      config->transpose_axis_contiguous[i] = false;
-      for (int j = 0; j < 3; ++j) {
-        config->transpose_mem_order[i][j] = -1;
-      }
-    }
-
-    // Halo Options
-    config->halo_comm_backend = CUDECOMP_HALO_COMM_MPI;
+    setConfigDefaults(config, struct_size, version);
   }
   CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
-cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaults(cudecompGridDescAutotuneOptions_t* options) {
+cudecompResult_t cudecompGridDescAutotuneOptionsSetDefaultsVersioned(cudecompGridDescAutotuneOptions_t* options,
+                                                                     int64_t struct_size, int32_t version) {
   using namespace cudecomp;
   try {
     if (!options) { THROW_INVALID_USAGE("options argument cannot be null"); }
-
-    // General options
-    options->n_warmup_trials = 3;
-    options->n_trials = 5;
-    options->grid_mode = CUDECOMP_AUTOTUNE_GRID_TRANSPOSE;
-    options->dtype = CUDECOMP_DOUBLE;
-    options->allow_uneven_decompositions = true;
-    options->disable_mpi_backends = false;
-    options->disable_nccl_backends = false;
-    options->disable_nvshmem_backends = false;
-    options->skip_threshold = 0.0;
-
-    // Transpose-specific options
-    options->autotune_transpose_backend = false;
-    for (int i = 0; i < 4; ++i) {
-      options->transpose_use_inplace_buffers[i] = false;
-      options->transpose_op_weights[i] = 1.0;
-      for (int j = 0; j < 3; ++j) {
-        options->transpose_input_halo_extents[i][j] = 0;
-        options->transpose_output_halo_extents[i][j] = 0;
-        options->transpose_input_padding[i][j] = 0;
-        options->transpose_output_padding[i][j] = 0;
-      }
+    if (struct_size != expectedAutotuneOptionsSizeForVersion(version)) {
+      THROW_INVALID_USAGE("options struct_size does not match its cuDecomp layout version");
     }
-
-    // Halo-specific options
-    options->autotune_halo_backend = false;
-    options->halo_axis = 0;
-    for (int i = 0; i < 3; ++i) {
-      options->halo_extents[i] = 0;
-      options->halo_periods[i] = false;
-      options->halo_padding[i] = 0;
-    }
+    setAutotuneOptionsDefaults(options, struct_size, version);
   }
   CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
-cudecompResult_t cudecompGetPencilInfo(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
-                                       cudecompPencilInfo_t* pencil_info, int32_t axis, const int32_t halo_extents[],
-                                       const int32_t padding[]) {
+cudecompResult_t cudecompGetPencilInfoVersioned(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                                cudecompPencilInfo_t* pencil_info, int64_t pencil_info_struct_size,
+                                                int32_t pencil_info_version, int32_t axis, const int32_t halo_extents[],
+                                                const int32_t padding[]) {
   using namespace cudecomp;
   try {
     checkHandle(handle);
     checkGridDesc(handle, grid_desc);
     if (!pencil_info) { THROW_INVALID_USAGE("pencil_info argument cannot be null."); }
+    if (pencil_info_struct_size != expectedPencilInfoSizeForVersion(pencil_info_version)) {
+      THROW_INVALID_USAGE("pencil_info struct_size does not match its cuDecomp layout version");
+    }
     if (axis < 0 || axis > 2) { THROW_INVALID_USAGE("axis argument out of range"); }
+
+    cudecompPencilInfo_t normalized_pencil_info{};
+    cudecompPencilInfo_t* caller_pencil_info = pencil_info;
+    pencil_info = &normalized_pencil_info;
 
     std::array<int32_t, 3> invorder;
 
@@ -1179,20 +1370,23 @@ cudecompResult_t cudecompGetPencilInfo(cudecompHandle_t handle, cudecompGridDesc
       pencil_info->shape[ord] = checkedPencilShape(shape_with_halo_padding);
       pencil_info->size = checkedPencilSizeProduct(pencil_info->size, pencil_info->shape[ord]);
     }
+
+    copyPencilInfoToCaller(caller_pencil_info, pencil_info_struct_size, pencil_info_version, *pencil_info);
   }
   CUDECOMP_CATCH_C_API_ERRORS()
   return CUDECOMP_RESULT_SUCCESS;
 }
 
-cudecompResult_t cudecompGetGridDescConfig(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
-                                           cudecompGridDescConfig_t* config) {
+cudecompResult_t cudecompGetGridDescConfigVersioned(cudecompHandle_t handle, cudecompGridDesc_t grid_desc,
+                                                    cudecompGridDescConfig_t* config, int64_t struct_size,
+                                                    int32_t version) {
   using namespace cudecomp;
   try {
     checkHandle(handle);
     checkGridDesc(handle, grid_desc);
     if (!config) { THROW_INVALID_USAGE("config argument cannot be null."); }
 
-    *config = grid_desc->config;
+    copyConfigToCaller(config, struct_size, version, grid_desc->config);
     // If gdims_dist was not set, return config with default values
     if (!grid_desc->gdims_dist_set) {
       config->gdims_dist[0] = 0;

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -282,14 +282,20 @@ static int64_t expectedPencilInfoPayloadSizeForVersion(int32_t version) {
 }
 
 static void checkConfigStruct(const cudecompGridDescConfig_t* config) {
-  if (config->magic != CUDECOMP_GRID_DESC_CONFIG_MAGIC) { THROW_INVALID_USAGE("config magic is invalid"); }
+  if (config->magic != CUDECOMP_GRID_DESC_CONFIG_MAGIC) {
+    THROW_INVALID_USAGE(
+        "config is not initialized; call cudecompGridDescConfigSetDefaults() before cudecompGridDescCreate()");
+  }
   if (config->struct_size != expectedConfigSizeForVersion(config->version)) {
     THROW_INVALID_USAGE("config struct_size does not match its cuDecomp layout version");
   }
 }
 
 static void checkAutotuneOptionsStruct(const cudecompGridDescAutotuneOptions_t* options) {
-  if (options->magic != CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_MAGIC) { THROW_INVALID_USAGE("options magic is invalid"); }
+  if (options->magic != CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_MAGIC) {
+    THROW_INVALID_USAGE("options are not initialized; call cudecompGridDescAutotuneOptionsSetDefaults() before "
+                        "cudecompGridDescCreate()");
+  }
   if (options->struct_size != expectedAutotuneOptionsSizeForVersion(options->version)) {
     THROW_INVALID_USAGE("options struct_size does not match its cuDecomp layout version");
   }

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -220,6 +220,7 @@ module cudecomp
     end function cudecompFinalize
   end interface
 
+  ! Pass public structures as C pointers so all Fortran structure versions can share these low-level interfaces.
   interface
     function cudecompGridDescCreateC(handle, grid_desc, config, config_struct_size, config_version, &
                                      options, options_struct_size, options_version) &
@@ -227,31 +228,14 @@ module cudecomp
       import
       type(cudecompHandle), value :: handle
       type(cudecompGridDesc) :: grid_desc
-      type(*) :: config
-      integer(c_int64_t), value :: config_struct_size
-      integer(c_int32_t), value :: config_version
-      type(*) :: options
-      integer(c_int64_t), value :: options_struct_size
-      integer(c_int32_t), value :: options_version
-      integer(c_int) :: res
-    end function cudecompGridDescCreateC
-  end interface
-
-  interface
-    function cudecompGridDescCreateC_nullopt(handle, grid_desc, config, config_struct_size, config_version, &
-                                             options, options_struct_size, options_version) &
-       bind(C, name="cudecompGridDescCreateVersioned") result(res)
-      import
-      type(cudecompHandle), value :: handle
-      type(cudecompGridDesc) :: grid_desc
-      type(*) :: config
+      type(c_ptr), value :: config
       integer(c_int64_t), value :: config_struct_size
       integer(c_int32_t), value :: config_version
       type(c_ptr), value :: options
       integer(c_int64_t), value :: options_struct_size
       integer(c_int32_t), value :: options_version
       integer(c_int) :: res
-    end function cudecompGridDescCreateC_nullopt
+    end function cudecompGridDescCreateC
   end interface
 
   interface
@@ -268,7 +252,7 @@ module cudecomp
     function cudecompGridDescConfigSetDefaultsC(config, struct_size, version) &
       bind(C, name="cudecompGridDescConfigSetDefaultsVersioned") result(res)
       import
-      type(*) :: config
+      type(c_ptr), value :: config
       integer(c_int64_t), value :: struct_size
       integer(c_int32_t), value :: version
       integer(c_int) :: res
@@ -280,7 +264,7 @@ module cudecomp
     function cudecompGridDescAutotuneOptionsSetDefaultsC(options, struct_size, version) &
       bind(C, name="cudecompGridDescAutotuneOptionsSetDefaultsVersioned") result(res)
       import
-      type(*) :: options
+      type(c_ptr), value :: options
       integer(c_int64_t), value :: struct_size
       integer(c_int32_t), value :: version
       integer(c_int) :: res
@@ -295,7 +279,7 @@ module cudecomp
       import
       type(cudecompHandle), value :: handle
       type(cudecompGridDesc), value :: grid_desc
-      type(*) :: pencil_info
+      type(c_ptr), value :: pencil_info
       integer(c_int64_t), value :: pencil_info_struct_size
       integer(c_int32_t), value :: pencil_info_version
       integer(c_int32_t), value :: axis
@@ -311,7 +295,7 @@ module cudecomp
       import
       type(cudecompHandle), value :: handle
       type(cudecompGridDesc), value :: grid_desc
-      type(*) :: config
+      type(c_ptr), value :: config
       integer(c_int64_t), value :: struct_size
       integer(c_int32_t), value :: version
       integer(c_int) :: res
@@ -584,21 +568,21 @@ contains
   ! cudecompGridDesc creation/manipulation functions
   function cudecompGridDescConfigSetDefaults_v1(config) result(res)
     implicit none
-    type(cudecompGridDescConfig_v1) :: config
+    type(cudecompGridDescConfig_v1), target :: config
     integer(c_int) :: res
     integer(c_int32_t), parameter :: STRUCT_VERSION = 1
 
-    res = cudecompGridDescConfigSetDefaultsC(config, int(c_sizeof(config), c_int64_t), &
+    res = cudecompGridDescConfigSetDefaultsC(c_loc(config), int(c_sizeof(config), c_int64_t), &
                                              STRUCT_VERSION)
   end function cudecompGridDescConfigSetDefaults_v1
 
   function cudecompGridDescAutotuneOptionsSetDefaults_v1(options) result(res)
     implicit none
-    type(cudecompGridDescAutotuneOptions_v1) :: options
+    type(cudecompGridDescAutotuneOptions_v1), target :: options
     integer(c_int) :: res
     integer(c_int32_t), parameter :: STRUCT_VERSION = 1
 
-    res = cudecompGridDescAutotuneOptionsSetDefaultsC(options, int(c_sizeof(options), c_int64_t), &
+    res = cudecompGridDescAutotuneOptionsSetDefaultsC(c_loc(options), int(c_sizeof(options), c_int64_t), &
                                                       STRUCT_VERSION)
 
     ! Adjust halo axis entry for one-based axis indexing
@@ -610,8 +594,8 @@ contains
     implicit none
     type(cudecompHandle) :: handle
     type(cudecompGridDesc) :: grid_desc
-    type(cudecompGridDescConfig_v1) :: config
-    type(cudecompGridDescAutotuneOptions_v1), optional :: options
+    type(cudecompGridDescConfig_v1), target :: config
+    type(cudecompGridDescAutotuneOptions_v1), optional, target :: options
     integer(c_int) :: res
     integer(c_int32_t), parameter :: CONFIG_STRUCT_VERSION = 1
     integer(c_int32_t), parameter :: OPTIONS_STRUCT_VERSION = 1
@@ -622,14 +606,14 @@ contains
     if (present(options)) then
       ! Adjust halo axis entry for zero-based axis indexing
       options%halo_axis = options%halo_axis - 1
-      res = cudecompGridDescCreateC(handle, grid_desc, config, int(c_sizeof(config), c_int64_t), &
-                                    CONFIG_STRUCT_VERSION, options, int(c_sizeof(options), c_int64_t), &
+      res = cudecompGridDescCreateC(handle, grid_desc, c_loc(config), int(c_sizeof(config), c_int64_t), &
+                                    CONFIG_STRUCT_VERSION, c_loc(options), int(c_sizeof(options), c_int64_t), &
                                     OPTIONS_STRUCT_VERSION)
       ! Adjust halo axis entry for one-based axis indexing
       options%halo_axis = options%halo_axis + 1
     else
-      res = cudecompGridDescCreateC_nullopt(handle, grid_desc, config, int(c_sizeof(config), c_int64_t), &
-                                            CONFIG_STRUCT_VERSION, C_NULL_PTR, 0_c_int64_t, 0_c_int32_t)
+      res = cudecompGridDescCreateC(handle, grid_desc, c_loc(config), int(c_sizeof(config), c_int64_t), &
+                                    CONFIG_STRUCT_VERSION, C_NULL_PTR, 0_c_int64_t, 0_c_int32_t)
     endif
 
     ! Adjust transpose mem order entries for one-based indexing
@@ -644,7 +628,7 @@ contains
     integer :: axis  ! unit offset, so x/y/z = 1/2/3
     integer, optional:: halo_extents(3)
     integer, optional:: padding(3)
-    type(cudecompPencilInfo_v1) :: pencil_info  ! res%order is unit offset, x/y/z = 1/2/3
+    type(cudecompPencilInfo_v1), target :: pencil_info  ! res%order is unit offset, x/y/z = 1/2/3
     integer(c_int) :: res
     integer(c_int32_t), parameter :: STRUCT_VERSION = 1
 
@@ -655,7 +639,7 @@ contains
     padding_(:) = [0, 0, 0]
     if (present(halo_extents)) halo_extents_ = halo_extents
     if (present(padding)) padding_ = padding
-    res = cudecompGetPencilInfoC(handle, grid_desc, pencil_info, int(c_sizeof(pencil_info), c_int64_t), &
+    res = cudecompGetPencilInfoC(handle, grid_desc, c_loc(pencil_info), int(c_sizeof(pencil_info), c_int64_t), &
                                  STRUCT_VERSION, axis - 1, halo_extents_, padding_)
     ! Update entries for Fortran indexing
     pencil_info%order = pencil_info%order + 1
@@ -666,11 +650,11 @@ contains
   function cudecompGetGridDescConfig_v1(handle, grid_desc, config) result(res)
     type(cudecompHandle), value :: handle
     type(cudecompGridDesc), value :: grid_desc
-    type(cudecompGridDescConfig_v1) :: config
+    type(cudecompGridDescConfig_v1), target :: config
     integer(c_int) :: res
     integer(c_int32_t), parameter :: STRUCT_VERSION = 1
 
-    res = cudecompGetGridDescConfigC(handle, grid_desc, config, int(c_sizeof(config), c_int64_t), &
+    res = cudecompGetGridDescConfigC(handle, grid_desc, c_loc(config), int(c_sizeof(config), c_int64_t), &
                                      STRUCT_VERSION)
 
     ! Adjust transpose mem order entries for one-based indexing

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -13,12 +13,97 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
+module cudecomp_internal
+  use, intrinsic :: iso_c_binding
+  implicit none
+  private
+  public :: cudecompGridDescConfig_v1, cudecompGridDescAutotuneOptions_v1, cudecompPencilInfo_v1
+
+  ! Structure defining configuration options for grid descriptor creation
+  type, bind(c) :: cudecompGridDescConfig_v1
+    integer(c_int64_t) :: struct_size
+    integer(c_int32_t) :: magic
+    integer(c_int32_t) :: version
+
+    ! Grid information
+    integer(c_int32_t) :: gdims(3) ! dimensions of data grid
+    integer(c_int32_t) :: gdims_dist(3) ! dimensions of data grid for distribution
+    integer(c_int32_t) :: pdims(2) ! dimensions of process grid
+    integer(c_int32_t) :: rank_order ! process grid rank assignment order
+
+    ! Transpose Options
+    integer(c_int32_t) :: transpose_comm_backend
+    logical(c_bool) :: transpose_axis_contiguous(3) ! flag (by axis) indicating whether pencil memory should be contiguous along pencil axis
+    integer(c_int32_t) :: transpose_mem_order(3,3) ! user-specified memory ordering by axis, overrides transpose_axis_contiguous setting
+
+    ! Halo Options
+    integer(c_int32_t) :: halo_comm_backend ! communication backend to use for halo communication
+
+  end type cudecompGridDescConfig_v1
+
+  ! Structure defining autotuning options for grid descriptor creation
+  type, bind(c) :: cudecompGridDescAutotuneOptions_v1
+    integer(c_int64_t) :: struct_size
+    integer(c_int32_t) :: magic
+    integer(c_int32_t) :: version
+
+    ! General options
+    integer(c_int32_t) :: n_warmup_trials ! number of warmup trials to run for each tested configuration during autotuning
+    integer(c_int32_t) :: n_trials ! number of timed trials to run for each tested configuration during autotuning
+    integer(c_int32_t) :: grid_mode ! which communication (transpose/halo) to use to autotune process grid
+    integer(c_int32_t) :: dtype ! datatype to use during autotuning
+    logical(c_bool) :: allow_uneven_decompositions ! flag to control whether autotuning allows uneven decompositions (based on gdims_dist if provided, gdims otherwise)
+    logical(c_bool) :: disable_mpi_backends ! flag to disable MPI backend options during autotuning
+    logical(c_bool) :: disable_nccl_backends ! flag to disable NCCL backend options during autotuning
+    logical(c_bool) :: disable_nvshmem_backends ! flag to disable NVSHMEM backend options during autotuning
+    real(c_double) :: skip_threshold ! threshold used to skip testing slow configurations
+
+    ! Transpose-specific options
+    logical(c_bool) :: autotune_transpose_backend ! flag to enable transpose backend autotuning
+    logical(c_bool) :: transpose_use_inplace_buffers(4) ! flag to control whether transpose autotuning uses in-place or out-of-place buffers
+    real(c_double) :: transpose_op_weights(4) ! multiplicative weight to apply to trial time contribution by transpose operation
+    integer(c_int32_t) :: transpose_input_halo_extents(3, 4) ! input_halo_extents argument to use during autotuning by transpose operation
+    integer(c_int32_t) :: transpose_output_halo_extents(3, 4) ! output_halo_extents argument to use during autotuning by transpose operation
+    integer(c_int32_t) :: transpose_input_padding(3, 4) ! input_padding argument to use during autotuning by transpose operation
+    integer(c_int32_t) :: transpose_output_padding(3, 4) ! output_padding argument to use during autotuning by transpose operation
+
+    ! Halo-specific options
+    logical(c_bool) :: autotune_halo_backend ! flag to enable halo backend autotuning
+    integer(c_int32_t) :: halo_extents(3) ! extents for halo autotuning
+    logical(c_bool) :: halo_periods(3) ! periodicity for halo autotuning
+    integer(c_int32_t) :: halo_axis ! which axis pencils to use for halo autotuning
+    integer(c_int32_t) :: halo_padding(3) ! padding argument for halo autotuning
+  end type cudecompGridDescAutotuneOptions_v1
+
+  ! Structure containing pencil-specific geometry information
+  type, bind(c) :: cudecompPencilInfo_v1
+    integer(c_int64_t) :: struct_size
+    integer(c_int32_t) :: magic
+    integer(c_int32_t) :: version
+
+    integer(c_int32_t) :: shape(3)        ! pencil shape (in local order, including halo elements)
+    integer(c_int32_t) :: lo(3)           ! lower bound coordinates (in local order, excluding halo elements)
+    integer(c_int32_t) :: hi(3)           ! upper bound coordinates (in local order, excluding halo elements)
+    integer(c_int32_t) :: order(3)        ! data layout order (e.g. 3,2,1 means memory is ordered z,y,x)
+    integer(c_int32_t) :: halo_extents(3) ! halo extents by dimension (always in x,y,z order)
+    integer(c_int32_t) :: padding(3)      ! padding by dimension (always in x,y,z order)
+    integer(c_int64_t) :: size            ! number of elements in pencil (including halo elements)
+  end type cudecompPencilInfo_v1
+end module cudecomp_internal
+
 module cudecomp
   use, intrinsic :: iso_c_binding
   use, intrinsic :: iso_fortran_env, only: int64, real32, real64
   use cudafor
+  use cudecomp_internal, only: cudecompGridDescConfig => cudecompGridDescConfig_v1, &
+                               cudecompGridDescAutotuneOptions => cudecompGridDescAutotuneOptions_v1, &
+                               cudecompPencilInfo => cudecompPencilInfo_v1
+  use cudecomp_internal, only: cudecompGridDescConfig_v1, cudecompGridDescAutotuneOptions_v1, &
+                               cudecompPencilInfo_v1
   private :: cudafor
-
+  private :: cudecompGetGridDescConfig_v1, cudecompGridDescAutotuneOptionsSetDefaults_v1, &
+             cudecompGridDescConfigSetDefaults_v1, cudecompGridDescCreate_v1, cudecompGetPencilInfo_v1, &
+             cudecompGridDescConfig_v1, cudecompGridDescAutotuneOptions_v1, cudecompPencilInfo_v1
   ! enumerators
 
   ! enum for cuDecomp transpose backend options
@@ -89,65 +174,6 @@ module cudecomp
     type(c_ptr) :: member
   end type cudecompGridDesc
 
-  ! Structure defining configuration options for grid descriptor creation
-  type, bind(c) :: cudecompGridDescConfig
-    ! Grid information
-    integer(c_int32_t) :: gdims(3) ! dimensions of data grid
-    integer(c_int32_t) :: gdims_dist(3) ! dimensions of data grid for distribution
-    integer(c_int32_t) :: pdims(2) ! dimensions of process grid
-    integer(c_int32_t) :: rank_order ! process grid rank assignment order
-
-    ! Transpose Options
-    integer(c_int32_t) :: transpose_comm_backend
-    logical(c_bool) :: transpose_axis_contiguous(3) ! flag (by axis) indicating whether pencil memory should be contiguous along pencil axis
-    integer(c_int32_t) :: transpose_mem_order(3,3) ! user-specified memory ordering by axis, overrides transpose_axis_contiguous setting
-
-    ! Halo Options
-    integer(c_int32_t) :: halo_comm_backend ! communication backend to use for halo communication
-
-  end type cudecompGridDescConfig
-
-  ! Structure defining autotuning options for grid descriptor creation
-  type, bind(c) :: cudecompGridDescAutotuneOptions
-    ! General options
-    integer(c_int32_t) :: n_warmup_trials ! number of warmup trials to run for each tested configuration during autotuning
-    integer(c_int32_t) :: n_trials ! number of timed trials to run for each tested configuration during autotuning
-    integer(c_int32_t) :: grid_mode ! which communication (transpose/halo) to use to autotune process grid
-    integer(c_int32_t) :: dtype ! datatype to use during autotuning
-    logical(c_bool) :: allow_uneven_decompositions ! flag to control whether autotuning allows uneven decompositions (based on gdims_dist if provided, gdims otherwise)
-    logical(c_bool) :: disable_mpi_backends ! flag to disable MPI backend options during autotuning
-    logical(c_bool) :: disable_nccl_backends ! flag to disable NCCL backend options during autotuning
-    logical(c_bool) :: disable_nvshmem_backends ! flag to disable NVSHMEM backend options during autotuning
-    real(c_double) :: skip_threshold ! threshold used to skip testing slow configurations
-
-    ! Transpose-specific options
-    logical(c_bool) :: autotune_transpose_backend ! flag to enable transpose backend autotuning
-    logical(c_bool) :: transpose_use_inplace_buffers(4) ! flag to control whether transpose autotuning uses in-place or out-of-place buffers
-    real(c_double) :: transpose_op_weights(4) ! multiplicative weight to apply to trial time contribution by transpose operation
-    integer(c_int32_t) :: transpose_input_halo_extents(3, 4) ! input_halo_extents argument to use during autotuning by transpose operation
-    integer(c_int32_t) :: transpose_output_halo_extents(3, 4) ! output_halo_extents argument to use during autotuning by transpose operation
-    integer(c_int32_t) :: transpose_input_padding(3, 4) ! input_padding argument to use during autotuning by transpose operation
-    integer(c_int32_t) :: transpose_output_padding(3, 4) ! output_padding argument to use during autotuning by transpose operation
-
-    ! Halo-specific options
-    logical(c_bool) :: autotune_halo_backend ! flag to enable halo backend autotuning
-    integer(c_int32_t) :: halo_extents(3) ! extents for halo autotuning
-    logical(c_bool) :: halo_periods(3) ! periodicity for halo autotuning
-    integer(c_int32_t) :: halo_axis ! which axis pencils to use for halo autotuning
-    integer(c_int32_t) :: halo_padding(3) ! padding argument for halo autotuning
-  end type cudecompGridDescAutotuneOptions
-
-  ! Info structure containing pencil specific information
-  type, bind(c) :: cudecompPencilInfo
-    integer(c_int32_t) :: shape(3)        ! pencil shape (in local order, including halo elements)
-    integer(c_int32_t) :: lo(3)           ! lower bound coordinates (in local order, excluding halo elements)
-    integer(c_int32_t) :: hi(3)           ! upper bound coordinates (in local order, excluding halo elements)
-    integer(c_int32_t) :: order(3)        ! data layout order (e.g. 3,2,1 means memory is ordered z,y,x)
-    integer(c_int32_t) :: halo_extents(3) ! halo extents by dimension (always in x,y,z order)
-    integer(c_int32_t) :: padding(3)      ! padding by dimension (always in x,y,z order)
-    integer(c_int64_t) :: size            ! number of elements in pencil (including halo elements)
-  end type cudecompPencilInfo
-
   ! interfaces
 
   ! cuDecomp initialization/finalization functions
@@ -156,6 +182,26 @@ module cudecomp
   interface cudecompInit
     module procedure cudecompInit_MPI_F, cudecompInit_MPI_F08
   end interface cudecompInit
+
+  interface cudecompGridDescConfigSetDefaults
+    module procedure cudecompGridDescConfigSetDefaults_v1
+  end interface cudecompGridDescConfigSetDefaults
+
+  interface cudecompGridDescAutotuneOptionsSetDefaults
+    module procedure cudecompGridDescAutotuneOptionsSetDefaults_v1
+  end interface cudecompGridDescAutotuneOptionsSetDefaults
+
+  interface cudecompGridDescCreate
+    module procedure cudecompGridDescCreate_v1
+  end interface cudecompGridDescCreate
+
+  interface cudecompGetGridDescConfig
+    module procedure cudecompGetGridDescConfig_v1
+  end interface cudecompGetGridDescConfig
+
+  interface cudecompGetPencilInfo
+    module procedure cudecompGetPencilInfo_v1
+  end interface cudecompGetPencilInfo
 
   interface
     function cudecompInit_FC(handle, mpi_comm) bind(C, name="cudecompInit_F") result(res)
@@ -175,25 +221,35 @@ module cudecomp
   end interface
 
   interface
-    function cudecompGridDescCreateC(handle, grid_desc, config, options) &
-       bind(C, name="cudecompGridDescCreate") result(res)
+    function cudecompGridDescCreateC(handle, grid_desc, config, config_struct_size, config_version, &
+                                     options, options_struct_size, options_version) &
+       bind(C, name="cudecompGridDescCreateVersioned") result(res)
       import
       type(cudecompHandle), value :: handle
       type(cudecompGridDesc) :: grid_desc
-      type(cudecompGridDescConfig) :: config
-      type(cudecompGridDescAutotuneOptions) :: options
+      type(*) :: config
+      integer(c_int64_t), value :: config_struct_size
+      integer(c_int32_t), value :: config_version
+      type(*) :: options
+      integer(c_int64_t), value :: options_struct_size
+      integer(c_int32_t), value :: options_version
       integer(c_int) :: res
     end function cudecompGridDescCreateC
   end interface
 
   interface
-    function cudecompGridDescCreateC_nullopt(handle, grid_desc, config, options) &
-       bind(C, name="cudecompGridDescCreate") result(res)
+    function cudecompGridDescCreateC_nullopt(handle, grid_desc, config, config_struct_size, config_version, &
+                                             options, options_struct_size, options_version) &
+       bind(C, name="cudecompGridDescCreateVersioned") result(res)
       import
       type(cudecompHandle), value :: handle
       type(cudecompGridDesc) :: grid_desc
-      type(cudecompGridDescConfig) :: config
+      type(*) :: config
+      integer(c_int64_t), value :: config_struct_size
+      integer(c_int32_t), value :: config_version
       type(c_ptr), value :: options
+      integer(c_int64_t), value :: options_struct_size
+      integer(c_int32_t), value :: options_version
       integer(c_int) :: res
     end function cudecompGridDescCreateC_nullopt
   end interface
@@ -209,46 +265,55 @@ module cudecomp
 
   ! cudecompGridDescConfig creation/manipulation functions
   interface
-    function cudecompGridDescConfigSetDefaults(config) &
-      bind(C, name="cudecompGridDescConfigSetDefaults") result(res)
+    function cudecompGridDescConfigSetDefaultsC(config, struct_size, version) &
+      bind(C, name="cudecompGridDescConfigSetDefaultsVersioned") result(res)
       import
-      type(cudecompGridDescConfig) :: config
+      type(*) :: config
+      integer(c_int64_t), value :: struct_size
+      integer(c_int32_t), value :: version
       integer(c_int) :: res
-    end function cudecompGridDescConfigSetDefaults
+    end function cudecompGridDescConfigSetDefaultsC
   end interface
 
   ! cudecompGridDescAutotuneOptions creation/manipulation functions
   interface
-    function cudecompGridDescAutotuneOptionsSetDefaultsC(options) &
-      bind(C, name="cudecompGridDescAutotuneOptionsSetDefaults") result(res)
+    function cudecompGridDescAutotuneOptionsSetDefaultsC(options, struct_size, version) &
+      bind(C, name="cudecompGridDescAutotuneOptionsSetDefaultsVersioned") result(res)
       import
-      type(cudecompGridDescAutotuneOptions) :: options
+      type(*) :: options
+      integer(c_int64_t), value :: struct_size
+      integer(c_int32_t), value :: version
       integer(c_int) :: res
     end function cudecompGridDescAutotuneOptionsSetDefaultsC
   end interface
 
   ! General functions
   interface
-    function cudecompGetPencilInfoC(handle, grid_desc, pencil_info, axis, halo_extents, padding) &
-      bind(C, name="cudecompGetPencilInfo") result(res)
+    function cudecompGetPencilInfoC(handle, grid_desc, pencil_info, pencil_info_struct_size, &
+                                    pencil_info_version, axis, halo_extents, padding) &
+      bind(C, name="cudecompGetPencilInfoVersioned") result(res)
       import
       type(cudecompHandle), value :: handle
       type(cudecompGridDesc), value :: grid_desc
+      type(*) :: pencil_info
+      integer(c_int64_t), value :: pencil_info_struct_size
+      integer(c_int32_t), value :: pencil_info_version
       integer(c_int32_t), value :: axis
       integer(c_int32_t) :: halo_extents(3)
       integer(c_int32_t) :: padding(3)
-      type(cudecompPencilInfo) :: pencil_info
       integer(c_int) :: res
     end function cudecompGetPencilInfoC
   end interface
 
   interface
-    function cudecompGetGridDescConfigC(handle, grid_desc, config) &
-      bind(C, name="cudecompGetGridDescConfig") result(res)
+    function cudecompGetGridDescConfigC(handle, grid_desc, config, struct_size, version) &
+      bind(C, name="cudecompGetGridDescConfigVersioned") result(res)
       import
       type(cudecompHandle), value :: handle
       type(cudecompGridDesc), value :: grid_desc
-      type(cudecompGridDescConfig) :: config
+      type(*) :: config
+      integer(c_int64_t), value :: struct_size
+      integer(c_int32_t), value :: version
       integer(c_int) :: res
     end function cudecompGetGridDescConfigC
   end interface
@@ -517,24 +582,39 @@ contains
   end function cudecompInit_MPI_F08
 
   ! cudecompGridDesc creation/manipulation functions
-  function cudecompGridDescAutotuneOptionsSetDefaults(options) result(res)
-    type(cudecompGridDescAutotuneOptions) :: options
+  function cudecompGridDescConfigSetDefaults_v1(config) result(res)
+    implicit none
+    type(cudecompGridDescConfig_v1) :: config
     integer(c_int) :: res
+    integer(c_int32_t), parameter :: STRUCT_VERSION = 1
 
-    res = cudecompGridDescAutotuneOptionsSetDefaultsC(options)
+    res = cudecompGridDescConfigSetDefaultsC(config, int(c_sizeof(config), c_int64_t), &
+                                             STRUCT_VERSION)
+  end function cudecompGridDescConfigSetDefaults_v1
+
+  function cudecompGridDescAutotuneOptionsSetDefaults_v1(options) result(res)
+    implicit none
+    type(cudecompGridDescAutotuneOptions_v1) :: options
+    integer(c_int) :: res
+    integer(c_int32_t), parameter :: STRUCT_VERSION = 1
+
+    res = cudecompGridDescAutotuneOptionsSetDefaultsC(options, int(c_sizeof(options), c_int64_t), &
+                                                      STRUCT_VERSION)
 
     ! Adjust halo axis entry for one-based axis indexing
     options%halo_axis = options%halo_axis + 1
 
-  end function cudecompGridDescAutotuneOptionsSetDefaults
+  end function cudecompGridDescAutotuneOptionsSetDefaults_v1
 
-  function cudecompGridDescCreate(handle, grid_desc, config, options) result(res)
+  function cudecompGridDescCreate_v1(handle, grid_desc, config, options) result(res)
     implicit none
     type(cudecompHandle) :: handle
     type(cudecompGridDesc) :: grid_desc
-    type(cudecompGridDescConfig) :: config
-    type(cudecompGridDescAutotuneOptions), optional :: options
+    type(cudecompGridDescConfig_v1) :: config
+    type(cudecompGridDescAutotuneOptions_v1), optional :: options
     integer(c_int) :: res
+    integer(c_int32_t), parameter :: CONFIG_STRUCT_VERSION = 1
+    integer(c_int32_t), parameter :: OPTIONS_STRUCT_VERSION = 1
 
     ! Adjust transpose mem order entries for zero-based indexing
     config%transpose_mem_order = config%transpose_mem_order - 1
@@ -542,27 +622,31 @@ contains
     if (present(options)) then
       ! Adjust halo axis entry for zero-based axis indexing
       options%halo_axis = options%halo_axis - 1
-      res = cudecompGridDescCreateC(handle, grid_desc, config, options)
+      res = cudecompGridDescCreateC(handle, grid_desc, config, int(c_sizeof(config), c_int64_t), &
+                                    CONFIG_STRUCT_VERSION, options, int(c_sizeof(options), c_int64_t), &
+                                    OPTIONS_STRUCT_VERSION)
       ! Adjust halo axis entry for one-based axis indexing
       options%halo_axis = options%halo_axis + 1
     else
-      res = cudecompGridDescCreateC_nullopt(handle, grid_desc, config, C_NULL_PTR)
+      res = cudecompGridDescCreateC_nullopt(handle, grid_desc, config, int(c_sizeof(config), c_int64_t), &
+                                            CONFIG_STRUCT_VERSION, C_NULL_PTR, 0_c_int64_t, 0_c_int32_t)
     endif
 
     ! Adjust transpose mem order entries for one-based indexing
     config%transpose_mem_order = config%transpose_mem_order + 1
-  end function cudecompGridDescCreate
+  end function cudecompGridDescCreate_v1
 
   ! General functions
-  function cudecompGetPencilInfo(handle, grid_desc, pencil_info, axis, halo_extents, padding) result(res)
+  function cudecompGetPencilInfo_v1(handle, grid_desc, pencil_info, axis, halo_extents, padding) result(res)
     implicit none
     type(cudecompHandle) :: handle
     type(cudecompGridDesc) :: grid_desc
     integer :: axis  ! unit offset, so x/y/z = 1/2/3
     integer, optional:: halo_extents(3)
     integer, optional:: padding(3)
-    type(cudecompPencilInfo) :: pencil_info  ! res%order is unit offset, x/y/z = 1/2/3
+    type(cudecompPencilInfo_v1) :: pencil_info  ! res%order is unit offset, x/y/z = 1/2/3
     integer(c_int) :: res
+    integer(c_int32_t), parameter :: STRUCT_VERSION = 1
 
     integer :: halo_extents_(3)
     integer :: padding_(3)
@@ -571,25 +655,28 @@ contains
     padding_(:) = [0, 0, 0]
     if (present(halo_extents)) halo_extents_ = halo_extents
     if (present(padding)) padding_ = padding
-    res = cudecompGetPencilInfoC(handle, grid_desc, pencil_info, axis - 1, halo_extents_, padding_)
+    res = cudecompGetPencilInfoC(handle, grid_desc, pencil_info, int(c_sizeof(pencil_info), c_int64_t), &
+                                 STRUCT_VERSION, axis - 1, halo_extents_, padding_)
     ! Update entries for Fortran indexing
     pencil_info%order = pencil_info%order + 1
     pencil_info%lo = pencil_info%lo + 1
     pencil_info%hi = pencil_info%hi + 1
-  end function cudecompGetPencilInfo
+  end function cudecompGetPencilInfo_v1
 
-  function cudecompGetGridDescConfig(handle, grid_desc, config) result(res)
+  function cudecompGetGridDescConfig_v1(handle, grid_desc, config) result(res)
     type(cudecompHandle), value :: handle
     type(cudecompGridDesc), value :: grid_desc
-    type(cudecompGridDescConfig) :: config
+    type(cudecompGridDescConfig_v1) :: config
     integer(c_int) :: res
+    integer(c_int32_t), parameter :: STRUCT_VERSION = 1
 
-    res = cudecompGetGridDescConfigC(handle, grid_desc, config)
+    res = cudecompGetGridDescConfigC(handle, grid_desc, config, int(c_sizeof(config), c_int64_t), &
+                                     STRUCT_VERSION)
 
     ! Adjust transpose mem order entries for one-based indexing
     config%transpose_mem_order = config%transpose_mem_order + 1
 
-  end function cudecompGetGridDescConfig
+  end function cudecompGetGridDescConfig_v1
 
   function cudecompGetHaloWorkspaceSize(handle, grid_desc, axis, halo_extents, workspace_size) result(res)
     implicit none

--- a/tests/ctest/api_tests.cc
+++ b/tests/ctest/api_tests.cc
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdlib>
@@ -184,8 +183,7 @@ void expectNvshmemNotInitialized(const cudecomp_test::MpiTestComm& comm) {
   // NVSHMEM may leave the bootstrap layer active after nvshmem_finalize().
   int all_ranks_match = local_status < NVSHMEM_STATUS_IS_INITIALIZED ? 1 : 0;
   EXPECT_EQ(MPI_SUCCESS, MPI_Allreduce(MPI_IN_PLACE, &all_ranks_match, 1, MPI_INT, MPI_MIN, comm.mpiComm()));
-  EXPECT_EQ(1, all_ranks_match) << "local NVSHMEM init status is " << local_status
-                                << ", expected below initialized";
+  EXPECT_EQ(1, all_ranks_match) << "local NVSHMEM init status is " << local_status << ", expected below initialized";
 }
 #endif
 
@@ -204,6 +202,9 @@ void setGdimsDist(cudecompGridDescConfig_t& config) {
 }
 
 void expectPencilInfoEquals(const cudecompPencilInfo_t& actual, const ExpectedPencilInfo& expected) {
+  EXPECT_EQ(static_cast<int64_t>(sizeof(actual)), actual.struct_size);
+  EXPECT_EQ(CUDECOMP_PENCIL_INFO_MAGIC, actual.magic);
+  EXPECT_EQ(CUDECOMP_PENCIL_INFO_VERSION, actual.version);
   for (int i = 0; i < 3; ++i) {
     EXPECT_EQ(expected.shape[i], actual.shape[i]);
     EXPECT_EQ(expected.lo[i], actual.lo[i]);
@@ -254,6 +255,9 @@ TEST(ApiGridDescConfigSetDefaultsTest, SetsDocumentedDefaults) {
   cudecompGridDescConfig_t config;
   ASSERT_EQ(CUDECOMP_RESULT_SUCCESS, cudecompGridDescConfigSetDefaults(&config));
 
+  EXPECT_EQ(static_cast<int64_t>(sizeof(config)), config.struct_size);
+  EXPECT_EQ(CUDECOMP_GRID_DESC_CONFIG_MAGIC, config.magic);
+  EXPECT_EQ(CUDECOMP_GRID_DESC_CONFIG_VERSION, config.version);
   EXPECT_EQ(CUDECOMP_RANK_ORDER_DEFAULT, config.rank_order);
   EXPECT_EQ(CUDECOMP_TRANSPOSE_COMM_MPI_P2P, config.transpose_comm_backend);
   EXPECT_EQ(CUDECOMP_HALO_COMM_MPI, config.halo_comm_backend);
@@ -278,6 +282,9 @@ TEST(ApiGridDescAutotuneOptionsSetDefaultsTest, SetsDocumentedDefaults) {
   cudecompGridDescAutotuneOptions_t options;
   ASSERT_EQ(CUDECOMP_RESULT_SUCCESS, cudecompGridDescAutotuneOptionsSetDefaults(&options));
 
+  EXPECT_EQ(static_cast<int64_t>(sizeof(options)), options.struct_size);
+  EXPECT_EQ(CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_MAGIC, options.magic);
+  EXPECT_EQ(CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION, options.version);
   EXPECT_EQ(3, options.n_warmup_trials);
   EXPECT_EQ(5, options.n_trials);
   EXPECT_EQ(CUDECOMP_AUTOTUNE_GRID_TRANSPOSE, options.grid_mode);
@@ -1027,6 +1034,18 @@ TEST_F(ApiFinalizeTest, RejectsInvalidArguments) {
 
 TEST_F(ApiGridDescCreateTest, RejectsInvalidConfigs) {
   auto config = distributedConfig();
+  config.magic = 0;
+  expectGridDescCreateInvalid(config);
+
+  config = distributedConfig();
+  config.version = CUDECOMP_GRID_DESC_CONFIG_VERSION + 1;
+  expectGridDescCreateInvalid(config);
+
+  config = distributedConfig();
+  config.struct_size = static_cast<int64_t>(sizeof(config)) - 1;
+  expectGridDescCreateInvalid(config);
+
+  config = distributedConfig();
   config.pdims[0] = 1;
   config.pdims[1] = 1;
   expectGridDescCreateInvalid(config);
@@ -1075,6 +1094,13 @@ TEST_F(ApiGridDescCreateTest, RejectsInvalidArguments) {
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGridDescCreate(nullptr, &unused_grid_desc, &config, nullptr));
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGridDescCreate(handle_, nullptr, &config, nullptr));
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGridDescCreate(handle_, &unused_grid_desc, nullptr, nullptr));
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
+            cudecompGridDescCreateVersioned(handle_, &unused_grid_desc, &config,
+                                            static_cast<int64_t>(sizeof(config)) - 1, CUDECOMP_GRID_DESC_CONFIG_VERSION,
+                                            nullptr, 0, 0));
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
+            cudecompGridDescCreateVersioned(handle_, &unused_grid_desc, &config, static_cast<int64_t>(sizeof(config)),
+                                            CUDECOMP_GRID_DESC_CONFIG_VERSION + 1, nullptr, 0, 0));
 }
 
 TEST_F(ApiGridDescCreateTest, RejectsInvalidAutotuneInputs) {
@@ -1086,6 +1112,25 @@ TEST_F(ApiGridDescCreateTest, RejectsInvalidAutotuneInputs) {
 
   config = distributedConfig();
   auto options = fastAutotuneOptions();
+  options.magic = 0;
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGridDescCreate(handle_, &unused_grid_desc, &config, &options));
+
+  options = fastAutotuneOptions();
+  options.version = CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION + 1;
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGridDescCreate(handle_, &unused_grid_desc, &config, &options));
+
+  options = fastAutotuneOptions();
+  options.struct_size = static_cast<int64_t>(sizeof(options)) - 1;
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGridDescCreate(handle_, &unused_grid_desc, &config, &options));
+
+  options = fastAutotuneOptions();
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
+            cudecompGridDescCreateVersioned(handle_, &unused_grid_desc, &config, static_cast<int64_t>(sizeof(config)),
+                                            CUDECOMP_GRID_DESC_CONFIG_VERSION, &options,
+                                            static_cast<int64_t>(sizeof(options)) - 1,
+                                            CUDECOMP_GRID_DESC_AUTOTUNE_OPTIONS_VERSION));
+
+  options = fastAutotuneOptions();
   options.grid_mode = static_cast<cudecompAutotuneGridMode_t>(999);
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGridDescCreate(handle_, &unused_grid_desc, &config, &options));
 }
@@ -1138,6 +1183,14 @@ TEST_F(ApiGetGridDescConfigTest, RejectsInvalidArguments) {
   cudecompGridDescConfig_t queried_config;
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGetGridDescConfig(handle_, grid_desc, nullptr));
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGetGridDescConfig(handle_, nullptr, &queried_config));
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
+            cudecompGetGridDescConfigVersioned(handle_, grid_desc, &queried_config,
+                                               static_cast<int64_t>(sizeof(queried_config)),
+                                               CUDECOMP_GRID_DESC_CONFIG_VERSION + 1));
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
+            cudecompGetGridDescConfigVersioned(handle_, grid_desc, &queried_config,
+                                               static_cast<int64_t>(sizeof(queried_config)) - 1,
+                                               CUDECOMP_GRID_DESC_CONFIG_VERSION));
 }
 
 TEST_F(ApiGridDescCreateTest, AutotunesTransposeConfig) {
@@ -1267,6 +1320,12 @@ TEST_F(ApiGetPencilInfoTest, RejectsInvalidArguments) {
   const std::array<int32_t, 3> oversized_padding{std::numeric_limits<int32_t>::max(), 0, 0};
 
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGetPencilInfo(handle_, grid_desc, nullptr, 0, nullptr, nullptr));
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
+            cudecompGetPencilInfoVersioned(handle_, grid_desc, &pinfo, static_cast<int64_t>(sizeof(pinfo)) - 1,
+                                           CUDECOMP_PENCIL_INFO_VERSION, 0, nullptr, nullptr));
+  EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
+            cudecompGetPencilInfoVersioned(handle_, grid_desc, &pinfo, static_cast<int64_t>(sizeof(pinfo)),
+                                           CUDECOMP_PENCIL_INFO_VERSION + 1, 0, nullptr, nullptr));
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE, cudecompGetPencilInfo(handle_, grid_desc, &pinfo, -1, nullptr, nullptr));
   EXPECT_EQ(CUDECOMP_RESULT_INVALID_USAGE,
             cudecompGetPencilInfo(handle_, grid_desc, &pinfo, 0, negative_halo_extents.data(), nullptr));

--- a/tests/ctest/fortran_api_test.f90
+++ b/tests/ctest/fortran_api_test.f90
@@ -2,6 +2,7 @@
 ! SPDX-License-Identifier: Apache-2.0
 
 program cudecomp_fortran_api_test
+  use, intrinsic :: iso_c_binding, only: c_sizeof
   use, intrinsic :: iso_fortran_env, only: real32, real64
   use cudafor
   use cudecomp
@@ -90,6 +91,7 @@ contains
     type(cudecompGridDescAutotuneOptions) :: options
 
     call expect_success(cudecompGridDescConfigSetDefaults(config), "cudecompGridDescConfigSetDefaults")
+    if (config%struct_size /= c_sizeof(config)) call record_failure("default config struct_size is incorrect")
     call expect_equal_int(config%rank_order, CUDECOMP_RANK_ORDER_DEFAULT, "default rank order")
     call expect_equal_int(config%transpose_comm_backend, CUDECOMP_TRANSPOSE_COMM_MPI_P2P, &
                           "default transpose backend")
@@ -103,6 +105,7 @@ contains
 
     call expect_success(cudecompGridDescAutotuneOptionsSetDefaults(options), &
                         "cudecompGridDescAutotuneOptionsSetDefaults")
+    if (options%struct_size /= c_sizeof(options)) call record_failure("default options struct_size is incorrect")
     call expect_equal_int(options%n_warmup_trials, 3, "default warmup trials")
     call expect_equal_int(options%n_trials, 5, "default trials")
     call expect_equal_int(options%grid_mode, CUDECOMP_AUTOTUNE_GRID_TRANSPOSE, "default grid mode")
@@ -178,6 +181,7 @@ contains
 
     call expect_success(cudecompGetPencilInfo(handle, grid_desc, pinfo, 1), &
                         "cudecompGetPencilInfo without optional arrays")
+    if (pinfo%struct_size /= c_sizeof(pinfo)) call record_failure("pencil info struct_size is incorrect")
     call expect_axis1_pencil_without_halo(pinfo)
 
     call expect_success(cudecompGetPencilInfo(handle, grid_desc, pinfo, 2, k_halo_extents, k_padding), &


### PR DESCRIPTION
Over the development history of cuDecomp, I have on several occasions modified the content of the public structure types (`cudecompGridDescConfig_t`, `cudecompGridDescAutotuneOptions_t`, and `cudecompPencilInfo_t`) which caused ABI breakages. For example, in this upcoming release, #154 and #119 added new fields to the config and autotune options structs.

While many users of this library rebuild their applications along with updating cuDecomp versions, this is not always convenient. This PR introduces an internal redesign to the public structure types, allowing future field additions without breaking the ABI. This will provide a forward ABI compatibility moving forward (e.g. applications built against cuDecomp v 0.y.z can link against v0.y.z+ but not the other way around). This PR itself is an ABI break, but starting with the next release, this PR will allow us to better maintain ABI stability.