### PR TITLE
Fix potential deadlock due to mismatched NCCL local communicator handling.

### DIFF
--- a/docs/api/f_api.rst
+++ b/docs/api/f_api.rst
@@ -214,6 +214,8 @@ ______________________
 
   This function creates a grid descriptor that cuDecomp requires for most library operations that perform communication or query decomposition information. This grid descriptor contains information about how the global data grid is distributed and other internal resources to facilitate communication.
 
+  This function is collective over the handle MPI communicator.
+
   :p cudecompHandle handle [in]: The initialized cuDecomp library handle
   :p cudecompGridDesc grid_desc [out]: An uninitalized cuDecomp grid descriptor.
   :p cudecompGridDescConfig config [inout]: A populated cuDecomp grid descriptor configuration structure. This structure defines the required attributes of the decomposition. On successful exit, fields in this structure may be updated to reflect autotuning results.
@@ -230,6 +232,8 @@ _______________________
 .. f:function:: cudecompGridDescDestroy(handle, grid_desc)
 
   Destroys a cuDecomp grid descriptor and frees associated resources.
+
+  This function is collective over the handle MPI communicator.
 
   :p cudecompHandle handle [in]: The initialized cuDecomp library handle
   :p cudecompGridDesc grid_desc [in]: A cuDecomp grid descriptor.

--- a/include/cudecomp.h
+++ b/include/cudecomp.h
@@ -281,6 +281,7 @@ cudecompResult_t cudecompGridDescCreateVersioned(cudecompHandle_t handle, cudeco
  * @details This function creates a grid descriptor that cuDecomp requires for most library operations that perform
  * communication or query decomposition information. This grid descriptor contains information about how
  * the global data grid is distributed and other internal resources to facilitate communication.
+ * This function is collective over the handle MPI communicator.
  * @param[in] handle The initialized cuDecomp library handle
  * @param[out] grid_desc A pointer to an uninitialized cudecompGridDesc_t
  * @param[in,out] config A pointer to a cudecompGridDescConfig_t structure initialized by
@@ -303,6 +304,7 @@ static inline cudecompResult_t cudecompGridDescCreate(cudecompHandle_t handle, c
 
 /**
  * @brief Destroys a cuDecomp grid descriptor and frees associated resources.
+ * @details This function is collective over the handle MPI communicator.
  * @param[in] handle The initialized cuDecomp library handle
  * @param[in] grid_desc A cuDecomp grid descriptor
  *

--- a/src/cudecomp.cc
+++ b/src/cudecomp.cc
@@ -818,7 +818,8 @@ static nvshmemRuntime acquireNvshmemRuntime(cudecompHandle_t& handle) {
 static void releaseUnusedHandleResources(cudecompHandle_t handle, bool release_streams = false) noexcept {
   if (!handle || !handle->initialized) { return; }
 
-  // Destroy NCCL communicators to reclaim resources if not used by other grid descriptors
+  // Grid descriptors retain NCCL communicator references uniformly across each communicator, so collective grid
+  // descriptor creation and destruction leave the same reference counts on all of its ranks.
   if (handle->nccl_comm && handle->nccl_comm.use_count() == 1) { handle->nccl_comm.reset(); }
   if (handle->nccl_local_comm && handle->nccl_local_comm.use_count() == 1) { handle->nccl_local_comm.reset(); }
   if (release_streams) { handle->streams.clear(); }
@@ -1151,30 +1152,25 @@ cudecompResult_t cudecompGridDescCreateVersioned(cudecompHandle_t handle, cudeco
     // Initialize NCCL communicator if needed
     if (need_nccl) {
       if (!handle->nccl_comm) { handle->nccl_comm = ncclCommFromMPIComm(handle->mpi_comm); }
-      if (!handle->nccl_local_comm) {
-        if (grid_desc->config.pdims[0] > 0 && grid_desc->config.pdims[1] > 0) {
-          // If pdims are set, temporarily set up comm info stuctures to determine if we need to create a local NCCL
-          // communicator
-          createCommInfo(handle, grid_desc);
+      MPI_Comm local_comm = handle->mpi_clique_comm != MPI_COMM_NULL ? handle->mpi_clique_comm : handle->mpi_local_comm;
+      if (grid_desc->config.pdims[0] > 0 && grid_desc->config.pdims[1] > 0) {
+        // All ranks must participate in these world-wide communicator splits even when some local groups already have
+        // a cached NCCL communicator.
+        createCommInfo(handle, grid_desc);
 
-          // Create local NCCL communicator if row or column communicator uses it
-          int need_local_nccl_comm =
-              static_cast<int>((grid_desc->row_comm_info.ngroups == 1 && grid_desc->row_comm_info.nranks > 1) ||
-                               (grid_desc->col_comm_info.ngroups == 1 && grid_desc->col_comm_info.nranks > 1));
+        int need_local_nccl_comm =
+            static_cast<int>((grid_desc->row_comm_info.ngroups == 1 && grid_desc->row_comm_info.nranks > 1) ||
+                             (grid_desc->col_comm_info.ngroups == 1 && grid_desc->col_comm_info.nranks > 1));
+        CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &need_local_nccl_comm, 1, MPI_INT, MPI_LOR, local_comm));
 
-          // Local comm can include ranks in other rows/columns, need additional check for those cases.
-          CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &need_local_nccl_comm, 1, MPI_INT, MPI_LOR,
-                                  handle->mpi_clique_comm != MPI_COMM_NULL ? handle->mpi_clique_comm
-                                                                           : handle->mpi_local_comm));
-
-          if (need_local_nccl_comm) {
-            handle->nccl_local_comm = ncclCommFromMPIComm(
-                handle->mpi_clique_comm != MPI_COMM_NULL ? handle->mpi_clique_comm : handle->mpi_local_comm);
-          }
-          grid_desc->row_comm_info.reset();
-          grid_desc->col_comm_info.reset();
-        } else {
-          // If pdims are not set, set up local NCCL communicator for use during autotuning
+        if (need_local_nccl_comm && !handle->nccl_local_comm) {
+          handle->nccl_local_comm = ncclCommFromMPIComm(local_comm);
+        }
+        grid_desc->row_comm_info.reset();
+        grid_desc->col_comm_info.reset();
+      } else {
+        // If pdims are not set, set up a local NCCL communicator for use during autotuning.
+        if (!handle->nccl_local_comm) {
           handle->nccl_local_comm = ncclCommFromMPIComm(
               handle->mpi_clique_comm != MPI_COMM_NULL ? handle->mpi_clique_comm : handle->mpi_local_comm);
         }
@@ -1233,14 +1229,13 @@ cudecompResult_t cudecompGridDescCreateVersioned(cudecompHandle_t handle, cudeco
 #endif
     if (transposeBackendRequiresNccl(grid_desc->config.transpose_comm_backend) ||
         haloBackendRequiresNccl(grid_desc->config.halo_comm_backend)) {
-      // If this grid descriptor initialized the group local NCCL communicator but does not need it, release reference
-      // to it
-      if (grid_desc->nccl_local_comm) {
-        if ((grid_desc->row_comm_info.ngroups > 1 || grid_desc->row_comm_info.nranks == 1) &&
-            (grid_desc->col_comm_info.ngroups > 1 || grid_desc->col_comm_info.nranks == 1)) {
-          grid_desc->nccl_local_comm.reset();
-        }
-      }
+      int need_local_nccl_comm =
+          static_cast<int>((grid_desc->row_comm_info.ngroups == 1 && grid_desc->row_comm_info.nranks > 1) ||
+                           (grid_desc->col_comm_info.ngroups == 1 && grid_desc->col_comm_info.nranks > 1));
+      MPI_Comm local_comm = handle->mpi_clique_comm != MPI_COMM_NULL ? handle->mpi_clique_comm : handle->mpi_local_comm;
+      CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &need_local_nccl_comm, 1, MPI_INT, MPI_LOR, local_comm));
+      // Descriptor references must be uniform across the NCCL communicator so its eventual destruction is collective.
+      if (!need_local_nccl_comm) { grid_desc->nccl_local_comm.reset(); }
     } else {
       // Release grid descriptor references to NCCL communicators
       grid_desc->nccl_comm.reset();

--- a/src/cudecomp_m.cuf
+++ b/src/cudecomp_m.cuf
@@ -238,6 +238,7 @@ module cudecomp
     end function cudecompGridDescCreateC
   end interface
 
+  ! Collective over the handle MPI communicator.
   interface
     function cudecompGridDescDestroy(handle, grid_desc) bind(C, name="cudecompGridDescDestroy") result(res)
       import

--- a/tests/ctest/CMakeLists.txt
+++ b/tests/ctest/CMakeLists.txt
@@ -147,7 +147,10 @@ function(add_cudecomp_transpose_test test_name filter labels)
 endfunction()
 
 add_cudecomp_transpose_test(cudecomp_transpose_mpi "MpiBackends/*" "transpose;mpi")
-add_cudecomp_transpose_test(cudecomp_transpose_nccl "NcclBackends/*" "transpose;nccl")
+add_cudecomp_transpose_test(cudecomp_transpose_nccl
+  "NcclBackends/*:NcclCommunicatorLifecycleTest.*"
+  "transpose;nccl"
+)
 set_tests_properties(cudecomp_transpose_nccl PROPERTIES
   ENVIRONMENT "CUDECOMP_TEST_KEEPALIVE_BACKEND=nccl"
 )

--- a/tests/ctest/transpose_tests.cc
+++ b/tests/ctest/transpose_tests.cc
@@ -475,6 +475,50 @@ class TransposeCorrectnessTest : public ::testing::TestWithParam<TransposeCase> 
 class CudaGraphTransposeCorrectnessTest : public ::testing::TestWithParam<TransposeCase> {};
 class NcclUserBufferRegistrationTest : public ::testing::TestWithParam<TransposeCase> {};
 
+TEST(NcclCommunicatorLifecycleTest, RetainsLocalCommunicatorUntilAllDescriptorsReleaseIt) {
+  const auto world_comm = cudecomp_test::MpiTestComm::world();
+  if (world_comm.size() != 4) { GTEST_SKIP() << "NCCL communicator lifecycle test requires exactly four ranks"; }
+
+  const auto setup_decision = cudecomp_test::initializeGpuForTest(world_comm, true);
+  ASSERT_FALSE(setup_decision.fail) << setup_decision.reason;
+  if (setup_decision.skip) { GTEST_SKIP() << setup_decision.reason; }
+
+  cudecompHandle_t handle = nullptr;
+  CHECK_CUDECOMP_GLOBAL(world_comm, cudecompInit(&handle, world_comm.mpiComm()));
+  cudecomp_test::cudecompHandleGuard handle_guard(handle);
+
+  // With a 2x2 process grid, ranks 0-2 use an intra-host row or column while rank 3 does not. The local NCCL
+  // communicator still belongs to all four ranks and must therefore have a uniform lifetime across them.
+  ASSERT_TRUE(applySyntheticHostnames(handle, {0, 0, 0, 1}));
+
+  cudecompGridDescConfig_t config;
+  ASSERT_EQ(CUDECOMP_RESULT_SUCCESS, cudecompGridDescConfigSetDefaults(&config));
+  config.gdims[0] = kBaselineGdims[0];
+  config.gdims[1] = kBaselineGdims[1];
+  config.gdims[2] = kBaselineGdims[2];
+  config.pdims[0] = 2;
+  config.pdims[1] = 2;
+  config.transpose_comm_backend = CUDECOMP_TRANSPOSE_COMM_NCCL;
+
+  cudecompGridDesc_t first_grid_desc = nullptr;
+  CHECK_CUDECOMP_GLOBAL(world_comm, cudecompGridDescCreate(handle, &first_grid_desc, &config, nullptr));
+  EXPECT_TRUE(handle->nccl_comm);
+  EXPECT_TRUE(handle->nccl_local_comm);
+
+  // Before the lifecycle fix, rank 3 released its local communicator after the first creation. This second creation
+  // then entered different collective call sequences across ranks and hung.
+  cudecompGridDesc_t second_grid_desc = nullptr;
+  CHECK_CUDECOMP_GLOBAL(world_comm, cudecompGridDescCreate(handle, &second_grid_desc, &config, nullptr));
+
+  CHECK_CUDECOMP_GLOBAL(world_comm, cudecompGridDescDestroy(handle, second_grid_desc));
+  EXPECT_TRUE(handle->nccl_comm);
+  EXPECT_TRUE(handle->nccl_local_comm);
+
+  CHECK_CUDECOMP_GLOBAL(world_comm, cudecompGridDescDestroy(handle, first_grid_desc));
+  EXPECT_FALSE(handle->nccl_comm);
+  EXPECT_FALSE(handle->nccl_local_comm);
+}
+
 testing::AssertionResult ncclUserBufferRegistrationIsActive(cudecompHandle_t handle, void* buffer) {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
   if (!handle->nccl_enable_ubr) { return testing::AssertionFailure() << "NCCL user buffer registration is disabled"; }


### PR DESCRIPTION
Some recent testing for the next release uncovered a different potential deadlock in the code related to NCCL local communicator handling, similar to what was fixed in #98. 

#98 fixed a potential deadlock due to mismatched NCCL local communicator creation in some special cases:

> It was discovered that for grid configurations that distribute intra-node GPUs unevenly across row and column communicators, the library can deadlock when creating a node-local NCCL communicator. The issue is that the decision to create a NCCL local communicator is based on only the row and column communicator a particular rank is in, but the communicator creation involves all ranks on a node. If some but not all ranks on a node determine they need to create a NCCL local communicator, this deadlocks.

It was discovered that a similar mismatch in decision making can occur when the local NCCL communicator is destroyed, leaving the handle NCCL communicator state inconsistent among ranks. This can result in a deadlock on subsequent grid descriptor creation: some ranks can observe an existing cached NCCL local communicator in the handle while others attempt to create a new one. 

This PR addresses this issue by making the decision to destroy the NCCL local communicator collective among the ranks in the handle MPI communicator.